### PR TITLE
Workout component library: extract + remediate (atoms + molecules)

### DIFF
--- a/packages/ui/src/components/custom/Workout/DeviationBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { DeviationBar } from './DeviationBar'
+
+const meta: Meta<typeof DeviationBar> = {
+  title: 'Custom/Workout/DeviationBar',
+  component: DeviationBar,
+  tags: ['autodocs'],
+  argTypes: {
+    deviation: {
+      control: { type: 'range', min: -1, max: 1, step: 0.1 },
+      description: 'Deviation from plan (-1 to +1)',
+    },
+    width: {
+      control: 'number',
+      description: 'Width of the bar in pixels',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof DeviationBar>
+
+export const OnPlan: Story = {
+  args: { deviation: 0 },
+}
+
+export const SlightlyLighter: Story = {
+  args: { deviation: -0.2 },
+}
+
+export const MuchLighter: Story = {
+  args: { deviation: -0.8 },
+}
+
+export const SlightlyHarder: Story = {
+  args: { deviation: 0.3 },
+}
+
+export const MuchHarder: Story = {
+  args: { deviation: 0.9 },
+}
+
+export const FullRange: Story = {
+  render: () => (
+    <View style={{ gap: 8 }}>
+      {[-1, -0.7, -0.3, 0, 0.3, 0.7, 1].map((d) => (
+        <View key={d} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          <DeviationBar deviation={d} />
+        </View>
+      ))}
+    </View>
+  ),
+}
+
+export const WideBar: Story = {
+  args: { deviation: 0.5, width: 80 },
+}

--- a/packages/ui/src/components/custom/Workout/DeviationBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.test.tsx
@@ -58,6 +58,24 @@ describe('DeviationBar', () => {
     expect(bar).toHaveAttribute('role', 'slider')
   })
 
+  it('renders an 8px dot with a text-primary border and shadow', () => {
+    const { getByTestId } = render(<DeviationBar deviation={0} />)
+    const dot = getByTestId('deviation-dot')
+    expect(dot).toHaveStyle({ width: '8px', height: '8px' })
+    expect(dot).toHaveStyle({ borderTopWidth: '1.5px', borderTopColor: '#F3F4F6' })
+    expect(dot).toHaveStyle({ boxShadow: '0 0 4px rgba(0,0,0,0.5)' })
+  })
+
+  it('renders the track with the deviation gradient background', () => {
+    const { getByTestId } = render(<DeviationBar deviation={0} />)
+    const bar = getByTestId('deviation-bar')
+    const track = bar.firstElementChild as HTMLElement
+    expect(track).toHaveStyle({
+      backgroundImage:
+        'linear-gradient(90deg, rgba(20,184,166,0.25) 0%, rgba(107,114,128,0.15) 50%, rgba(255,176,32,0.25) 100%)',
+    })
+  })
+
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
       const { container } = render(<DeviationBar deviation={0.3} />)

--- a/packages/ui/src/components/custom/Workout/DeviationBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { DeviationBar } from './DeviationBar'
+
+describe('DeviationBar', () => {
+  it('renders the bar and dot', () => {
+    render(<DeviationBar deviation={0} />)
+    expect(screen.getByTestId('deviation-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('deviation-dot')).toBeInTheDocument()
+  })
+
+  it('labels on-plan deviation correctly', () => {
+    render(<DeviationBar deviation={0} />)
+    expect(screen.getByLabelText('Session deviation: on plan')).toBeInTheDocument()
+  })
+
+  it('labels lighter deviation correctly', () => {
+    render(<DeviationBar deviation={-0.5} />)
+    expect(screen.getByLabelText('Session deviation: lighter than planned')).toBeInTheDocument()
+  })
+
+  it('labels harder deviation correctly', () => {
+    render(<DeviationBar deviation={0.5} />)
+    expect(screen.getByLabelText('Session deviation: harder than planned')).toBeInTheDocument()
+  })
+
+  it('clamps deviation to -1', () => {
+    render(<DeviationBar deviation={-2} />)
+    expect(screen.getByTestId('deviation-bar')).toBeInTheDocument()
+  })
+
+  it('clamps deviation to +1', () => {
+    render(<DeviationBar deviation={2} />)
+    expect(screen.getByTestId('deviation-bar')).toBeInTheDocument()
+  })
+
+  it('accepts custom width', () => {
+    render(<DeviationBar deviation={0} width={80} />)
+    expect(screen.getByTestId('deviation-bar')).toBeInTheDocument()
+  })
+
+  it('renders dot at left edge for -1 deviation', () => {
+    const { getByTestId } = render(<DeviationBar deviation={-1} width={40} />)
+    const dot = getByTestId('deviation-dot')
+    expect(dot).toBeInTheDocument()
+  })
+
+  it('renders dot at right edge for +1 deviation', () => {
+    const { getByTestId } = render(<DeviationBar deviation={1} width={40} />)
+    const dot = getByTestId('deviation-dot')
+    expect(dot).toBeInTheDocument()
+  })
+
+  it('has adjustable accessibility role', () => {
+    render(<DeviationBar deviation={0} />)
+    const bar = screen.getByTestId('deviation-bar')
+    expect(bar).toHaveAttribute('role', 'slider')
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<DeviationBar deviation={0.3} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/DeviationBar.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.tsx
@@ -1,6 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React from 'react'
-import { View, type ViewProps } from 'react-native'
+import { View, type ViewProps, type ViewStyle } from 'react-native'
 
 export interface DeviationBarProps extends ViewProps {
   deviation: number
@@ -31,8 +30,8 @@ export function DeviationBar({
   const clamped = Math.max(-1, Math.min(1, deviation))
   const resolvedWidth = width ?? 40
   const dotPosition = ((clamped + 1) / 2) * resolvedWidth
-  const dotSize = 6
-  const trackHeight = 4
+  const dotSize = 8
+  const trackHeight = 6
   const containerHeight = 10
   const valueNow = Math.round(clamped * 100)
 
@@ -50,7 +49,14 @@ export function DeviationBar({
       {...props}
     >
       <View
-        style={{ height: trackHeight, backgroundColor: '#333333', width: resolvedWidth, borderRadius: 9999 }}
+        style={{
+          height: trackHeight,
+          width: resolvedWidth,
+          borderRadius: 3,
+          // react-native-web renders backgroundImage at runtime; not in RN ViewStyle types
+          backgroundImage:
+            'linear-gradient(90deg, rgba(20,184,166,0.25) 0%, rgba(107,114,128,0.15) 50%, rgba(255,176,32,0.25) 100%)',
+        } as ViewStyle}
       />
       <View
         style={{
@@ -58,6 +64,9 @@ export function DeviationBar({
           width: dotSize,
           height: dotSize,
           borderRadius: 9999,
+          borderWidth: 1.5,
+          borderColor: '#F3F4F6',
+          boxShadow: '0 0 4px rgba(0,0,0,0.5)',
           backgroundColor: getDotColor(clamped),
           left: Math.max(0, Math.min(dotPosition - dotSize / 2, resolvedWidth - dotSize)),
           top: (containerHeight - dotSize) / 2,

--- a/packages/ui/src/components/custom/Workout/DeviationBar.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.tsx
@@ -1,0 +1,69 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, type ViewProps } from 'react-native'
+
+export interface DeviationBarProps extends ViewProps {
+  deviation: number
+  width?: number
+  className?: string
+}
+
+function getDotColor(deviation: number): string {
+  const abs = Math.abs(deviation)
+  if (deviation < -0.3) return '#14B8A6'
+  if (abs <= 0.3) return '#6B7280'
+  if (abs <= 0.7) return '#FFB020'
+  return '#D14343'
+}
+
+function getDeviationDescription(deviation: number): string {
+  if (deviation < -0.3) return 'lighter than planned'
+  if (deviation > 0.3) return 'harder than planned'
+  return 'on plan'
+}
+
+export function DeviationBar({
+  deviation,
+  width,
+  className,
+  ...props
+}: DeviationBarProps) {
+  const clamped = Math.max(-1, Math.min(1, deviation))
+  const resolvedWidth = width ?? 40
+  const dotPosition = ((clamped + 1) / 2) * resolvedWidth
+  const dotSize = 6
+  const trackHeight = 4
+  const containerHeight = 10
+  const valueNow = Math.round(clamped * 100)
+
+  return (
+    <View
+      className={className}
+      style={{ flexDirection: 'row', alignItems: 'center', height: containerHeight, width: resolvedWidth }}
+      accessibilityRole="adjustable"
+      accessibilityValue={{ min: -100, max: 100, now: valueNow }}
+      accessibilityLabel={`Session deviation: ${getDeviationDescription(clamped)}`}
+      testID="deviation-bar"
+      aria-valuenow={valueNow}
+      aria-valuemin={-100}
+      aria-valuemax={100}
+      {...props}
+    >
+      <View
+        style={{ height: trackHeight, backgroundColor: '#333333', width: resolvedWidth, borderRadius: 9999 }}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          width: dotSize,
+          height: dotSize,
+          borderRadius: 9999,
+          backgroundColor: getDotColor(clamped),
+          left: Math.max(0, Math.min(dotPosition - dotSize / 2, resolvedWidth - dotSize)),
+          top: (containerHeight - dotSize) / 2,
+        }}
+        testID="deviation-dot"
+      />
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { E1rmBadge } from './E1rmBadge'
+
+const meta: Meta<typeof E1rmBadge> = {
+  title: 'Custom/Workout/E1rmBadge',
+  component: E1rmBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'number', description: 'Estimated 1RM value' },
+    unit: { control: 'select', options: ['lbs', 'kg'], description: 'Unit system' },
+    showIcon: { control: 'boolean', description: 'Show crown icon' },
+    isPr: { control: 'boolean', description: 'Apply PR styling (orange bg, star)' },
+    size: { control: 'select', options: ['sm', 'md', 'lg'], description: 'Badge size' },
+    delta: { control: 'number', description: 'Percentage change since last mesocycle' },
+    onPress: { action: 'pressed', description: 'Callback when tapped' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof E1rmBadge>
+
+export const Default: Story = {
+  args: { value: 217, unit: 'lbs' },
+}
+
+export const WithoutIcon: Story = {
+  args: { value: 217, unit: 'lbs', showIcon: false },
+}
+
+export const WithPr: Story = {
+  args: { value: 217, unit: 'lbs', isPr: true },
+}
+
+export const WithPositiveDelta: Story = {
+  args: { value: 217, unit: 'lbs', delta: 3 },
+}
+
+export const WithNegativeDelta: Story = {
+  args: { value: 217, unit: 'lbs', delta: -2 },
+}
+
+export const PrWithDelta: Story = {
+  args: { value: 217, unit: 'lbs', isPr: true, delta: 3, size: 'lg' },
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <View style={{ gap: 12 }}>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <E1rmBadge value={217} unit="lbs" size="sm" />
+        <E1rmBadge value={217} unit="lbs" size="md" />
+        <E1rmBadge value={217} unit="lbs" size="lg" />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <E1rmBadge value={217} unit="lbs" size="sm" showIcon={false} />
+        <E1rmBadge value={217} unit="lbs" size="md" showIcon={false} />
+        <E1rmBadge value={217} unit="lbs" size="lg" showIcon={false} />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <E1rmBadge value={217} unit="lbs" size="sm" isPr />
+        <E1rmBadge value={217} unit="lbs" size="md" isPr />
+        <E1rmBadge value={217} unit="lbs" size="lg" isPr />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <E1rmBadge value={217} unit="lbs" delta={3} />
+        <E1rmBadge value={217} unit="lbs" delta={-2} />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <E1rmBadge value={217} unit="lbs" isPr delta={3} size="lg" />
+      </View>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.test.tsx
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.test.tsx
@@ -56,6 +56,20 @@ describe('E1rmBadge', () => {
       render(<E1rmBadge value={315} isPr />)
       expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
     })
+
+    it('uses default border color when not a PR', () => {
+      render(<E1rmBadge value={225} />)
+      expect(screen.getByTestId('e1rm-badge')).toHaveStyle({
+        borderTopColor: '#1F1F1F',
+      })
+    })
+
+    it('uses brand-primary-subtle border color on PR state', () => {
+      render(<E1rmBadge value={315} isPr />)
+      expect(screen.getByTestId('e1rm-badge')).toHaveStyle({
+        borderTopColor: 'rgba(255, 121, 0, 0.12)',
+      })
+    })
   })
 
   describe('size', () => {

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.test.tsx
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { E1rmBadge } from './E1rmBadge'
+
+describe('E1rmBadge', () => {
+  it('renders value and default unit', () => {
+    render(<E1rmBadge value={225} />)
+    expect(screen.getByText('225 lbs')).toBeInTheDocument()
+  })
+
+  it('renders with kg unit', () => {
+    render(<E1rmBadge value={100} unit="kg" />)
+    expect(screen.getByText('100 kg')).toBeInTheDocument()
+  })
+
+  it('wraps in Pressable when onPress is provided', () => {
+    const onPress = vi.fn()
+    render(<E1rmBadge value={225} onPress={onPress} />)
+    const pressable = screen.getByTestId('e1rm-badge-pressable')
+    fireEvent.click(pressable)
+    expect(onPress).toHaveBeenCalledOnce()
+  })
+
+  it('does not render Pressable when onPress is omitted', () => {
+    render(<E1rmBadge value={225} />)
+    expect(screen.queryByTestId('e1rm-badge-pressable')).not.toBeInTheDocument()
+  })
+
+  it('sets accessibility label with value and unit', () => {
+    render(<E1rmBadge value={315} unit="lbs" />)
+    expect(
+      screen.getByLabelText('Estimated one rep max: 315 lbs'),
+    ).toBeInTheDocument()
+  })
+
+  describe('showIcon', () => {
+    it('shows crown icon by default', () => {
+      render(<E1rmBadge value={225} />)
+      expect(screen.getByTestId('e1rm-icon')).toBeInTheDocument()
+    })
+
+    it('hides crown icon when showIcon is false', () => {
+      render(<E1rmBadge value={225} showIcon={false} />)
+      expect(screen.queryByTestId('e1rm-icon')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('isPr', () => {
+    it('renders without error when isPr is false', () => {
+      render(<E1rmBadge value={225} />)
+      expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
+    })
+
+    it('renders without error when isPr is true', () => {
+      render(<E1rmBadge value={315} isPr />)
+      expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
+    })
+  })
+
+  describe('size', () => {
+    it('defaults to md size', () => {
+      render(<E1rmBadge value={225} />)
+      expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
+    })
+
+    it('renders sm size', () => {
+      render(<E1rmBadge value={225} size="sm" />)
+      expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
+    })
+
+    it('renders lg size', () => {
+      render(<E1rmBadge value={225} size="lg" />)
+      expect(screen.getByTestId('e1rm-badge')).toBeInTheDocument()
+    })
+  })
+
+  describe('delta', () => {
+    it('shows positive delta', () => {
+      render(<E1rmBadge value={225} delta={3} />)
+      const delta = screen.getByTestId('e1rm-delta')
+      expect(delta).toHaveTextContent('+3%')
+    })
+
+    it('shows negative delta', () => {
+      render(<E1rmBadge value={225} delta={-2} />)
+      const delta = screen.getByTestId('e1rm-delta')
+      expect(delta).toHaveTextContent('-2%')
+    })
+
+    it('shows zero delta as positive', () => {
+      render(<E1rmBadge value={225} delta={0} />)
+      const delta = screen.getByTestId('e1rm-delta')
+      expect(delta).toHaveTextContent('+0%')
+    })
+
+    it('does not show delta when not provided', () => {
+      render(<E1rmBadge value={225} />)
+      expect(screen.queryByTestId('e1rm-delta')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <E1rmBadge value={225} isPr onPress={() => {}} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with delta', async () => {
+      const { container } = render(
+        <E1rmBadge value={225} delta={3} onPress={() => {}} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations as static badge', async () => {
+      const { container } = render(<E1rmBadge value={315} unit="kg" isPr delta={-2} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('pressable includes delta in accessibility label', () => {
+      render(<E1rmBadge value={225} delta={5} onPress={() => {}} />)
+      expect(
+        screen.getByLabelText('Estimated one rep max: 225 lbs, +5% change'),
+      ).toBeInTheDocument()
+    })
+
+    it('pressable includes negative delta in accessibility label', () => {
+      render(<E1rmBadge value={225} delta={-3} onPress={() => {}} />)
+      expect(
+        screen.getByLabelText('Estimated one rep max: 225 lbs, -3% change'),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.tsx
@@ -1,0 +1,134 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useRef } from 'react'
+import { View, Text, Pressable, Animated, type ViewProps } from 'react-native'
+import { Crown } from 'lucide-react'
+
+export type E1rmBadgeSize = 'sm' | 'md' | 'lg'
+
+export interface E1rmBadgeProps extends ViewProps {
+  value: number
+  unit?: 'lbs' | 'kg'
+  /** Show crown icon */
+  showIcon?: boolean
+  isPr?: boolean
+  /** Percentage delta from previous mesocycle */
+  delta?: number
+  /** Size variant */
+  size?: E1rmBadgeSize
+  onPress?: () => void
+  className?: string
+}
+
+const sizeConfig: Record<E1rmBadgeSize, { fontSize: number; paddingH: number; paddingV: number; iconSize: number }> = {
+  sm: { fontSize: 9, paddingH: 6, paddingV: 2, iconSize: 10 },
+  md: { fontSize: 10, paddingH: 8, paddingV: 2, iconSize: 12 },
+  lg: { fontSize: 12, paddingH: 10, paddingV: 4, iconSize: 14 },
+}
+
+export function E1rmBadge({
+  value,
+  unit = 'lbs',
+  showIcon = true,
+  isPr,
+  delta,
+  size = 'md',
+  onPress,
+  className,
+  ...props
+}: E1rmBadgeProps) {
+  const scaleAnim = useRef(new Animated.Value(1)).current
+  const config = sizeConfig[size]
+
+  const handlePressIn = () => {
+    Animated.timing(scaleAnim, {
+      toValue: 0.97,
+      duration: 150,
+      useNativeDriver: true,
+    }).start()
+  }
+
+  const handlePressOut = () => {
+    Animated.timing(scaleAnim, {
+      toValue: 1,
+      duration: 150,
+      useNativeDriver: true,
+    }).start()
+  }
+
+  const iconColor = isPr ? '#FF7900' : '#9CA3AF'
+
+  const deltaLabel = delta != null ? `, ${delta >= 0 ? '+' : ''}${delta}% change` : ''
+  const fullLabel = `Estimated one rep max: ${value} ${unit}${deltaLabel}`
+
+  const badge = (
+    <View
+      className={className}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 3,
+        borderRadius: 2,
+        borderWidth: 1,
+        borderColor: isPr ? 'rgba(255, 121, 0, 0.3)' : '#1F1F1F',
+        backgroundColor: isPr ? 'rgba(255, 121, 0, 0.12)' : '#1C1C1C',
+        paddingHorizontal: config.paddingH,
+        paddingVertical: config.paddingV,
+      }}
+      accessibilityLabel={`Estimated one rep max: ${value} ${unit}`}
+      testID="e1rm-badge"
+      {...props}
+    >
+      {showIcon && (
+        <View
+          accessibilityElementsHidden
+          testID="e1rm-icon"
+        >
+          <Crown size={config.iconSize} color={iconColor} strokeWidth={2} />
+        </View>
+      )}
+      <Text
+        style={{
+          fontFamily: '"Space Grotesk", sans-serif',
+          fontWeight: '600',
+          fontSize: config.fontSize,
+          color: isPr ? '#FF7900' : '#9CA3AF',
+        }}
+      >
+        {isPr ? '\u2733 ' : ''}{value} {unit}
+      </Text>
+      {delta != null && (
+        <Text
+          style={{
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontSize: config.fontSize,
+            marginLeft: 4,
+            color: delta >= 0 ? '#4caf50' : '#ef5350',
+          }}
+          testID="e1rm-delta"
+        >
+          {delta >= 0 ? '+' : ''}
+          {delta}%
+        </Text>
+      )}
+    </View>
+  )
+
+  if (onPress) {
+    return (
+      <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
+        <Pressable
+          onPress={onPress}
+          onPressIn={handlePressIn}
+          onPressOut={handlePressOut}
+          accessibilityRole="button"
+          accessibilityLabel={fullLabel}
+          testID="e1rm-badge-pressable"
+        >
+          {badge}
+        </Pressable>
+      </Animated.View>
+    )
+  }
+
+  return badge
+}

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.tsx
@@ -1,5 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useRef } from 'react'
+import { useState } from 'react'
 import { View, Text, Pressable, Animated, type ViewProps } from 'react-native'
 import { Crown } from 'lucide-react'
 
@@ -36,7 +36,7 @@ export function E1rmBadge({
   className,
   ...props
 }: E1rmBadgeProps) {
-  const scaleAnim = useRef(new Animated.Value(1)).current
+  const [scaleAnim] = useState(() => new Animated.Value(1))
   const config = sizeConfig[size]
 
   const handlePressIn = () => {
@@ -69,7 +69,7 @@ export function E1rmBadge({
         gap: 3,
         borderRadius: 2,
         borderWidth: 1,
-        borderColor: isPr ? 'rgba(255, 121, 0, 0.3)' : '#1F1F1F',
+        borderColor: isPr ? 'rgba(255, 121, 0, 0.12)' : '#1F1F1F',
         backgroundColor: isPr ? 'rgba(255, 121, 0, 0.12)' : '#1C1C1C',
         paddingHorizontal: config.paddingH,
         paddingVertical: config.paddingV,

--- a/packages/ui/src/components/custom/Workout/E1rmBadge.visual.test.ts
+++ b/packages/ui/src/components/custom/Workout/E1rmBadge.visual.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('E1rmBadge Visual', () => {
+  test('default variant matches snapshot', async ({ page }) => {
+    await page.goto('/iframe.html?id=custom-workout-e1rmbadge--default')
+    await page.waitForSelector('[data-testid="e1rm-badge"]')
+
+    const badge = page.locator('[data-testid="e1rm-badge"]')
+
+    const styles = await badge.evaluate((el) => {
+      const cs = window.getComputedStyle(el)
+      return {
+        backgroundColor: cs.backgroundColor,
+        borderRadius: cs.borderRadius,
+        borderColor: cs.borderColor,
+        fontFamily: cs.fontFamily,
+      }
+    })
+
+    expect(styles.borderRadius).toBe('2px')
+    // backgroundColor should be surface-raised (#1C1C1C = rgb(28, 28, 28))
+    expect(styles.backgroundColor).toContain('28, 28, 28')
+    // borderColor should be border-default (#1F1F1F = rgb(31, 31, 31))
+    expect(styles.borderColor).toContain('31, 31, 31')
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { ExerciseCard } from './ExerciseCard'
+import type { SetRowProps } from './SetRow'
+
+const meta: Meta<typeof ExerciseCard> = {
+  title: 'Custom/Workout/ExerciseCard',
+  component: ExerciseCard,
+  tags: ['autodocs'],
+  argTypes: {
+    state: {
+      control: 'select',
+      options: ['collapsed', 'expanded', 'upcoming'],
+      description: 'Card display state',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ maxWidth: 400, padding: 16, backgroundColor: '#121212' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof ExerciseCard>
+
+const sampleSets: SetRowProps[] = [
+  {
+    mode: 'completed',
+    setNumber: 1,
+    reps: 8,
+    weight: 135,
+    unit: 'lbs',
+    rpe: 7,
+    previous: { reps: 8, weight: 130 },
+    velocities: [1.1, 0.95, 0.82, 0.68, 0.55, 0.48, 0.42, 0.38],
+  },
+  {
+    mode: 'completed',
+    setNumber: 2,
+    reps: 8,
+    weight: 135,
+    unit: 'lbs',
+    rpe: 8.5,
+    previous: { reps: 8, weight: 135 },
+    velocities: [0.95, 0.88, 0.78, 0.65, 0.52, 0.45, 0.40, 0.35],
+  },
+  {
+    mode: 'active',
+    setNumber: 3,
+    reps: null,
+    weight: null,
+    unit: 'lbs',
+    isNextSet: true,
+    targets: { reps: 8, weight: 135 },
+    previous: { reps: 8, weight: 135 },
+  },
+  {
+    mode: 'active',
+    setNumber: 4,
+    reps: null,
+    weight: null,
+    unit: 'lbs',
+    targets: { reps: 8, weight: 135 },
+    previous: { reps: 8, weight: 135 },
+  },
+]
+
+export const CollapsedWithVelocity: Story = {
+  args: {
+    name: 'Bench Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 4, reps: 8, weight: 135, unit: 'lbs' },
+    setVelocities: [
+      [1.1, 0.95, 0.82, 0.68, 0.55, 0.48, 0.42, 0.38],
+      [0.95, 0.88, 0.78, 0.65, 0.52, 0.45, 0.40, 0.35],
+    ],
+    totalPlannedSets: 4,
+    e1rm: { value: 225, unit: 'lbs' },
+  },
+}
+
+export const CollapsedWithPR: Story = {
+  args: {
+    name: 'Squat',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 5, weight: 275, unit: 'lbs' },
+    setVelocities: [
+      [0.65, 0.55, 0.45, 0.38, 0.32],
+      [0.60, 0.50, 0.42, 0.35, 0.30],
+      [0.58, 0.48, 0.40, 0.33, 0.28],
+    ],
+    totalPlannedSets: 3,
+    e1rm: { value: 365, unit: 'lbs' },
+    isPR: true,
+  },
+}
+
+export const ExpandedWithSets: Story = {
+  args: {
+    name: 'Bench Press',
+    state: 'expanded',
+    onToggle: () => {},
+    summary: { sets: 4, reps: 8, weight: 135, unit: 'lbs' },
+    sets: sampleSets,
+    e1rm: { value: 225, unit: 'lbs' },
+  },
+}
+
+export const ExpandedWithTempo: Story = {
+  args: {
+    name: 'Romanian Deadlift',
+    state: 'expanded',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 10, weight: 185, unit: 'lbs' },
+    tempo: [2, 1, 3, 0],
+    sets: [
+      {
+        mode: 'completed',
+        setNumber: 1,
+        reps: 10,
+        weight: 185,
+        unit: 'lbs',
+        rpe: 7,
+        previous: { reps: 10, weight: 175 },
+      },
+      {
+        mode: 'active',
+        setNumber: 2,
+        reps: null,
+        weight: null,
+        unit: 'lbs',
+        isNextSet: true,
+        targets: { reps: 10, weight: 185 },
+        previous: { reps: 10, weight: 185 },
+      },
+      {
+        mode: 'active',
+        setNumber: 3,
+        reps: null,
+        weight: null,
+        unit: 'lbs',
+        targets: { reps: 10, weight: 185 },
+        previous: { reps: 10, weight: 185 },
+      },
+    ],
+  },
+}
+
+export const Upcoming: Story = {
+  args: {
+    name: 'Lat Pulldown',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3\u00D78-12 @ RPE 8',
+    previousBest: '135 lbs \u00D7 10',
+  },
+}
+
+export const SupersetFirst: Story = {
+  args: {
+    name: 'Bench Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 8, weight: 185, unit: 'lbs' },
+    supersetPosition: 'first',
+    setVelocities: [[1.0, 0.9, 0.8]],
+    totalPlannedSets: 3,
+  },
+}
+
+export const SupersetLast: Story = {
+  args: {
+    name: 'Barbell Row',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 8, weight: 155, unit: 'lbs' },
+    supersetPosition: 'last',
+    setVelocities: [[0.9, 0.8, 0.7]],
+    totalPlannedSets: 3,
+  },
+}

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.test.tsx
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { ExerciseCard } from './ExerciseCard'
+import type { SetRowProps } from './SetRow'
+
+const baseCollapsedProps = {
+  name: 'Bench Press',
+  state: 'collapsed' as const,
+  onToggle: vi.fn(),
+  summary: { sets: 3, reps: 6, weight: 175, unit: 'lbs' as const },
+}
+
+const baseSets: SetRowProps[] = [
+  { mode: 'completed', setNumber: 1, reps: 8, weight: 135, unit: 'lbs' },
+  { mode: 'completed', setNumber: 2, reps: 8, weight: 135, unit: 'lbs' },
+  { mode: 'active', setNumber: 3, reps: null, weight: null, unit: 'lbs', isNextSet: true },
+]
+
+describe('ExerciseCard', () => {
+  describe('collapsed state', () => {
+    it('renders exercise name', () => {
+      render(<ExerciseCard {...baseCollapsedProps} />)
+      expect(screen.getByTestId('exercise-card-name')).toHaveTextContent('Bench Press')
+    })
+
+    it('renders summary text', () => {
+      render(<ExerciseCard {...baseCollapsedProps} />)
+      expect(screen.getByTestId('exercise-card-summary')).toHaveTextContent(
+        '3\u00D76 @ 175 lbs',
+      )
+    })
+
+    it('renders E1rmBadge when e1rm provided', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          e1rm={{ value: 225, unit: 'lbs' }}
+        />,
+      )
+      expect(screen.getByTestId('exercise-card-e1rm')).toBeInTheDocument()
+    })
+
+    it('renders PrBadge when isPR is true', () => {
+      render(<ExerciseCard {...baseCollapsedProps} isPR />)
+      expect(screen.getByTestId('pr-badge-star')).toBeInTheDocument()
+    })
+
+    it('renders mini velocity strips for completed sets', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          setVelocities={[[1.1, 0.95], [0.9, 0.8]]}
+          totalPlannedSets={4}
+        />,
+      )
+      expect(screen.getByTestId('exercise-card-velocity-strip-0')).toBeInTheDocument()
+      expect(screen.getByTestId('exercise-card-velocity-strip-1')).toBeInTheDocument()
+    })
+
+    it('renders placeholder strips for remaining planned sets', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          setVelocities={[[1.1, 0.95]]}
+          totalPlannedSets={3}
+        />,
+      )
+      expect(screen.getByTestId('exercise-card-placeholder-0')).toBeInTheDocument()
+      expect(screen.getByTestId('exercise-card-placeholder-1')).toBeInTheDocument()
+    })
+
+    it('does not render strips container when no velocities and no planned sets', () => {
+      render(<ExerciseCard {...baseCollapsedProps} />)
+      expect(screen.queryByTestId('exercise-card-strips')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('expanded state', () => {
+    const expandedProps = {
+      name: 'Squat',
+      state: 'expanded' as const,
+      onToggle: vi.fn(),
+      summary: { sets: 3, reps: 8, weight: 185, unit: 'lbs' as const },
+      sets: baseSets,
+    }
+
+    it('renders exercise name in header', () => {
+      render(<ExerciseCard {...expandedProps} />)
+      expect(screen.getByTestId('exercise-card-name')).toHaveTextContent('Squat')
+    })
+
+    it('renders column headers', () => {
+      render(<ExerciseCard {...expandedProps} />)
+      const headers = screen.getByTestId('exercise-card-column-headers')
+      expect(headers).toHaveTextContent('SET')
+      expect(headers).toHaveTextContent('PREV')
+      expect(headers).toHaveTextContent('REPS')
+      expect(headers).toHaveTextContent('LBS')
+      expect(headers).toHaveTextContent('RPE')
+    })
+
+    it('renders SetRow components', () => {
+      render(<ExerciseCard {...expandedProps} />)
+      const setRows = screen.getAllByTestId('set-row')
+      expect(setRows).toHaveLength(3)
+    })
+
+    it('renders TempoDisplay when tempo provided', () => {
+      render(
+        <ExerciseCard
+          {...expandedProps}
+          tempo={[2, 1, 3, 0]}
+        />,
+      )
+      expect(screen.getByTestId('exercise-card-tempo')).toBeInTheDocument()
+      expect(screen.getByTestId('tempo-display')).toBeInTheDocument()
+    })
+
+    it('does not render TempoDisplay when no tempo', () => {
+      render(<ExerciseCard {...expandedProps} />)
+      expect(screen.queryByTestId('exercise-card-tempo')).not.toBeInTheDocument()
+    })
+
+    it('sets aria-expanded on header button', () => {
+      render(<ExerciseCard {...expandedProps} />)
+      const header = screen.getByTestId('exercise-card-header')
+      expect(header).toHaveAttribute('aria-expanded', 'true')
+    })
+  })
+
+  describe('upcoming state', () => {
+    const upcomingProps = {
+      name: 'Deadlift',
+      state: 'upcoming' as const,
+      onToggle: vi.fn(),
+      prescription: '3\u00D78-12 @ RPE 8',
+      previousBest: '185 lbs \u00D7 10',
+    }
+
+    it('renders with reduced opacity', () => {
+      render(<ExerciseCard {...upcomingProps} />)
+      const card = screen.getByTestId('exercise-card')
+      expect(card).toHaveStyle({ opacity: 0.6 })
+    })
+
+    it('renders exercise name', () => {
+      render(<ExerciseCard {...upcomingProps} />)
+      expect(screen.getByTestId('exercise-card-name')).toHaveTextContent('Deadlift')
+    })
+
+    it('renders prescription text', () => {
+      render(<ExerciseCard {...upcomingProps} />)
+      expect(screen.getByTestId('exercise-card-prescription')).toHaveTextContent(
+        '3\u00D78-12 @ RPE 8',
+      )
+    })
+
+    it('renders previous best text', () => {
+      render(<ExerciseCard {...upcomingProps} />)
+      expect(screen.getByTestId('exercise-card-previous-best')).toHaveTextContent(
+        '185 lbs \u00D7 10',
+      )
+    })
+
+    it('does not render interactive elements', () => {
+      render(<ExerciseCard {...upcomingProps} />)
+      expect(screen.queryByTestId('exercise-card-strips')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('exercise-card-column-headers')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('onToggle', () => {
+    it('fires onToggle when collapsed card is pressed', () => {
+      const onToggle = vi.fn()
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          onToggle={onToggle}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('exercise-card-header'))
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+
+    it('fires onToggle when expanded header is pressed', () => {
+      const onToggle = vi.fn()
+      render(
+        <ExerciseCard
+          name="Squat"
+          state="expanded"
+          onToggle={onToggle}
+          sets={baseSets}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('exercise-card-header'))
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('superset position border radius', () => {
+    it('applies first position border radius', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          supersetPosition="first"
+        />,
+      )
+      const card = screen.getByTestId('exercise-card')
+      const container = card.firstChild as HTMLElement
+      expect(container).toHaveStyle({
+        borderTopLeftRadius: '12px',
+        borderTopRightRadius: '12px',
+        borderBottomLeftRadius: '8px',
+        borderBottomRightRadius: '8px',
+      })
+    })
+
+    it('applies last position border radius', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          supersetPosition="last"
+        />,
+      )
+      const card = screen.getByTestId('exercise-card')
+      const container = card.firstChild as HTMLElement
+      expect(container).toHaveStyle({
+        borderTopLeftRadius: '8px',
+        borderTopRightRadius: '8px',
+        borderBottomLeftRadius: '12px',
+        borderBottomRightRadius: '12px',
+      })
+    })
+
+    it('applies middle position border radius', () => {
+      render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          supersetPosition="middle"
+        />,
+      )
+      const card = screen.getByTestId('exercise-card')
+      const container = card.firstChild as HTMLElement
+      expect(container).toHaveStyle({
+        borderTopLeftRadius: '8px',
+        borderTopRightRadius: '8px',
+        borderBottomLeftRadius: '8px',
+        borderBottomRightRadius: '8px',
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has correct accessibility label for collapsed state', () => {
+      render(<ExerciseCard {...baseCollapsedProps} />)
+      expect(
+        screen.getByLabelText('Bench Press, 3\u00D76 @ 175 lbs'),
+      ).toBeInTheDocument()
+    })
+
+    it('has correct accessibility label for upcoming state with prescription', () => {
+      render(
+        <ExerciseCard
+          name="Deadlift"
+          state="upcoming"
+          onToggle={vi.fn()}
+          prescription="3x8 @ RPE 8"
+        />,
+      )
+      expect(
+        screen.getByLabelText('Deadlift, 3x8 @ RPE 8'),
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations in collapsed state', async () => {
+      const { container } = render(
+        <ExerciseCard
+          {...baseCollapsedProps}
+          e1rm={{ value: 225, unit: 'lbs' }}
+          isPR
+          setVelocities={[[1.1, 0.95]]}
+          totalPlannedSets={3}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations in expanded state', async () => {
+      const { container } = render(
+        <ExerciseCard
+          name="Squat"
+          state="expanded"
+          onToggle={vi.fn()}
+          summary={{ sets: 3, reps: 8, weight: 185, unit: 'lbs' }}
+          sets={baseSets}
+          tempo={[2, 1, 3, 0]}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations in upcoming state', async () => {
+      const { container } = render(
+        <ExerciseCard
+          name="Deadlift"
+          state="upcoming"
+          onToggle={vi.fn()}
+          prescription="3x8 @ RPE 8"
+          previousBest="185 lbs x 10"
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -1,5 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { View, Text, Pressable } from 'react-native'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 import { VelocityStrip } from './VelocityStrip'
@@ -296,13 +296,7 @@ function ExpandedCard({
 
       {tempo && (
         <View style={{ marginTop: 8, paddingHorizontal: 14 }} testID="exercise-card-tempo">
-          <TempoDisplay
-            concentric={tempo[0]}
-            hold={tempo[1]}
-            eccentric={tempo[2]}
-            idle={tempo[3]}
-            size="sm"
-          />
+          <TempoDisplay tempo={tempo} size="sm" />
         </View>
       )}
 

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -1,0 +1,435 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useState } from 'react'
+import { View, Text, Pressable } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { VelocityStrip } from './VelocityStrip'
+import { PlaceholderStrip } from './PlaceholderStrip'
+import { E1rmBadge } from './E1rmBadge'
+import { PrBadge } from './PrBadge'
+import { TempoDisplay } from './TempoDisplay'
+import { SetRow, type SetRowProps } from './SetRow'
+
+export type ExerciseCardState = 'collapsed' | 'expanded' | 'upcoming'
+
+export interface ExerciseCardProps {
+  name: string
+  state: ExerciseCardState
+  onToggle: () => void
+  onNavigateDetail?: () => void
+  summary?: {
+    sets: number
+    reps: number | string
+    weight: number
+    unit: 'lbs' | 'kg'
+  }
+  e1rm?: { value: number; unit: 'lbs' | 'kg' }
+  isPR?: boolean
+  setVelocities?: number[][]
+  totalPlannedSets?: number
+  sets?: SetRowProps[]
+  tempo?: [number, number, number, number]
+  prescription?: string
+  previousBest?: string
+  supersetPosition?: 'first' | 'last' | 'middle' | null
+  supersetColor?: string
+}
+
+const COLORS = {
+  textPrimary: '#F3F4F6',
+  textSecondary: '#9CA3AF',
+  textTertiary: '#6B7280',
+  brandPrimary: '#FF7900',
+}
+
+const COLUMN_HEADERS = ['SET', 'PREV', 'REPS', 'LBS', 'RPE'] as const
+
+function getSupersetBorderRadius(
+  position: ExerciseCardProps['supersetPosition'],
+): Record<string, number> {
+  switch (position) {
+    case 'first':
+      return {
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        borderBottomLeftRadius: 8,
+        borderBottomRightRadius: 8,
+      }
+    case 'last':
+      return {
+        borderTopLeftRadius: 8,
+        borderTopRightRadius: 8,
+        borderBottomLeftRadius: 12,
+        borderBottomRightRadius: 12,
+      }
+    case 'middle':
+      return {
+        borderTopLeftRadius: 8,
+        borderTopRightRadius: 8,
+        borderBottomLeftRadius: 8,
+        borderBottomRightRadius: 8,
+      }
+    default:
+      return {
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        borderBottomLeftRadius: 12,
+        borderBottomRightRadius: 12,
+      }
+  }
+}
+
+function getSupersetMargin(
+  position: ExerciseCardProps['supersetPosition'],
+): Record<string, number> {
+  if (position === 'first' || position === 'middle') {
+    return { marginBottom: 2 }
+  }
+  return {}
+}
+
+function formatSummary(summary: ExerciseCardProps['summary']): string {
+  if (!summary) return ''
+  return `${summary.sets}\u00D7${summary.reps} @ ${summary.weight} ${summary.unit}`
+}
+
+function formatAccessibilityLabel(
+  name: string,
+  summary: ExerciseCardProps['summary'],
+  prescription: ExerciseCardProps['prescription'],
+): string {
+  if (summary) return `${name}, ${formatSummary(summary)}`
+  if (prescription) return `${name}, ${prescription}`
+  return name
+}
+
+function CollapsedCard({
+  name,
+  onToggle,
+  summary,
+  e1rm,
+  isPR,
+  setVelocities,
+  totalPlannedSets,
+  supersetPosition,
+}: ExerciseCardProps) {
+  const [pressed, setPressed] = useState(false)
+  const completedSets = setVelocities?.length ?? 0
+  const remaining = Math.max(0, (totalPlannedSets ?? 0) - completedSets)
+  const borderRadius = getSupersetBorderRadius(supersetPosition)
+  const supersetMargin = getSupersetMargin(supersetPosition)
+
+  return (
+    <Pressable
+      onPress={onToggle}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      accessibilityRole="button"
+      accessibilityLabel={formatAccessibilityLabel(name, summary, undefined)}
+      testID="exercise-card"
+    >
+      <View
+        style={{
+          padding: 12,
+          paddingHorizontal: 14,
+          cursor: 'pointer',
+          backgroundColor: pressed
+            ? WORKOUT_TOKENS.surface.raised
+            : 'transparent',
+          ...borderRadius,
+          ...supersetMargin,
+        }}
+      >
+        <View
+          className="flex-row items-center"
+          testID="exercise-card-header"
+        >
+          <Text
+            style={{
+              fontSize: 14,
+              fontFamily: '"Space Grotesk", sans-serif',
+              fontWeight: '700',
+              color: COLORS.textPrimary,
+            }}
+            testID="exercise-card-name"
+          >
+            {name}
+          </Text>
+          <View className="flex-1" />
+          {summary && (
+            <Text
+              style={{
+                fontSize: 12,
+                fontFamily: 'Inter, sans-serif',
+                color: COLORS.textSecondary,
+                marginRight: 8,
+              }}
+              testID="exercise-card-summary"
+            >
+              {formatSummary(summary)}
+            </Text>
+          )}
+          {e1rm && (
+            <E1rmBadge
+              value={e1rm.value}
+              unit={e1rm.unit}
+              size="sm"
+              showIcon={false}
+              testID="exercise-card-e1rm"
+            />
+          )}
+          {isPR && (
+            <View style={{ marginLeft: 4 }}>
+              <PrBadge type="e1rm" compact animate={false} />
+            </View>
+          )}
+        </View>
+
+        {(completedSets > 0 || remaining > 0) && (
+          <View
+            className="flex-row"
+            style={{ marginTop: 6, gap: 4 }}
+            testID="exercise-card-strips"
+          >
+            {setVelocities?.map((velocities, i) => (
+              <VelocityStrip
+                key={i}
+                velocities={velocities}
+                variant="mini"
+                testID={`exercise-card-velocity-strip-${i}`}
+              />
+            ))}
+            {Array.from({ length: remaining }, (_, i) => (
+              <PlaceholderStrip
+                key={`placeholder-${i}`}
+                testID={`exercise-card-placeholder-${i}`}
+              />
+            ))}
+          </View>
+        )}
+      </View>
+    </Pressable>
+  )
+}
+
+function ExpandedCard({
+  name,
+  onToggle,
+  summary,
+  e1rm,
+  isPR,
+  sets,
+  tempo,
+  supersetPosition,
+}: ExerciseCardProps) {
+  const borderRadius = getSupersetBorderRadius(supersetPosition)
+  const supersetMargin = getSupersetMargin(supersetPosition)
+
+  return (
+    <View
+      style={{
+        backgroundColor: WORKOUT_TOKENS.surface.elevated,
+        borderWidth: 1,
+        borderColor: WORKOUT_TOKENS.border.default,
+        ...borderRadius,
+        ...supersetMargin,
+      }}
+      testID="exercise-card"
+    >
+      <Pressable
+        onPress={onToggle}
+        accessibilityRole="button"
+        accessibilityLabel={formatAccessibilityLabel(name, summary, undefined)}
+        aria-expanded={true}
+        testID="exercise-card-header"
+      >
+        <View
+          className="flex-row items-center"
+          style={{
+            padding: 12,
+            paddingHorizontal: 14,
+            paddingBottom: 10,
+            borderBottomWidth: 1,
+            borderBottomColor: WORKOUT_TOKENS.border.default,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 14,
+              fontFamily: '"Space Grotesk", sans-serif',
+              fontWeight: '700',
+              color: COLORS.textPrimary,
+            }}
+            testID="exercise-card-name"
+          >
+            {name}
+          </Text>
+          <View className="flex-1" />
+          {summary && (
+            <Text
+              style={{
+                fontSize: 12,
+                fontFamily: 'Inter, sans-serif',
+                color: COLORS.textSecondary,
+                marginRight: 8,
+              }}
+              testID="exercise-card-summary"
+            >
+              {formatSummary(summary)}
+            </Text>
+          )}
+          {e1rm && (
+            <E1rmBadge
+              value={e1rm.value}
+              unit={e1rm.unit}
+              size="sm"
+              showIcon={false}
+              testID="exercise-card-e1rm"
+            />
+          )}
+          {isPR && (
+            <View style={{ marginLeft: 4 }}>
+              <PrBadge type="e1rm" compact animate={false} />
+            </View>
+          )}
+        </View>
+      </Pressable>
+
+      {tempo && (
+        <View style={{ marginTop: 8, paddingHorizontal: 14 }} testID="exercise-card-tempo">
+          <TempoDisplay
+            concentric={tempo[0]}
+            hold={tempo[1]}
+            eccentric={tempo[2]}
+            idle={tempo[3]}
+            size="sm"
+          />
+        </View>
+      )}
+
+      <View
+        className="flex-row"
+        style={{
+          paddingVertical: 8,
+          paddingHorizontal: 8,
+          paddingBottom: 4,
+        }}
+        testID="exercise-card-column-headers"
+      >
+        {COLUMN_HEADERS.map((header, i) => {
+          const widths = [36, undefined, 44, 56, 36]
+          const width = widths[i]
+          const isFlex = width === undefined
+
+          return (
+            <View
+              key={header}
+              style={{
+                ...(isFlex ? {} : { width }),
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 8,
+              }}
+              {...(isFlex ? { className: 'flex-1' } : {})}
+            >
+              <Text
+                style={{
+                  fontSize: 10,
+                  fontWeight: '600',
+                  fontFamily: 'Inter, sans-serif',
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.8,
+                  color: COLORS.textTertiary,
+                }}
+              >
+                {header}
+              </Text>
+            </View>
+          )
+        })}
+      </View>
+
+      {sets && (
+        <View testID="exercise-card-sets">
+          {sets.map((setProps, i) => (
+            <SetRow key={i} {...setProps} />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}
+
+function UpcomingCard({
+  name,
+  prescription,
+  previousBest,
+  supersetPosition,
+}: ExerciseCardProps) {
+  const borderRadius = getSupersetBorderRadius(supersetPosition)
+  const supersetMargin = getSupersetMargin(supersetPosition)
+
+  return (
+    <View
+      style={{
+        opacity: 0.6,
+        padding: 12,
+        paddingHorizontal: 14,
+        ...borderRadius,
+        ...supersetMargin,
+      }}
+      accessibilityLabel={formatAccessibilityLabel(name, undefined, prescription)}
+      testID="exercise-card"
+    >
+      <View className="flex-row items-center">
+        <Text
+          style={{
+            fontSize: 14,
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontWeight: '700',
+            color: COLORS.textPrimary,
+          }}
+          testID="exercise-card-name"
+        >
+          {name}
+        </Text>
+        {prescription && (
+          <Text
+            style={{
+              fontSize: 12,
+              fontFamily: 'Inter, sans-serif',
+              color: COLORS.textSecondary,
+              marginLeft: 8,
+            }}
+            testID="exercise-card-prescription"
+          >
+            {prescription}
+          </Text>
+        )}
+        <View className="flex-1" />
+        {previousBest && (
+          <Text
+            style={{
+              fontSize: 11,
+              fontFamily: 'Inter, sans-serif',
+              color: COLORS.textTertiary,
+            }}
+            testID="exercise-card-previous-best"
+          >
+            {previousBest}
+          </Text>
+        )}
+      </View>
+    </View>
+  )
+}
+
+export function ExerciseCard(props: ExerciseCardProps) {
+  switch (props.state) {
+    case 'collapsed':
+      return <CollapsedCard {...props} />
+    case 'expanded':
+      return <ExpandedCard {...props} />
+    case 'upcoming':
+      return <UpcomingCard {...props} />
+  }
+}

--- a/packages/ui/src/components/custom/Workout/InputBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/InputBar.stories.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { InputBar } from './InputBar'
+
+const meta: Meta<typeof InputBar> = {
+  title: 'Custom/Workout/InputBar',
+  component: InputBar,
+  tags: ['autodocs'],
+  argTypes: {
+    canRecord: {
+      control: 'boolean',
+      description: 'Whether the record button is enabled',
+    },
+    unit: {
+      control: 'select',
+      options: ['lbs', 'kg'],
+      description: 'Weight unit',
+    },
+    visible: {
+      control: 'boolean',
+      description: 'Whether the input bar is visible',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 400, backgroundColor: '#111111' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof InputBar>
+
+export const Default: Story = {
+  args: {
+    exerciseName: 'Bench Press',
+    setNumber: 2,
+    totalSets: 5,
+    reps: '',
+    weight: '',
+    unit: 'lbs',
+    onRepsChange: () => {},
+    onWeightChange: () => {},
+    onRecord: () => {},
+    canRecord: true,
+    visible: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    canRecord: false,
+  },
+}
+
+export const Kilograms: Story = {
+  args: {
+    ...Default.args,
+    unit: 'kg',
+    weight: '60',
+    reps: '8',
+  },
+}
+
+export const WithFilledValues: Story = {
+  args: {
+    ...Default.args,
+    reps: '5',
+    weight: '225',
+  },
+}

--- a/packages/ui/src/components/custom/Workout/InputBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/InputBar.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { InputBar, type InputBarProps } from './InputBar'
+
+const defaultProps: InputBarProps = {
+  exerciseName: 'Bench Press',
+  setNumber: 2,
+  totalSets: 5,
+  reps: '5',
+  weight: '135',
+  unit: 'lbs',
+  onRepsChange: vi.fn(),
+  onWeightChange: vi.fn(),
+  onRecord: vi.fn(),
+  canRecord: true,
+  visible: true,
+}
+
+function renderInputBar(overrides: Partial<InputBarProps> = {}) {
+  return render(<InputBar {...defaultProps} {...overrides} />)
+}
+
+describe('InputBar', () => {
+  it('renders with all props', () => {
+    renderInputBar()
+    expect(screen.getByTestId('input-bar')).toBeInTheDocument()
+  })
+
+  it('displays exercise name', () => {
+    renderInputBar({ exerciseName: 'Squat' })
+    expect(screen.getByTestId('input-bar-exercise-name')).toHaveTextContent('Squat')
+  })
+
+  it('displays set info with total', () => {
+    renderInputBar({ setNumber: 3, totalSets: 4 })
+    expect(screen.getByTestId('input-bar-set-info')).toHaveTextContent('Set 3/4')
+  })
+
+  it('displays set info without total', () => {
+    renderInputBar({ setNumber: 1, totalSets: null })
+    expect(screen.getByTestId('input-bar-set-info')).toHaveTextContent('Set 1')
+  })
+
+  it('fires onRepsChange when reps input changes', () => {
+    const onRepsChange = vi.fn()
+    renderInputBar({ onRepsChange })
+    const input = screen.getByTestId('input-bar-reps')
+    fireEvent.change(input, { target: { value: '8' } })
+    expect(onRepsChange).toHaveBeenCalled()
+  })
+
+  it('fires onWeightChange when weight input changes', () => {
+    const onWeightChange = vi.fn()
+    renderInputBar({ onWeightChange })
+    const input = screen.getByTestId('input-bar-weight')
+    fireEvent.change(input, { target: { value: '225' } })
+    expect(onWeightChange).toHaveBeenCalled()
+  })
+
+  it('fires onRecord when record button is clicked', () => {
+    const onRecord = vi.fn()
+    renderInputBar({ onRecord })
+    fireEvent.click(screen.getByTestId('input-bar-record'))
+    expect(onRecord).toHaveBeenCalledOnce()
+  })
+
+  it('applies reduced opacity when canRecord is false', () => {
+    renderInputBar({ canRecord: false })
+    const button = screen.getByTestId('input-bar-record')
+    expect(button).toHaveStyle({ opacity: '0.4' })
+  })
+
+  it('returns null when visible is false', () => {
+    renderInputBar({ visible: false })
+    expect(screen.queryByTestId('input-bar')).not.toBeInTheDocument()
+  })
+
+  it('shows correct unit label', () => {
+    renderInputBar({ unit: 'kg' })
+    expect(screen.getByTestId('input-bar-unit')).toHaveTextContent('kg')
+  })
+
+  it('shows lbs unit label', () => {
+    renderInputBar({ unit: 'lbs' })
+    expect(screen.getByTestId('input-bar-unit')).toHaveTextContent('lbs')
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = renderInputBar()
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has toolbar role on container', () => {
+      renderInputBar()
+      expect(screen.getByRole('toolbar')).toBeInTheDocument()
+    })
+
+    it('has correct accessibility label on record button', () => {
+      renderInputBar()
+      expect(screen.getByLabelText('Record set')).toBeInTheDocument()
+    })
+
+    it('has correct accessibility label on reps input', () => {
+      renderInputBar()
+      expect(screen.getByLabelText('Reps')).toBeInTheDocument()
+    })
+
+    it('has correct accessibility label on weight input', () => {
+      renderInputBar({ unit: 'kg' })
+      expect(screen.getByLabelText('Weight in kg')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/InputBar.tsx
+++ b/packages/ui/src/components/custom/Workout/InputBar.tsx
@@ -1,0 +1,163 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, Text, Pressable, TextInput } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+export interface InputBarProps {
+  exerciseName: string
+  setNumber: number
+  totalSets: number | null
+  reps: string
+  weight: string
+  unit: 'lbs' | 'kg'
+  onRepsChange: (value: string) => void
+  onWeightChange: (value: string) => void
+  onRecord: () => void
+  canRecord: boolean
+  visible: boolean
+}
+
+const BRAND_PRIMARY = '#FF7900'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_TERTIARY = '#6B7280'
+
+const inputStyle = {
+  fontSize: 14,
+  fontWeight: '600' as const,
+  fontFamily: 'Inter, sans-serif',
+  backgroundColor: WORKOUT_TOKENS.surface.raised,
+  borderWidth: 1,
+  borderColor: WORKOUT_TOKENS.border.strong,
+  borderRadius: 6,
+  textAlign: 'center' as const,
+  color: TEXT_PRIMARY,
+  paddingVertical: 5,
+  paddingHorizontal: 2,
+}
+
+export function InputBar({
+  exerciseName,
+  setNumber,
+  totalSets,
+  reps,
+  weight,
+  unit,
+  onRepsChange,
+  onWeightChange,
+  onRecord,
+  canRecord,
+  visible,
+}: InputBarProps) {
+  if (!visible) return null
+
+  const setLabel = totalSets != null ? `Set ${setNumber}/${totalSets}` : `Set ${setNumber}`
+
+  return (
+    <View
+      style={{
+        width: '100%',
+        backgroundColor: WORKOUT_TOKENS.surface.elevated,
+        borderTopWidth: 1,
+        borderTopColor: WORKOUT_TOKENS.border.default,
+        paddingTop: 10,
+        paddingHorizontal: 16,
+        paddingBottom: 12,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+      }}
+      accessibilityRole="toolbar"
+      testID="input-bar"
+    >
+      <View style={{ minWidth: 80, flexDirection: 'column' }}>
+        <Text
+          style={{
+            fontSize: 12,
+            fontWeight: '700',
+            fontFamily: '"Space Grotesk", sans-serif',
+            color: TEXT_PRIMARY,
+          }}
+          testID="input-bar-exercise-name"
+          numberOfLines={1}
+        >
+          {exerciseName}
+        </Text>
+        <Text
+          style={{
+            fontSize: 10,
+            fontFamily: 'Inter, sans-serif',
+            color: TEXT_TERTIARY,
+          }}
+          testID="input-bar-set-info"
+        >
+          {setLabel}
+        </Text>
+      </View>
+
+      <View className="flex-1 flex-row items-center" style={{ gap: 4 }}>
+        <TextInput
+          value={reps}
+          onChangeText={onRepsChange}
+          style={{ ...inputStyle, width: 36 }}
+          accessibilityLabel="Reps"
+          testID="input-bar-reps"
+          keyboardType="numeric"
+        />
+        <Text
+          style={{
+            fontSize: 12,
+            fontFamily: 'Inter, sans-serif',
+            color: TEXT_TERTIARY,
+          }}
+        >
+          {'\u00D7'}
+        </Text>
+        <TextInput
+          value={weight}
+          onChangeText={onWeightChange}
+          style={{ ...inputStyle, width: 52 }}
+          accessibilityLabel={`Weight in ${unit}`}
+          testID="input-bar-weight"
+          keyboardType="numeric"
+        />
+        <Text
+          style={{
+            fontSize: 12,
+            fontWeight: '500',
+            fontFamily: 'Inter, sans-serif',
+            color: TEXT_TERTIARY,
+          }}
+          testID="input-bar-unit"
+        >
+          {unit}
+        </Text>
+      </View>
+
+      <Pressable
+        onPress={onRecord}
+        disabled={!canRecord}
+        style={({ pressed }) => ({
+          backgroundColor: BRAND_PRIMARY,
+          borderRadius: 8,
+          paddingVertical: 10,
+          paddingHorizontal: 16,
+          opacity: !canRecord ? 0.4 : pressed ? 0.8 : 1,
+        })}
+        accessibilityRole="button"
+        accessibilityLabel="Record set"
+        testID="input-bar-record"
+      >
+        <Text
+          style={{
+            fontSize: 13,
+            fontWeight: '700',
+            fontFamily: 'Inter, sans-serif',
+            color: '#FFFFFF',
+          }}
+        >
+          Record
+        </Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/IntensityBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.stories.tsx
@@ -8,56 +8,53 @@ const meta: Meta<typeof IntensityBar> = {
   tags: ['autodocs'],
   argTypes: {
     level: {
-      control: { type: 'range', min: 0, max: 140, step: 5 },
-      description: 'Intensity percentage (0-140)',
+      control: { type: 'range', min: 0, max: 1, step: 0.05 },
+      description: 'Intensity level (0-1)',
     },
-    target: {
-      control: { type: 'range', min: 0, max: 100, step: 5 },
-      description: 'Target percentage (blue line)',
+    threshold: {
+      control: { type: 'range', min: 0, max: 1, step: 0.05 },
+      description: 'MRV/overexertion threshold position (0-1)',
     },
-    height: { control: 'number', description: 'Bar height in pixels' },
-    showLabel: { control: 'boolean', description: 'Show percentage label below bar' },
+    orientation: {
+      control: { type: 'radio' },
+      options: ['vertical', 'horizontal'],
+      description: 'Bar orientation',
+    },
+    size: { control: 'number', description: 'Length along the fill axis (px)' },
+    thickness: { control: 'number', description: 'Bar thickness (px)' },
+    showThresholdLabel: { control: 'boolean', description: 'Show MRV label' },
   },
 }
 
 export default meta
 type Story = StoryObj<typeof IntensityBar>
 
-export const Building: Story = {
-  args: { level: 50, target: 85, showLabel: true },
+export const Low: Story = {
+  args: { level: 0.3, threshold: 0.85, showThresholdLabel: true },
 }
 
-export const Approaching: Story = {
-  args: { level: 85, target: 85, showLabel: true },
+export const Moderate: Story = {
+  args: { level: 0.55, threshold: 0.85, showThresholdLabel: true },
 }
 
-export const AtTarget: Story = {
-  args: { level: 96, target: 95, showLabel: true },
+export const High: Story = {
+  args: { level: 0.85, threshold: 0.85, showThresholdLabel: true },
 }
 
-export const Over110: Story = {
-  args: { level: 110, target: 85, showLabel: true },
+export const Horizontal: Story = {
+  args: { level: 0.6, threshold: 0.85, orientation: 'horizontal', size: 120 },
 }
 
-export const Over120: Story = {
-  args: { level: 120, target: 85, showLabel: true },
-}
-
-export const Over130: Story = {
-  args: { level: 130, target: 85, showLabel: true },
-}
-
-export const AllLevels: Story = {
+export const AllZones: Story = {
   render: () => (
     <View style={{ flexDirection: 'row', gap: 16, alignItems: 'flex-end', padding: 16 }}>
-      <IntensityBar level={30} target={85} showLabel />
-      <IntensityBar level={60} target={85} showLabel />
-      <IntensityBar level={80} target={85} showLabel />
-      <IntensityBar level={90} target={85} showLabel />
-      <IntensityBar level={97} target={95} showLabel />
-      <IntensityBar level={110} target={85} showLabel />
-      <IntensityBar level={120} target={85} showLabel />
-      <IntensityBar level={130} target={85} showLabel />
+      <IntensityBar level={0.2} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={0.35} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={0.5} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={0.65} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={0.75} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={0.9} threshold={0.85} showThresholdLabel />
+      <IntensityBar level={1.0} threshold={0.85} showThresholdLabel />
     </View>
   ),
 }

--- a/packages/ui/src/components/custom/Workout/IntensityBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { IntensityBar } from './IntensityBar'
+
+const meta: Meta<typeof IntensityBar> = {
+  title: 'Custom/Workout/IntensityBar',
+  component: IntensityBar,
+  tags: ['autodocs'],
+  argTypes: {
+    level: {
+      control: { type: 'range', min: 0, max: 140, step: 5 },
+      description: 'Intensity percentage (0-140)',
+    },
+    target: {
+      control: { type: 'range', min: 0, max: 100, step: 5 },
+      description: 'Target percentage (blue line)',
+    },
+    height: { control: 'number', description: 'Bar height in pixels' },
+    showLabel: { control: 'boolean', description: 'Show percentage label below bar' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof IntensityBar>
+
+export const Building: Story = {
+  args: { level: 50, target: 85, showLabel: true },
+}
+
+export const Approaching: Story = {
+  args: { level: 85, target: 85, showLabel: true },
+}
+
+export const AtTarget: Story = {
+  args: { level: 96, target: 95, showLabel: true },
+}
+
+export const Over110: Story = {
+  args: { level: 110, target: 85, showLabel: true },
+}
+
+export const Over120: Story = {
+  args: { level: 120, target: 85, showLabel: true },
+}
+
+export const Over130: Story = {
+  args: { level: 130, target: 85, showLabel: true },
+}
+
+export const AllLevels: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 16, alignItems: 'flex-end', padding: 16 }}>
+      <IntensityBar level={30} target={85} showLabel />
+      <IntensityBar level={60} target={85} showLabel />
+      <IntensityBar level={80} target={85} showLabel />
+      <IntensityBar level={90} target={85} showLabel />
+      <IntensityBar level={97} target={95} showLabel />
+      <IntensityBar level={110} target={85} showLabel />
+      <IntensityBar level={120} target={85} showLabel />
+      <IntensityBar level={130} target={85} showLabel />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
@@ -5,85 +5,107 @@ import { IntensityBar } from './IntensityBar'
 
 describe('IntensityBar', () => {
   it('renders the bar', () => {
-    render(<IntensityBar level={50} />)
+    render(<IntensityBar level={0.5} />)
     expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
   })
 
   it('renders fill element', () => {
-    render(<IntensityBar level={50} />)
+    render(<IntensityBar level={0.5} />)
     expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
   })
 
-  it('renders target line when target is provided', () => {
-    render(<IntensityBar level={50} target={85} />)
-    expect(screen.getByTestId('intensity-target')).toBeInTheDocument()
+  it('renders threshold line when threshold is provided', () => {
+    render(<IntensityBar level={0.5} threshold={0.85} />)
+    expect(screen.getByTestId('intensity-threshold')).toBeInTheDocument()
   })
 
-  it('does not render target line when target is omitted', () => {
-    render(<IntensityBar level={50} />)
-    expect(screen.queryByTestId('intensity-target')).not.toBeInTheDocument()
+  it('does not render threshold line when threshold is omitted', () => {
+    render(<IntensityBar level={0.5} />)
+    expect(screen.queryByTestId('intensity-threshold')).not.toBeInTheDocument()
   })
 
-  it('shows percentage label when showLabel is true', () => {
-    render(<IntensityBar level={60} showLabel />)
-    expect(screen.getByText('60%')).toBeInTheDocument()
+  it('shows MRV label when showThresholdLabel is true and threshold set', () => {
+    render(<IntensityBar level={0.6} threshold={0.85} showThresholdLabel />)
+    expect(screen.getByText('MRV')).toBeInTheDocument()
   })
 
-  it('hides percentage label when showLabel is false', () => {
-    render(<IntensityBar level={60} />)
-    expect(screen.queryByTestId('intensity-label')).not.toBeInTheDocument()
+  it('hides MRV label when showThresholdLabel is false', () => {
+    render(<IntensityBar level={0.6} threshold={0.85} />)
+    expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
   })
 
-  it('shows correct label for over 100%', () => {
-    render(<IntensityBar level={120} showLabel />)
-    expect(screen.getByText('120%')).toBeInTheDocument()
-  })
-
-  it('renders bulge for level over 100', () => {
-    render(<IntensityBar level={115} />)
-    expect(screen.getByTestId('intensity-bulge')).toBeInTheDocument()
-  })
-
-  it('does not render bulge for level at or below 100', () => {
-    render(<IntensityBar level={95} />)
-    expect(screen.queryByTestId('intensity-bulge')).not.toBeInTheDocument()
+  it('hides MRV label when threshold is omitted even if showThresholdLabel is true', () => {
+    render(<IntensityBar level={0.6} showThresholdLabel />)
+    expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
   })
 
   it('has correct accessibility role', () => {
-    render(<IntensityBar level={50} />)
+    render(<IntensityBar level={0.5} />)
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
-  it('has correct accessibility label', () => {
-    render(<IntensityBar level={75} />)
+  it('maps level 0-1 to percentage in accessibility label', () => {
+    render(<IntensityBar level={0.75} />)
     expect(screen.getByLabelText('Intensity level: 75%')).toBeInTheDocument()
   })
 
-  it('accepts custom height', () => {
-    render(<IntensityBar level={50} height={32} />)
+  it('clamps level above 1 to 100%', () => {
+    render(<IntensityBar level={1.5} />)
+    expect(screen.getByLabelText('Intensity level: 100%')).toBeInTheDocument()
+  })
+
+  it('clamps level below 0 to 0%', () => {
+    render(<IntensityBar level={-0.5} />)
+    expect(screen.getByLabelText('Intensity level: 0%')).toBeInTheDocument()
+  })
+
+  it('renders horizontal orientation', () => {
+    render(<IntensityBar level={0.5} orientation="horizontal" />)
+    expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+  })
+
+  it('accepts custom size and thickness', () => {
+    render(<IntensityBar level={0.5} size={32} thickness={8} />)
     expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
   })
 
   describe('fill zones', () => {
-    it('renders building fill for low levels', () => {
-      render(<IntensityBar level={50} />)
-      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    it('renders teal fill for low levels (0-0.4)', () => {
+      render(<IntensityBar level={0.3} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#14B8A6' })
     })
 
-    it('renders approaching fill for 75-95%', () => {
-      render(<IntensityBar level={85} />)
-      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    it('renders amber fill for moderate levels (0.4-0.7)', () => {
+      render(<IntensityBar level={0.5} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FFB020' })
     })
 
-    it('renders target fill for 95-100%', () => {
-      render(<IntensityBar level={97} />)
-      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    it('renders red fill for high levels (0.7-1.0)', () => {
+      render(<IntensityBar level={0.85} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#D14343' })
+    })
+
+    it('uses teal at the lower zone boundary', () => {
+      render(<IntensityBar level={0.39} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#14B8A6' })
+    })
+
+    it('uses amber at the 0.4 boundary', () => {
+      render(<IntensityBar level={0.4} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FFB020' })
+    })
+
+    it('uses red at the 0.7 boundary', () => {
+      render(<IntensityBar level={0.7} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#D14343' })
     })
   })
 
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
-      const { container } = render(<IntensityBar level={50} target={85} showLabel />)
+      const { container } = render(
+        <IntensityBar level={0.5} threshold={0.85} showThresholdLabel />,
+      )
       const results = await axe(container)
       expect(results).toHaveNoViolations()
     })

--- a/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { IntensityBar } from './IntensityBar'
+
+describe('IntensityBar', () => {
+  it('renders the bar', () => {
+    render(<IntensityBar level={50} />)
+    expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
+  })
+
+  it('renders fill element', () => {
+    render(<IntensityBar level={50} />)
+    expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+  })
+
+  it('renders target line when target is provided', () => {
+    render(<IntensityBar level={50} target={85} />)
+    expect(screen.getByTestId('intensity-target')).toBeInTheDocument()
+  })
+
+  it('does not render target line when target is omitted', () => {
+    render(<IntensityBar level={50} />)
+    expect(screen.queryByTestId('intensity-target')).not.toBeInTheDocument()
+  })
+
+  it('shows percentage label when showLabel is true', () => {
+    render(<IntensityBar level={60} showLabel />)
+    expect(screen.getByText('60%')).toBeInTheDocument()
+  })
+
+  it('hides percentage label when showLabel is false', () => {
+    render(<IntensityBar level={60} />)
+    expect(screen.queryByTestId('intensity-label')).not.toBeInTheDocument()
+  })
+
+  it('shows correct label for over 100%', () => {
+    render(<IntensityBar level={120} showLabel />)
+    expect(screen.getByText('120%')).toBeInTheDocument()
+  })
+
+  it('renders bulge for level over 100', () => {
+    render(<IntensityBar level={115} />)
+    expect(screen.getByTestId('intensity-bulge')).toBeInTheDocument()
+  })
+
+  it('does not render bulge for level at or below 100', () => {
+    render(<IntensityBar level={95} />)
+    expect(screen.queryByTestId('intensity-bulge')).not.toBeInTheDocument()
+  })
+
+  it('has correct accessibility role', () => {
+    render(<IntensityBar level={50} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('has correct accessibility label', () => {
+    render(<IntensityBar level={75} />)
+    expect(screen.getByLabelText('Intensity level: 75%')).toBeInTheDocument()
+  })
+
+  it('accepts custom height', () => {
+    render(<IntensityBar level={50} height={32} />)
+    expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
+  })
+
+  describe('fill zones', () => {
+    it('renders building fill for low levels', () => {
+      render(<IntensityBar level={50} />)
+      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    })
+
+    it('renders approaching fill for 75-95%', () => {
+      render(<IntensityBar level={85} />)
+      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    })
+
+    it('renders target fill for 95-100%', () => {
+      render(<IntensityBar level={97} />)
+      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<IntensityBar level={50} target={85} showLabel />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/IntensityBar.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.tsx
@@ -1,188 +1,164 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useEffect, useRef } from 'react'
-import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
+import { useEffect, useState } from 'react'
+import { View, Text, Animated, type ViewProps, type ViewStyle } from 'react-native'
+
+export type IntensityBarOrientation = 'vertical' | 'horizontal'
 
 export interface IntensityBarProps extends ViewProps {
-  /** Intensity as percentage (0-100+). Values over 100 trigger overflow bulge. */
+  /** Current intensity level 0-1 */
   level: number
-  /** Target percentage (0-100). Blue target line position. */
-  target?: number
-  height?: number
-  showLabel?: boolean
+  /** MRV/overexertion threshold position 0-1 */
+  threshold?: number
+  /** Orientation */
+  orientation?: IntensityBarOrientation
+  /** Height for vertical (default 24px) or width for horizontal */
+  size?: number
+  /** Width for vertical (default 6px) or height for horizontal */
+  thickness?: number
+  /** Show threshold label ("MRV") */
+  showThresholdLabel?: boolean
   className?: string
 }
 
-function getFillStyle(level: number): Record<string, unknown> {
-  if (level > 100) {
-    if (level >= 130) return { backgroundColor: '#7A1C1C' }
-    if (level >= 120) return { backgroundColor: '#A62626' }
-    return { backgroundColor: '#D14343' }
-  }
-  if (level >= 95) {
-    return {
-      backgroundImage: 'linear-gradient(to top, #FFB020 0%, #FF7900 50%, #D14343 100%)',
-    }
-  }
-  if (level >= 75) return { backgroundColor: '#FFB020' }
-  return { backgroundColor: '#14B8A6' }
+const TRACK_BG = 'rgba(255,255,255,0.06)'
+const THRESHOLD_COLOR = '#FFFFFF'
+const LABEL_COLOR = '#6B7280'
+
+/** Fill color by intensity zone: teal 0-0.4, amber 0.4-0.7, red 0.7-1.0. */
+function getZoneColor(level: number): string {
+  if (level >= 0.7) return '#D14343'
+  if (level >= 0.4) return '#FFB020'
+  return '#14B8A6'
 }
 
-function getBulgeSize(level: number): number {
-  if (level >= 130) return 11
-  if (level >= 120) return 10
-  if (level >= 110) return 8
-  return 0
-}
-
-function getBulgeColor(level: number): string {
-  if (level >= 130) return '#7A1C1C'
-  if (level >= 120) return '#A62626'
-  return '#D14343'
-}
-
-function isNearTarget(level: number, target: number | undefined): boolean {
-  if (target == null) return false
-  return Math.abs(level - target) <= 2
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
 }
 
 export function IntensityBar({
   level,
-  target,
-  height = 36,
-  showLabel,
+  threshold,
+  orientation = 'vertical',
+  size = 24,
+  thickness = 6,
+  showThresholdLabel,
   className,
   ...props
 }: IntensityBarProps) {
-  const fillPct = Math.min(level, 100)
-  const fillHeight = (fillPct / 100) * height
-  const isOver = level > 100
-  const bulgeSize = isOver ? getBulgeSize(level) : 0
-  const percentage = Math.round(level)
-  const nearTarget = isNearTarget(level, target)
+  const isVertical = orientation === 'vertical'
+  const clampedLevel = clamp01(level)
+  const percentage = Math.round(clampedLevel * 100)
+  const zoneColor = getZoneColor(clampedLevel)
 
-  const bulgeGlowAnim = useRef(new Animated.Value(0)).current
+  const [fillAnim] = useState(() => new Animated.Value(clampedLevel))
 
   useEffect(() => {
-    if (level < 120) {
-      bulgeGlowAnim.setValue(0)
-      return
-    }
-
-    const duration = level >= 130 ? 1500 : 2000
-    const animation = Animated.loop(
-      Animated.sequence([
-        Animated.timing(bulgeGlowAnim, {
-          toValue: 1,
-          duration: duration / 2,
-          easing: Easing.inOut(Easing.ease),
-          useNativeDriver: false,
-        }),
-        Animated.timing(bulgeGlowAnim, {
-          toValue: 0,
-          duration: duration / 2,
-          easing: Easing.inOut(Easing.ease),
-          useNativeDriver: false,
-        }),
-      ]),
-    )
+    const animation = Animated.timing(fillAnim, {
+      toValue: clampedLevel,
+      duration: 250,
+      useNativeDriver: false,
+    })
     animation.start()
     return () => animation.stop()
-  }, [level, bulgeGlowAnim])
+  }, [clampedLevel, fillAnim])
 
-  const fillStyle = getFillStyle(level)
-  const atTargetGlow = nearTarget
-    ? { boxShadow: '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(33, 150, 243, 0.15)' }
-    : undefined
+  const fillSizePercent = fillAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0%', '100%'],
+  })
+
+  const trackStyle = isVertical
+    ? { width: thickness, height: size }
+    : { width: size, height: thickness }
+
+  const fillStyle = isVertical
+    ? {
+        position: 'absolute' as const,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: fillSizePercent,
+      }
+    : {
+        position: 'absolute' as const,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        width: fillSizePercent,
+      }
+
+  const thresholdLineStyle: ViewStyle | undefined =
+    threshold != null
+      ? isVertical
+        ? {
+            position: 'absolute' as const,
+            bottom: `${clamp01(threshold) * 100}%`,
+            left: -2,
+            right: -2,
+            height: 1,
+            backgroundColor: THRESHOLD_COLOR,
+            zIndex: 4,
+          }
+        : {
+            position: 'absolute' as const,
+            left: `${clamp01(threshold) * 100}%`,
+            top: -2,
+            bottom: -2,
+            width: 1,
+            backgroundColor: THRESHOLD_COLOR,
+            zIndex: 4,
+          }
+      : undefined
 
   return (
     <View
       className={className}
       style={{ alignItems: 'center' }}
       accessibilityRole="progressbar"
-      accessibilityValue={{ min: 0, max: 100, now: Math.min(percentage, 100) }}
+      accessibilityValue={{ min: 0, max: 100, now: percentage }}
       accessibilityLabel={`Intensity level: ${percentage}%`}
       testID="intensity-bar"
       {...props}
     >
       <View
-        style={{ width: 6, height, borderRadius: 3, backgroundColor: '#333333', position: 'relative', overflow: 'visible' }}
+        style={{
+          ...trackStyle,
+          borderRadius: 3,
+          backgroundColor: TRACK_BG,
+          position: 'relative',
+          overflow: 'visible',
+        }}
         accessibilityElementsHidden
       >
-        {/* Bulge circle behind fill */}
-        {isOver && bulgeSize > 0 && (
-          <Animated.View
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 3 - bulgeSize / 2,
-              width: bulgeSize,
-              height: bulgeSize,
-              borderRadius: bulgeSize / 2,
-              backgroundColor: getBulgeColor(level),
-              zIndex: 1,
-              ...(level >= 120
-                ? {
-                    boxShadow: bulgeGlowAnim.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [
-                        '0 0 0 0 rgba(209, 67, 67, 0)',
-                        '0 0 3px 1px rgba(209, 67, 67, 0.25)',
-                      ],
-                    }),
-                  }
-                : {}),
-            }}
-            testID="intensity-bulge"
-          />
-        )}
-
-        {/* Fill bar */}
-        <View
-          style={[
-            {
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              borderRadius: 3,
-              height: isOver ? height : fillHeight,
-              zIndex: 2,
-              transition: 'height 0.3s ease',
-            },
-            fillStyle as Record<string, unknown>,
-            atTargetGlow as Record<string, unknown>,
-          ]}
+        <Animated.View
+          style={{
+            ...fillStyle,
+            borderRadius: 3,
+            backgroundColor: zoneColor,
+            zIndex: 2,
+          }}
           testID="intensity-fill"
         />
 
-        {/* Target line */}
-        {target != null && (
-          <View
-            style={{
-              position: 'absolute',
-              bottom: (target / 100) * height - 0.75,
-              left: -3,
-              right: -3,
-              height: 1.5,
-              backgroundColor: 'rgba(33, 150, 243, 0.5)',
-              zIndex: 4,
-            }}
-            testID="intensity-target"
-          />
+        {threshold != null && (
+          <View style={thresholdLineStyle} testID="intensity-threshold" />
         )}
       </View>
-      {showLabel && (
+      {showThresholdLabel && threshold != null && (
         <Text
           style={{
             fontSize: 8,
-            color: '#6B7280',
-            fontFamily: '"Nunito Sans", sans-serif',
+            fontWeight: '500',
+            color: LABEL_COLOR,
+            fontFamily: 'Inter, sans-serif',
             marginTop: 6,
           }}
           accessibilityElementsHidden
-          testID="intensity-label"
+          testID="intensity-threshold-label"
         >
-          {percentage}%
+          MRV
         </Text>
       )}
     </View>

--- a/packages/ui/src/components/custom/Workout/IntensityBar.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.tsx
@@ -1,0 +1,190 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useEffect, useRef } from 'react'
+import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
+
+export interface IntensityBarProps extends ViewProps {
+  /** Intensity as percentage (0-100+). Values over 100 trigger overflow bulge. */
+  level: number
+  /** Target percentage (0-100). Blue target line position. */
+  target?: number
+  height?: number
+  showLabel?: boolean
+  className?: string
+}
+
+function getFillStyle(level: number): Record<string, unknown> {
+  if (level > 100) {
+    if (level >= 130) return { backgroundColor: '#7A1C1C' }
+    if (level >= 120) return { backgroundColor: '#A62626' }
+    return { backgroundColor: '#D14343' }
+  }
+  if (level >= 95) {
+    return {
+      backgroundImage: 'linear-gradient(to top, #FFB020 0%, #FF7900 50%, #D14343 100%)',
+    }
+  }
+  if (level >= 75) return { backgroundColor: '#FFB020' }
+  return { backgroundColor: '#14B8A6' }
+}
+
+function getBulgeSize(level: number): number {
+  if (level >= 130) return 11
+  if (level >= 120) return 10
+  if (level >= 110) return 8
+  return 0
+}
+
+function getBulgeColor(level: number): string {
+  if (level >= 130) return '#7A1C1C'
+  if (level >= 120) return '#A62626'
+  return '#D14343'
+}
+
+function isNearTarget(level: number, target: number | undefined): boolean {
+  if (target == null) return false
+  return Math.abs(level - target) <= 2
+}
+
+export function IntensityBar({
+  level,
+  target,
+  height = 36,
+  showLabel,
+  className,
+  ...props
+}: IntensityBarProps) {
+  const fillPct = Math.min(level, 100)
+  const fillHeight = (fillPct / 100) * height
+  const isOver = level > 100
+  const bulgeSize = isOver ? getBulgeSize(level) : 0
+  const percentage = Math.round(level)
+  const nearTarget = isNearTarget(level, target)
+
+  const bulgeGlowAnim = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    if (level < 120) {
+      bulgeGlowAnim.setValue(0)
+      return
+    }
+
+    const duration = level >= 130 ? 1500 : 2000
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bulgeGlowAnim, {
+          toValue: 1,
+          duration: duration / 2,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: false,
+        }),
+        Animated.timing(bulgeGlowAnim, {
+          toValue: 0,
+          duration: duration / 2,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: false,
+        }),
+      ]),
+    )
+    animation.start()
+    return () => animation.stop()
+  }, [level, bulgeGlowAnim])
+
+  const fillStyle = getFillStyle(level)
+  const atTargetGlow = nearTarget
+    ? { boxShadow: '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(33, 150, 243, 0.15)' }
+    : undefined
+
+  return (
+    <View
+      className={className}
+      style={{ alignItems: 'center' }}
+      accessibilityRole="progressbar"
+      accessibilityValue={{ min: 0, max: 100, now: Math.min(percentage, 100) }}
+      accessibilityLabel={`Intensity level: ${percentage}%`}
+      testID="intensity-bar"
+      {...props}
+    >
+      <View
+        style={{ width: 6, height, borderRadius: 3, backgroundColor: '#333333', position: 'relative', overflow: 'visible' }}
+        accessibilityElementsHidden
+      >
+        {/* Bulge circle behind fill */}
+        {isOver && bulgeSize > 0 && (
+          <Animated.View
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 3 - bulgeSize / 2,
+              width: bulgeSize,
+              height: bulgeSize,
+              borderRadius: bulgeSize / 2,
+              backgroundColor: getBulgeColor(level),
+              zIndex: 1,
+              ...(level >= 120
+                ? {
+                    boxShadow: bulgeGlowAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [
+                        '0 0 0 0 rgba(209, 67, 67, 0)',
+                        '0 0 3px 1px rgba(209, 67, 67, 0.25)',
+                      ],
+                    }),
+                  }
+                : {}),
+            }}
+            testID="intensity-bulge"
+          />
+        )}
+
+        {/* Fill bar */}
+        <View
+          style={[
+            {
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              borderRadius: 3,
+              height: isOver ? height : fillHeight,
+              zIndex: 2,
+              transition: 'height 0.3s ease',
+            },
+            fillStyle as Record<string, unknown>,
+            atTargetGlow as Record<string, unknown>,
+          ]}
+          testID="intensity-fill"
+        />
+
+        {/* Target line */}
+        {target != null && (
+          <View
+            style={{
+              position: 'absolute',
+              bottom: (target / 100) * height - 0.75,
+              left: -3,
+              right: -3,
+              height: 1.5,
+              backgroundColor: 'rgba(33, 150, 243, 0.5)',
+              zIndex: 4,
+            }}
+            testID="intensity-target"
+          />
+        )}
+      </View>
+      {showLabel && (
+        <Text
+          style={{
+            fontSize: 8,
+            color: '#6B7280',
+            fontFamily: '"Nunito Sans", sans-serif',
+            marginTop: 6,
+          }}
+          accessibilityElementsHidden
+          testID="intensity-label"
+        >
+          {percentage}%
+        </Text>
+      )}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { MuscleGroupChip, type VolumeStatus } from './MuscleGroupChip'
+
+const meta: Meta<typeof MuscleGroupChip> = {
+  title: 'Custom/Workout/MuscleGroupChip',
+  component: MuscleGroupChip,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'Muscle group name',
+    },
+    volumeStatus: {
+      control: 'select',
+      options: [undefined, 'untrained', 'behind', 'ontrack', 'target', 'over'],
+      description: 'Volume status determines dot color',
+    },
+    onPress: {
+      action: 'pressed',
+      description: 'Callback when chip is tapped',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof MuscleGroupChip>
+
+export const Default: Story = {
+  args: {
+    name: 'Chest',
+    volumeStatus: 'ontrack',
+  },
+}
+
+export const Untrained: Story = {
+  args: {
+    name: 'Rear Delts',
+    volumeStatus: 'untrained',
+  },
+}
+
+export const Behind: Story = {
+  args: {
+    name: 'Quads',
+    volumeStatus: 'behind',
+  },
+}
+
+export const OnTrack: Story = {
+  args: {
+    name: 'Back',
+    volumeStatus: 'ontrack',
+  },
+}
+
+export const Target: Story = {
+  args: {
+    name: 'Biceps',
+    volumeStatus: 'target',
+  },
+}
+
+export const Over: Story = {
+  args: {
+    name: 'Front Delts',
+    volumeStatus: 'over',
+  },
+}
+
+export const WithoutStatus: Story = {
+  args: {
+    name: 'Hamstrings',
+  },
+}
+
+export const Tappable: Story = {
+  args: {
+    name: 'Glutes',
+    volumeStatus: 'ontrack',
+    onPress: () => {},
+  },
+}
+
+const allStatuses: VolumeStatus[] = [
+  'untrained',
+  'behind',
+  'ontrack',
+  'target',
+  'over',
+]
+
+export const AllStatuses: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 8, flexWrap: 'wrap' }}>
+      {allStatuses.map((status) => (
+        <MuscleGroupChip
+          key={status}
+          name={status.charAt(0).toUpperCase() + status.slice(1)}
+          volumeStatus={status}
+        />
+      ))}
+      <MuscleGroupChip name="No Status" />
+    </View>
+  ),
+}
+
+export const MuscleGroups: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 8, flexWrap: 'wrap' }}>
+      <MuscleGroupChip name="Chest" volumeStatus="ontrack" />
+      <MuscleGroupChip name="Triceps" volumeStatus="target" />
+      <MuscleGroupChip name="Front Delts" volumeStatus="over" />
+      <MuscleGroupChip name="Side Delts" volumeStatus="behind" />
+      <MuscleGroupChip name="Abs" volumeStatus="untrained" />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { MuscleGroupChip } from './MuscleGroupChip'
+
+describe('MuscleGroupChip', () => {
+  it('renders muscle group name', () => {
+    render(<MuscleGroupChip name="Chest" />)
+    expect(screen.getByText('Chest')).toBeInTheDocument()
+  })
+
+  it('renders the colored dot', () => {
+    render(<MuscleGroupChip name="Quads" volumeStatus="ontrack" />)
+    expect(screen.getByTestId('muscle-group-chip-dot')).toBeInTheDocument()
+  })
+
+  it('sets accessibility label with name and status', () => {
+    render(<MuscleGroupChip name="Back" volumeStatus="behind" />)
+    expect(
+      screen.getByLabelText('Back, volume status: behind'),
+    ).toBeInTheDocument()
+  })
+
+  it('sets accessibility label with no status when omitted', () => {
+    render(<MuscleGroupChip name="Biceps" />)
+    expect(
+      screen.getByLabelText('Biceps, volume status: no status'),
+    ).toBeInTheDocument()
+  })
+
+  it('wraps in Pressable when onPress is provided', () => {
+    const onPress = vi.fn()
+    render(<MuscleGroupChip name="Chest" onPress={onPress} />)
+    const pressable = screen.getByTestId('muscle-group-chip-pressable')
+    fireEvent.click(pressable)
+    expect(onPress).toHaveBeenCalledOnce()
+  })
+
+  it('does not render Pressable when onPress is omitted', () => {
+    render(<MuscleGroupChip name="Chest" />)
+    expect(
+      screen.queryByTestId('muscle-group-chip-pressable'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders all volume status variants without error', () => {
+    const statuses = [
+      'untrained',
+      'behind',
+      'ontrack',
+      'target',
+      'over',
+    ] as const
+    const { rerender } = render(
+      <MuscleGroupChip name="Test" volumeStatus="untrained" />,
+    )
+    for (const status of statuses) {
+      rerender(<MuscleGroupChip name="Test" volumeStatus={status} />)
+      expect(screen.getByText('Test')).toBeInTheDocument()
+    }
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <MuscleGroupChip
+          name="Chest"
+          volumeStatus="ontrack"
+          onPress={() => {}}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations as static chip', async () => {
+      const { container } = render(
+        <MuscleGroupChip name="Quads" volumeStatus="behind" />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('pressable has correct accessibility label', () => {
+      render(
+        <MuscleGroupChip name="Back" volumeStatus="target" onPress={() => {}} />,
+      )
+      expect(screen.getByLabelText('Back, volume status: target')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
@@ -1,0 +1,93 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, Text, Pressable, type ViewProps } from 'react-native'
+
+// Aliases for spec compatibility: under=behind, maintenance=ontrack, productive=target
+export type VolumeStatus = 'untrained' | 'behind' | 'ontrack' | 'target' | 'over'
+
+export interface MuscleGroupChipProps extends ViewProps {
+  name: string
+  volumeStatus?: VolumeStatus
+  onPress?: () => void
+  className?: string
+}
+
+const dotColorMap: Record<VolumeStatus, string> = {
+  untrained: '#2C2C2C',
+  behind: '#406D87',
+  ontrack: '#14B8A6',
+  target: '#FF7900',
+  over: '#D14343',
+}
+
+export function MuscleGroupChip({
+  name,
+  volumeStatus,
+  onPress,
+  className,
+  ...props
+}: MuscleGroupChipProps) {
+  const dotColor = volumeStatus
+    ? dotColorMap[volumeStatus]
+    : '#2C2C2C'
+
+  const statusLabel = volumeStatus ?? 'no status'
+
+  const content = (
+    <View
+      className={className}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderRadius: 9999,
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+        backgroundColor: '#1C1C1C',
+        borderWidth: 1,
+        borderColor: '#1F1F1F',
+      }}
+      accessibilityLabel={onPress ? undefined : `${name}, volume status: ${statusLabel}`}
+      testID="muscle-group-chip"
+      {...props}
+    >
+      <View
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 9999,
+          marginRight: 6,
+          flexShrink: 0,
+          backgroundColor: dotColor,
+        }}
+        accessibilityElementsHidden
+        testID="muscle-group-chip-dot"
+      />
+      <Text
+        style={{
+          fontFamily: '"Nunito Sans", sans-serif',
+          fontWeight: '500',
+          fontSize: 10,
+          color: '#9CA3AF',
+        }}
+        accessibilityElementsHidden
+      >
+        {name}
+      </Text>
+    </View>
+  )
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`${name}, volume status: ${statusLabel}`}
+        testID="muscle-group-chip-pressable"
+      >
+        {content}
+      </Pressable>
+    )
+  }
+
+  return content
+}

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
@@ -1,5 +1,4 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 
 // Aliases for spec compatibility: under=behind, maintenance=ontrack, productive=target
@@ -40,11 +39,11 @@ export function MuscleGroupChip({
         flexDirection: 'row',
         alignItems: 'center',
         borderRadius: 9999,
-        paddingHorizontal: 8,
-        paddingVertical: 2,
-        backgroundColor: '#1C1C1C',
+        paddingHorizontal: 9,
+        paddingVertical: 3,
+        backgroundColor: 'var(--color-surface-raised)',
         borderWidth: 1,
-        borderColor: '#1F1F1F',
+        borderColor: 'var(--color-border-default)',
       }}
       accessibilityLabel={onPress ? undefined : `${name}, volume status: ${statusLabel}`}
       testID="muscle-group-chip"
@@ -55,7 +54,7 @@ export function MuscleGroupChip({
           width: 6,
           height: 6,
           borderRadius: 9999,
-          marginRight: 6,
+          marginRight: 5,
           flexShrink: 0,
           backgroundColor: dotColor,
         }}
@@ -64,10 +63,10 @@ export function MuscleGroupChip({
       />
       <Text
         style={{
-          fontFamily: '"Nunito Sans", sans-serif',
+          fontFamily: 'Inter, sans-serif',
           fontWeight: '500',
-          fontSize: 10,
-          color: '#9CA3AF',
+          fontSize: 11,
+          color: 'var(--color-text-secondary)',
         }}
         accessibilityElementsHidden
       >

--- a/packages/ui/src/components/custom/Workout/PlaceholderStrip.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/PlaceholderStrip.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { PlaceholderStrip } from './PlaceholderStrip'
+
+const meta: Meta<typeof PlaceholderStrip> = {
+  title: 'Custom/Workout/PlaceholderStrip',
+  component: PlaceholderStrip,
+  tags: ['autodocs'],
+  argTypes: {
+    width: {
+      control: 'text',
+      description: 'Fixed width or flex:1 (default)',
+    },
+    mode: {
+      control: 'select',
+      options: ['single', 'segmented'],
+      description: 'Render as single dashed strip or segmented mini-strip',
+    },
+    segments: {
+      control: 'number',
+      description: 'Number of segments in segmented mode',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof PlaceholderStrip>
+
+export const Default: Story = {
+  args: {},
+  decorators: [
+    (Story) => (
+      <View style={{ width: 300 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export const FixedWidth: Story = {
+  args: {
+    width: 200,
+  },
+}
+
+export const Segmented: Story = {
+  args: {
+    mode: 'segmented',
+    segments: 5,
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 300 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export const SegmentedThree: Story = {
+  args: {
+    mode: 'segmented',
+    segments: 3,
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 200 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export const MultipleStrips: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 4, width: 300 }}>
+      <View style={{ flex: 1, height: 3, backgroundColor: '#2ed573', borderRadius: 1 }} />
+      <View style={{ flex: 1, height: 3, backgroundColor: '#ffd43b', borderRadius: 1 }} />
+      <View style={{ flex: 1, height: 3, backgroundColor: '#ffa502', borderRadius: 1 }} />
+      <PlaceholderStrip />
+      <PlaceholderStrip />
+    </View>
+  ),
+}
+
+export const MixedModes: Story = {
+  render: () => (
+    <View style={{ gap: 12, width: 300 }}>
+      <PlaceholderStrip mode="single" />
+      <PlaceholderStrip mode="segmented" segments={5} />
+      <PlaceholderStrip mode="segmented" segments={8} />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/PlaceholderStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/PlaceholderStrip.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { PlaceholderStrip } from './PlaceholderStrip'
+
+describe('PlaceholderStrip', () => {
+  it('renders a strip element', () => {
+    render(<PlaceholderStrip />)
+    expect(screen.getByTestId('placeholder-strip')).toBeInTheDocument()
+  })
+
+  it('sets accessibility label', () => {
+    render(<PlaceholderStrip />)
+    expect(
+      screen.getByLabelText('Planned set, not yet completed'),
+    ).toBeInTheDocument()
+  })
+
+  it('applies fixed width when provided', () => {
+    render(<PlaceholderStrip width={200} />)
+    const strip = screen.getByTestId('placeholder-strip')
+    expect(strip).toBeInTheDocument()
+  })
+
+  it('renders multiple strips', () => {
+    render(
+      <>
+        <PlaceholderStrip />
+        <PlaceholderStrip />
+        <PlaceholderStrip />
+      </>,
+    )
+    const strips = screen.getAllByTestId('placeholder-strip')
+    expect(strips).toHaveLength(3)
+  })
+
+  it('defaults to single mode', () => {
+    render(<PlaceholderStrip />)
+    expect(screen.queryAllByTestId('placeholder-segment')).toHaveLength(0)
+  })
+
+  describe('segmented mode', () => {
+    it('renders segments when mode is segmented', () => {
+      render(<PlaceholderStrip mode="segmented" segments={5} />)
+      const segments = screen.getAllByTestId('placeholder-segment')
+      expect(segments).toHaveLength(5)
+    })
+
+    it('defaults to 3 segments when segments prop is omitted', () => {
+      render(<PlaceholderStrip mode="segmented" />)
+      const segments = screen.getAllByTestId('placeholder-segment')
+      expect(segments).toHaveLength(3)
+    })
+
+    it('still has the strip container testID', () => {
+      render(<PlaceholderStrip mode="segmented" segments={4} />)
+      expect(screen.getByTestId('placeholder-strip')).toBeInTheDocument()
+    })
+
+    it('sets accessibility label in segmented mode', () => {
+      render(<PlaceholderStrip mode="segmented" segments={3} />)
+      expect(
+        screen.getByLabelText('Planned set, not yet completed'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations in single mode', async () => {
+      const { container } = render(<PlaceholderStrip />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations in segmented mode', async () => {
+      const { container } = render(
+        <PlaceholderStrip mode="segmented" segments={4} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
@@ -1,7 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React from 'react'
 import { View, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 
 export interface PlaceholderStripProps extends ViewProps {
   width?: number | string
@@ -21,7 +21,15 @@ function SingleStrip({
     <View
       className={cn(className)}
       style={[
-        { height: 3, backgroundColor: '#3A3A3A', borderRadius: 2, opacity: 0.5 },
+        {
+          height: 3,
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          borderStyle: 'dashed',
+          borderColor: WORKOUT_TOKENS.border.strong,
+          borderRadius: 1,
+          opacity: 0.5,
+        },
         width != null ? { width: width as number } : { flex: 1 },
       ]}
       accessibilityRole="image"
@@ -56,7 +64,10 @@ function SegmentedStrip({
           style={{
             flex: 1,
             height: 3,
-            backgroundColor: '#3A3A3A',
+            backgroundColor: 'transparent',
+            borderWidth: 1,
+            borderStyle: 'dashed',
+            borderColor: WORKOUT_TOKENS.border.strong,
             borderRadius: 1,
             minWidth: 4,
           }}

--- a/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
@@ -1,0 +1,80 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, type ViewProps } from 'react-native'
+import { cn } from '../../../utils/cn'
+
+export interface PlaceholderStripProps extends ViewProps {
+  width?: number | string
+  /** Render as single solid strip or segmented mini-strip */
+  mode?: 'single' | 'segmented'
+  /** Number of segments when mode is 'segmented' */
+  segments?: number
+  className?: string
+}
+
+function SingleStrip({
+  width,
+  className,
+  ...props
+}: Omit<PlaceholderStripProps, 'mode' | 'segments'>) {
+  return (
+    <View
+      className={cn(className)}
+      style={[
+        { height: 3, backgroundColor: '#3A3A3A', borderRadius: 2, opacity: 0.5 },
+        width != null ? { width: width as number } : { flex: 1 },
+      ]}
+      accessibilityRole="image"
+      accessibilityLabel="Planned set, not yet completed"
+      testID="placeholder-strip"
+      {...props}
+    />
+  )
+}
+
+function SegmentedStrip({
+  segments = 3,
+  width,
+  className,
+  ...props
+}: Omit<PlaceholderStripProps, 'mode'>) {
+  return (
+    <View
+      className={cn('flex-row', className)}
+      style={[
+        { height: 3, gap: 2, opacity: 0.5 },
+        width != null ? { width: width as number } : { flex: 1 },
+      ]}
+      accessibilityRole="image"
+      accessibilityLabel="Planned set, not yet completed"
+      testID="placeholder-strip"
+      {...props}
+    >
+      {Array.from({ length: segments }, (_, i) => (
+        <View
+          key={i}
+          style={{
+            flex: 1,
+            height: 3,
+            backgroundColor: '#3A3A3A',
+            borderRadius: 1,
+            minWidth: 4,
+          }}
+          accessibilityElementsHidden
+          testID="placeholder-segment"
+        />
+      ))}
+    </View>
+  )
+}
+
+export function PlaceholderStrip({
+  mode = 'single',
+  segments,
+  ...props
+}: PlaceholderStripProps) {
+  if (mode === 'segmented') {
+    return <SegmentedStrip segments={segments} {...props} />
+  }
+  return <SingleStrip {...props} />
+}

--- a/packages/ui/src/components/custom/Workout/PrBadge.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { PrBadge } from './PrBadge'
+
+const meta: Meta<typeof PrBadge> = {
+  title: 'Custom/Workout/PrBadge',
+  component: PrBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['e1rm', 'weight', 'reps', 'volume', 'velocity'],
+      description: 'PR type determines auto-generated label',
+    },
+    label: {
+      control: 'text',
+      description: 'Custom label (overrides auto-generated)',
+    },
+    compact: {
+      control: 'boolean',
+      description: 'Show only star icon, no text',
+    },
+    animate: {
+      control: 'boolean',
+      description: 'Trigger pop animation on mount',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof PrBadge>
+
+export const Animated: Story = {
+  args: {
+    animate: true,
+    type: 'e1rm',
+  },
+}
+
+export const Static: Story = {
+  args: {
+    animate: false,
+    type: 'e1rm',
+  },
+}
+
+export const WeightPr: Story = {
+  args: {
+    type: 'weight',
+    animate: false,
+  },
+}
+
+export const RepsPr: Story = {
+  args: {
+    type: 'reps',
+    animate: false,
+  },
+}
+
+export const VelocityPr: Story = {
+  args: {
+    type: 'velocity',
+    animate: false,
+  },
+}
+
+export const CustomLabel: Story = {
+  args: {
+    label: 'PR 5RM',
+    animate: false,
+  },
+}
+
+export const Compact: Story = {
+  args: {
+    compact: true,
+    animate: false,
+  },
+}
+
+export const CompactAnimated: Story = {
+  args: {
+    compact: true,
+    animate: true,
+  },
+}
+
+export const AllTypes: Story = {
+  render: () => (
+    <View style={{ gap: 8 }}>
+      <View style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+        <PrBadge type="e1rm" animate={false} />
+        <PrBadge type="weight" animate={false} />
+        <PrBadge type="reps" animate={false} />
+        <PrBadge type="volume" animate={false} />
+        <PrBadge type="velocity" animate={false} />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+        <PrBadge compact animate={false} />
+        <PrBadge label="PR 5RM" animate={false} />
+      </View>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/PrBadge.test.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { PrBadge } from './PrBadge'
+
+describe('PrBadge', () => {
+  it('renders star and default PR label', () => {
+    render(<PrBadge animate={false} />)
+    expect(screen.getByText(/\u2605 PR e1RM/)).toBeInTheDocument()
+  })
+
+  it('renders with animation wrapper when animate is true', () => {
+    render(<PrBadge animate />)
+    expect(screen.getByTestId('pr-badge-animated')).toBeInTheDocument()
+  })
+
+  it('renders without animation wrapper when animate is false', () => {
+    render(<PrBadge animate={false} />)
+    expect(screen.queryByTestId('pr-badge-animated')).not.toBeInTheDocument()
+  })
+
+  it('defaults to animated', () => {
+    render(<PrBadge />)
+    expect(screen.getByTestId('pr-badge-animated')).toBeInTheDocument()
+  })
+
+  it('sets accessibility label with resolved label', () => {
+    render(<PrBadge animate={false} />)
+    expect(
+      screen.getByLabelText('Personal record: PR e1RM'),
+    ).toBeInTheDocument()
+  })
+
+  describe('type prop', () => {
+    it('generates label from e1rm type', () => {
+      render(<PrBadge type="e1rm" animate={false} />)
+      expect(screen.getByText(/PR e1RM/)).toBeInTheDocument()
+    })
+
+    it('generates label from weight type', () => {
+      render(<PrBadge type="weight" animate={false} />)
+      expect(screen.getByText(/PR Weight/)).toBeInTheDocument()
+    })
+
+    it('generates label from reps type', () => {
+      render(<PrBadge type="reps" animate={false} />)
+      expect(screen.getByText(/PR Reps/)).toBeInTheDocument()
+    })
+
+    it('generates label from volume type', () => {
+      render(<PrBadge type="volume" animate={false} />)
+      expect(screen.getByText(/PR Volume/)).toBeInTheDocument()
+    })
+
+    it('generates label from velocity type', () => {
+      render(<PrBadge type="velocity" animate={false} />)
+      expect(screen.getByText(/PR Velocity/)).toBeInTheDocument()
+    })
+  })
+
+  describe('custom label', () => {
+    it('uses custom label over auto-generated', () => {
+      render(<PrBadge label="PR 5RM" animate={false} />)
+      expect(screen.getByText(/PR 5RM/)).toBeInTheDocument()
+    })
+
+    it('sets accessibility label with custom label', () => {
+      render(<PrBadge label="PR 5RM" animate={false} />)
+      expect(
+        screen.getByLabelText('Personal record: PR 5RM'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('compact mode', () => {
+    it('renders only star icon when compact', () => {
+      render(<PrBadge compact animate={false} />)
+      const star = screen.getByTestId('pr-badge-star')
+      expect(star).toHaveTextContent('\u2605')
+    })
+
+    it('does not show label text in compact mode', () => {
+      render(<PrBadge compact animate={false} />)
+      expect(screen.queryByText(/PR e1RM/)).not.toBeInTheDocument()
+    })
+
+    it('has correct accessibility label in compact mode', () => {
+      render(<PrBadge compact animate={false} />)
+      expect(
+        screen.getByLabelText('Personal record: PR e1RM'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<PrBadge animate={false} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations in compact mode', async () => {
+      const { container } = render(<PrBadge compact animate={false} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/PrBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.tsx
@@ -1,0 +1,113 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useEffect, useRef } from 'react'
+import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
+
+export type PRType = 'e1rm' | 'weight' | 'reps' | 'volume' | 'velocity'
+
+export interface PrBadgeProps extends ViewProps {
+  /** PR type determines auto-generated label */
+  type?: PRType
+  /** Display label (e.g., "PR e1RM", "PR 5RM"). Auto-generated from type if omitted. */
+  label?: string
+  /** Show only the star icon, no text label */
+  compact?: boolean
+  /** Trigger pop animation on mount */
+  animate?: boolean
+  className?: string
+}
+
+const typeLabels: Record<PRType, string> = {
+  e1rm: 'PR e1RM',
+  weight: 'PR Weight',
+  reps: 'PR Reps',
+  volume: 'PR Volume',
+  velocity: 'PR Velocity',
+}
+
+export function PrBadge({
+  type = 'e1rm',
+  label: labelProp,
+  compact = false,
+  animate = true,
+  className,
+  ...props
+}: PrBadgeProps) {
+  const resolvedLabel = labelProp ?? typeLabels[type]
+  const scale = useRef(new Animated.Value(animate ? 0.8 : 1)).current
+  const opacity = useRef(new Animated.Value(animate ? 0 : 1)).current
+
+  useEffect(() => {
+    if (!animate) return
+
+    // HTML demo uses a 3-keyframe sequence; bezier approximation is close enough for native
+    Animated.parallel([
+      Animated.timing(scale, {
+        toValue: 1,
+        duration: 400,
+        easing: Easing.bezier(0.34, 1.56, 0.64, 1),
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 400,
+        easing: Easing.bezier(0.34, 1.56, 0.64, 1),
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }, [animate, scale, opacity])
+
+  const badge = compact ? (
+    <View
+      className={className}
+      accessibilityLabel={`Personal record: ${resolvedLabel}`}
+      {...props}
+    >
+      <Text
+        style={{ fontSize: 13, color: '#FF7900', lineHeight: 20 }}
+        testID="pr-badge-star"
+      >
+        {'\u2605'}
+      </Text>
+    </View>
+  ) : (
+    <View
+      className={className}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: 'rgba(255, 121, 0, 0.12)',
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+        borderRadius: 2,
+        borderWidth: 1,
+        borderColor: 'rgba(255, 121, 0, 0.3)',
+      }}
+      accessibilityLabel={`Personal record: ${resolvedLabel}`}
+      {...props}
+    >
+      <Text
+        style={{
+          fontSize: 12,
+          color: '#FF7900',
+          fontWeight: '700',
+          fontFamily: 'Inter, sans-serif',
+        }}
+      >
+        {'\u2605'} {resolvedLabel}
+      </Text>
+    </View>
+  )
+
+  if (animate) {
+    return (
+      <Animated.View
+        style={{ transform: [{ scale }], opacity }}
+        testID="pr-badge-animated"
+      >
+        {badge}
+      </Animated.View>
+    )
+  }
+
+  return badge
+}

--- a/packages/ui/src/components/custom/Workout/PrBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.tsx
@@ -1,5 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
 
 export type PRType = 'e1rm' | 'weight' | 'reps' | 'volume' | 'velocity'
@@ -33,8 +33,8 @@ export function PrBadge({
   ...props
 }: PrBadgeProps) {
   const resolvedLabel = labelProp ?? typeLabels[type]
-  const scale = useRef(new Animated.Value(animate ? 0.8 : 1)).current
-  const opacity = useRef(new Animated.Value(animate ? 0 : 1)).current
+  const [scale] = useState(() => new Animated.Value(animate ? 0.8 : 1))
+  const [opacity] = useState(() => new Animated.Value(animate ? 0 : 1))
 
   useEffect(() => {
     if (!animate) return
@@ -87,7 +87,7 @@ export function PrBadge({
     >
       <Text
         style={{
-          fontSize: 12,
+          fontSize: 10,
           color: '#FF7900',
           fontWeight: '700',
           fontFamily: 'Inter, sans-serif',

--- a/packages/ui/src/components/custom/Workout/RestTimer.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.tsx
@@ -1,6 +1,8 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React from 'react'
 import { View, Text, Pressable } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const BRAND_PRIMARY = '#FF7900'
 
 export interface RestTimerProps {
   totalSeconds: number
@@ -32,9 +34,9 @@ export function RestTimer({
     <View
       style={{
         width: '100%',
-        backgroundColor: '#1C1C1C',
+        backgroundColor: WORKOUT_TOKENS.surface.raised,
         borderTopWidth: 1,
-        borderTopColor: '#1F1F1F',
+        borderTopColor: WORKOUT_TOKENS.border.default,
         paddingVertical: 12,
         paddingHorizontal: 16,
       }}
@@ -101,7 +103,7 @@ export function RestTimer({
       <View
         style={{
           height: 3,
-          backgroundColor: '#1F1F1F',
+          backgroundColor: WORKOUT_TOKENS.border.default,
           borderRadius: 2,
           marginBottom: 12,
         }}
@@ -110,7 +112,7 @@ export function RestTimer({
         <View
           style={{
             height: '100%',
-            backgroundColor: '#FF7900',
+            backgroundColor: BRAND_PRIMARY,
             borderRadius: 2,
             width: `${progressPct}%`,
           }}
@@ -160,7 +162,7 @@ export function RestTimer({
               fontSize: 11,
               fontFamily: 'Inter, sans-serif',
               fontWeight: '600',
-              color: '#FF7900',
+              color: BRAND_PRIMARY,
             }}
           >
             Skip

--- a/packages/ui/src/components/custom/Workout/SetRow.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { SetRow } from './SetRow'
+
+const meta: Meta<typeof SetRow> = {
+  title: 'Custom/Workout/SetRow',
+  component: SetRow,
+  tags: ['autodocs'],
+  argTypes: {
+    mode: {
+      control: 'select',
+      options: ['active', 'completed', 'history'],
+      description: 'Row display mode',
+    },
+    unit: {
+      control: 'select',
+      options: ['lbs', 'kg'],
+      description: 'Weight unit',
+    },
+    isNextSet: {
+      control: 'boolean',
+      description: 'Whether this is the next set to perform',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof SetRow>
+
+export const CompletedWithVelocity: Story = {
+  args: {
+    mode: 'completed',
+    setNumber: 1,
+    reps: 8,
+    weight: 135,
+    unit: 'lbs',
+    rpe: 7.5,
+    previous: { reps: 8, weight: 130 },
+    velocities: [1.1, 0.95, 0.82, 0.68, 0.55, 0.48, 0.42, 0.38],
+  },
+}
+
+export const ActiveWithTargets: Story = {
+  args: {
+    mode: 'active',
+    setNumber: 3,
+    reps: null,
+    weight: null,
+    unit: 'lbs',
+    previous: { reps: 8, weight: 135 },
+    targets: { reps: 10, weight: 150 },
+  },
+}
+
+export const ActiveNextSet: Story = {
+  args: {
+    mode: 'active',
+    setNumber: 2,
+    reps: null,
+    weight: null,
+    unit: 'lbs',
+    isNextSet: true,
+    targets: { reps: 8, weight: 135 },
+    previous: { reps: 8, weight: 130 },
+  },
+}
+
+export const HistorySet: Story = {
+  args: {
+    mode: 'history',
+    setNumber: 1,
+    reps: 10,
+    weight: 185,
+    unit: 'lbs',
+    rpe: 8,
+    previous: { reps: 10, weight: 180 },
+  },
+}
+
+export const WithTypeBadge: Story = {
+  args: {
+    mode: 'completed',
+    setNumber: 1,
+    reps: 5,
+    weight: 95,
+    unit: 'lbs',
+    setType: 'W',
+    previous: null,
+  },
+}
+
+export const WithPrBadges: Story = {
+  args: {
+    mode: 'completed',
+    setNumber: 3,
+    reps: 8,
+    weight: 225,
+    unit: 'lbs',
+    rpe: 9.5,
+    previous: { reps: 8, weight: 215 },
+    prBadges: [
+      { type: 'e1rm', label: 'PR e1RM' },
+      { type: 'weight', label: 'PR Weight' },
+    ],
+  },
+}
+
+export const WithRPE: Story = {
+  args: {
+    mode: 'completed',
+    setNumber: 4,
+    reps: 5,
+    weight: 275,
+    unit: 'lbs',
+    rpe: 10,
+    previous: { reps: 5, weight: 265 },
+  },
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <View style={{ gap: 4, padding: 16, maxWidth: 400 }}>
+      <SetRow
+        mode="completed"
+        setNumber={1}
+        reps={8}
+        weight={135}
+        unit="lbs"
+        rpe={7}
+        previous={{ reps: 8, weight: 130 }}
+        velocities={[1.1, 0.95, 0.82, 0.68, 0.55, 0.48, 0.42, 0.38]}
+        prBadges={[{ type: 'e1rm', label: 'PR e1RM' }]}
+      />
+      <SetRow
+        mode="completed"
+        setNumber={2}
+        reps={8}
+        weight={135}
+        unit="lbs"
+        rpe={8.5}
+        previous={{ reps: 8, weight: 135 }}
+        velocities={[0.95, 0.88, 0.78, 0.65, 0.52, 0.45, 0.40, 0.35]}
+      />
+      <SetRow
+        mode="active"
+        setNumber={3}
+        reps={null}
+        weight={null}
+        unit="lbs"
+        isNextSet
+        targets={{ reps: 8, weight: 135 }}
+        previous={{ reps: 8, weight: 135 }}
+      />
+      <SetRow
+        mode="active"
+        setNumber={4}
+        reps={null}
+        weight={null}
+        unit="lbs"
+        targets={{ reps: 8, weight: 135 }}
+        previous={{ reps: 8, weight: 135 }}
+      />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/SetRow.test.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { SetRow } from './SetRow'
+
+const baseProps = {
+  mode: 'completed' as const,
+  setNumber: 1,
+  reps: 8,
+  weight: 135,
+  unit: 'lbs' as const,
+}
+
+describe('SetRow', () => {
+  describe('completed mode', () => {
+    it('renders set number, reps, weight', () => {
+      render(<SetRow {...baseProps} />)
+      expect(screen.getByTestId('set-row')).toBeInTheDocument()
+      expect(screen.getByTestId('set-row-set-number')).toHaveTextContent('1')
+      expect(screen.getByTestId('set-row-reps')).toHaveTextContent('8')
+      expect(screen.getByTestId('set-row-weight')).toHaveTextContent('135')
+    })
+
+    it('displays previous data when provided', () => {
+      render(<SetRow {...baseProps} previous={{ reps: 6, weight: 130 }} />)
+      expect(screen.getByTestId('set-row-previous')).toHaveTextContent(
+        '6 x 130',
+      )
+    })
+
+    it('displays dash when no previous data', () => {
+      render(<SetRow {...baseProps} />)
+      expect(screen.getByTestId('set-row-previous')).toHaveTextContent('\u2014')
+    })
+
+    it('applies reduced opacity for non-next completed sets', () => {
+      render(<SetRow {...baseProps} />)
+      const row = screen.getByTestId('set-row')
+      expect(row).toHaveStyle({ opacity: 0.55 })
+    })
+  })
+
+  describe('active mode', () => {
+    it('renders target values when reps/weight are null', () => {
+      render(
+        <SetRow
+          mode="active"
+          setNumber={2}
+          reps={null}
+          weight={null}
+          unit="lbs"
+          targets={{ reps: 10, weight: 150 }}
+        />,
+      )
+      expect(screen.getByTestId('set-row-target-reps')).toHaveTextContent('10')
+      expect(screen.getByTestId('set-row-target-weight')).toHaveTextContent(
+        '150',
+      )
+    })
+
+    it('renders dashes when no targets and values are null', () => {
+      render(
+        <SetRow mode="active" setNumber={2} reps={null} weight={null} unit="lbs" />,
+      )
+      expect(screen.getByTestId('set-row-reps')).toHaveTextContent('\u2014')
+      expect(screen.getByTestId('set-row-weight')).toHaveTextContent('\u2014')
+    })
+  })
+
+  describe('isNextSet highlighting', () => {
+    it('applies highlight styles for active isNextSet', () => {
+      render(
+        <SetRow
+          mode="active"
+          setNumber={1}
+          reps={null}
+          weight={null}
+          unit="lbs"
+          isNextSet
+        />,
+      )
+      const row = screen.getByTestId('set-row')
+      const style = row.getAttribute('style') ?? ''
+      expect(style).toContain('background-color')
+      expect(style).toContain('border')
+    })
+
+    it('does not apply highlight for non-next active sets', () => {
+      render(
+        <SetRow mode="active" setNumber={1} reps={null} weight={null} unit="lbs" />,
+      )
+      const row = screen.getByTestId('set-row')
+      expect(row).not.toHaveStyle({
+        backgroundColor: 'rgba(255,121,0,0.06)',
+      })
+    })
+  })
+
+  describe('history mode', () => {
+    it('renders like completed mode', () => {
+      render(
+        <SetRow mode="history" setNumber={3} reps={5} weight={200} unit="kg" />,
+      )
+      expect(screen.getByTestId('set-row-reps')).toHaveTextContent('5')
+      expect(screen.getByTestId('set-row-weight')).toHaveTextContent('200')
+    })
+  })
+
+  describe('velocity strip', () => {
+    it('renders velocity strip when velocities provided', () => {
+      render(
+        <SetRow {...baseProps} velocities={[1.1, 0.95, 0.82]} />,
+      )
+      expect(screen.getByTestId('set-row-velocity-strip')).toBeInTheDocument()
+    })
+
+    it('does not render velocity strip when no velocities', () => {
+      render(<SetRow {...baseProps} />)
+      expect(
+        screen.queryByTestId('set-row-velocity-strip'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('passes onVelocityToggle to velocity strip', () => {
+      const onToggle = vi.fn()
+      render(
+        <SetRow
+          {...baseProps}
+          velocities={[1.1, 0.95]}
+          onVelocityToggle={onToggle}
+        />,
+      )
+      const pressable = screen.getByTestId('velocity-strip-pressable')
+      fireEvent.click(pressable)
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('set type badge', () => {
+    it('renders set type badge instead of set number', () => {
+      render(<SetRow {...baseProps} setType="W" />)
+      expect(screen.getByTestId('set-row-type-badge')).toHaveTextContent('W')
+    })
+
+    it('does not render type badge when setType is not provided', () => {
+      render(<SetRow {...baseProps} />)
+      expect(
+        screen.queryByTestId('set-row-type-badge'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('PR badges', () => {
+    it('renders PR badges when provided', () => {
+      render(
+        <SetRow
+          {...baseProps}
+          prBadges={[{ type: 'e1rm', label: 'PR e1RM' }]}
+        />,
+      )
+      expect(screen.getByTestId('set-row-pr-badges')).toBeInTheDocument()
+    })
+
+    it('does not render PR badges container when no badges', () => {
+      render(<SetRow {...baseProps} />)
+      expect(
+        screen.queryByTestId('set-row-pr-badges'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('RPE', () => {
+    it('displays RPE value with color coding', () => {
+      render(<SetRow {...baseProps} rpe={9.5} />)
+      expect(screen.getByTestId('set-row-rpe')).toHaveTextContent('9.5')
+    })
+
+    it('displays dash when RPE is null', () => {
+      render(<SetRow {...baseProps} rpe={null} />)
+      expect(screen.getByTestId('set-row-rpe')).toHaveTextContent('\u2014')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has correct accessibility label', () => {
+      render(<SetRow {...baseProps} />)
+      expect(
+        screen.getByLabelText('Set 1: 8 reps at 135 lbs'),
+      ).toBeInTheDocument()
+    })
+
+    it('has correct accessibility label with null values', () => {
+      render(
+        <SetRow mode="active" setNumber={2} reps={null} weight={null} unit="kg" />,
+      )
+      expect(
+        screen.getByLabelText('Set 2: no reps'),
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(<SetRow {...baseProps} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with all features', async () => {
+      const { container } = render(
+        <SetRow
+          {...baseProps}
+          rpe={8}
+          velocities={[1.1, 0.95]}
+          setType="W"
+          prBadges={[{ type: 'e1rm', label: 'PR e1RM' }]}
+          previous={{ reps: 6, weight: 130 }}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -1,0 +1,253 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text } from 'react-native'
+import { VelocityStrip } from './VelocityStrip'
+import { PrBadge, type PRType } from './PrBadge'
+
+export type SetRowMode = 'active' | 'completed' | 'history'
+
+export interface SetRowProps {
+  mode: SetRowMode
+  setNumber: number
+  previous?: { reps: number; weight: number } | null
+  reps: number | null
+  weight: number | null
+  rpe?: number | null
+  unit: 'lbs' | 'kg'
+  velocities?: number[]
+  velocityExpanded?: boolean
+  onVelocityToggle?: () => void
+  setType?: string
+  prBadges?: Array<{ type: PRType; label: string }>
+  isNextSet?: boolean
+  targets?: { reps: number; weight: number }
+}
+
+function getRPEColor(rpe: number): string {
+  if (rpe >= 9.5) return '#ff4757'
+  if (rpe >= 8.5) return '#ffa502'
+  if (rpe >= 7) return '#ffd43b'
+  return '#2ed573'
+}
+
+function formatAccessibilityLabel(
+  setNumber: number,
+  reps: number | null,
+  weight: number | null,
+  unit: string,
+): string {
+  const repsText = reps != null ? `${reps} reps` : 'no reps'
+  const weightText = weight != null ? `at ${weight} ${unit}` : ''
+  return `Set ${setNumber}: ${repsText}${weightText ? ` ${weightText}` : ''}`
+}
+
+export function SetRow({
+  mode,
+  setNumber,
+  previous,
+  reps,
+  weight,
+  rpe,
+  unit,
+  velocities,
+  velocityExpanded,
+  onVelocityToggle,
+  setType,
+  prBadges,
+  isNextSet,
+  targets,
+}: SetRowProps) {
+  const isActive = mode === 'active'
+  const isCompleted = mode === 'completed'
+
+  const rowStyle: Record<string, unknown> = {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    padding: 7,
+    paddingHorizontal: 8,
+    gap: 8,
+    borderRadius: 8,
+  }
+
+  if (isActive && isNextSet) {
+    rowStyle.backgroundColor = 'rgba(255,121,0,0.06)'
+    rowStyle.borderWidth = 1
+    rowStyle.borderColor = 'rgba(255,121,0,0.15)'
+  }
+
+  if (isCompleted && !isNextSet) {
+    rowStyle.opacity = 0.55
+  }
+
+  return (
+    <View
+      style={rowStyle}
+      accessibilityLabel={formatAccessibilityLabel(
+        setNumber,
+        reps,
+        weight,
+        unit,
+      )}
+      testID="set-row"
+    >
+      <View
+        style={{ width: 36, alignItems: 'center', justifyContent: 'center' }}
+        testID="set-row-set-number"
+      >
+        {setType ? (
+          <Text
+            style={{
+              fontSize: 10,
+              fontWeight: '700',
+              fontFamily: 'Inter, sans-serif',
+              color: '#ffa502',
+              backgroundColor: 'rgba(255,165,2,0.12)',
+              paddingVertical: 1,
+              paddingHorizontal: 5,
+              borderRadius: 3,
+              overflow: 'hidden',
+            }}
+            testID="set-row-type-badge"
+          >
+            {setType}
+          </Text>
+        ) : (
+          <Text
+            style={{
+              fontSize: 13,
+              fontWeight: '600',
+              fontFamily: 'Inter, sans-serif',
+              color: '#9CA3AF',
+            }}
+          >
+            {setNumber}
+          </Text>
+        )}
+      </View>
+
+      <View
+        className="flex-1"
+        testID="set-row-previous"
+      >
+        <Text
+          style={{
+            fontSize: 12,
+            fontFamily: 'Inter, sans-serif',
+            color: '#9CA3AF',
+          }}
+        >
+          {previous
+            ? `${previous.reps} x ${previous.weight}`
+            : '\u2014'}
+        </Text>
+      </View>
+
+      <View
+        style={{ width: 44, alignItems: 'center', justifyContent: 'center' }}
+        testID="set-row-reps"
+      >
+        {isActive && reps == null && targets ? (
+          <Text
+            style={{
+              fontSize: 13,
+              fontStyle: 'italic',
+              fontFamily: 'Inter, sans-serif',
+              color: '#6B7280',
+            }}
+            testID="set-row-target-reps"
+          >
+            {targets.reps}
+          </Text>
+        ) : (
+          <Text
+            style={{
+              fontSize: 14,
+              fontWeight: '600',
+              fontFamily: 'Inter, sans-serif',
+              color: reps != null ? '#F3F4F6' : '#6B7280',
+            }}
+          >
+            {reps != null ? reps : '\u2014'}
+          </Text>
+        )}
+      </View>
+
+      <View
+        style={{ width: 56, alignItems: 'center', justifyContent: 'center' }}
+        testID="set-row-weight"
+      >
+        {isActive && weight == null && targets ? (
+          <Text
+            style={{
+              fontSize: 13,
+              fontStyle: 'italic',
+              fontFamily: 'Inter, sans-serif',
+              color: '#6B7280',
+            }}
+            testID="set-row-target-weight"
+          >
+            {targets.weight}
+          </Text>
+        ) : (
+          <Text
+            style={{
+              fontSize: 14,
+              fontWeight: '600',
+              fontFamily: 'Inter, sans-serif',
+              color: weight != null ? '#F3F4F6' : '#6B7280',
+            }}
+          >
+            {weight != null ? weight : '\u2014'}
+          </Text>
+        )}
+      </View>
+
+      <View
+        style={{ width: 36, alignItems: 'center', justifyContent: 'center' }}
+        testID="set-row-rpe"
+      >
+        <Text
+          style={{
+            fontSize: 13,
+            fontWeight: '600',
+            fontFamily: 'Inter, sans-serif',
+            color: rpe != null ? getRPEColor(rpe) : '#6B7280',
+          }}
+        >
+          {rpe != null ? rpe : '\u2014'}
+        </Text>
+      </View>
+
+      {prBadges && prBadges.length > 0 && (
+        <View
+          className="flex-row items-center"
+          style={{ gap: 4 }}
+          testID="set-row-pr-badges"
+        >
+          {prBadges.map((badge, i) => (
+            <PrBadge
+              key={i}
+              type={badge.type}
+              label={badge.label}
+              animate={false}
+              compact
+            />
+          ))}
+        </View>
+      )}
+
+      {velocities && velocities.length > 0 && (
+        <View
+          style={{ position: 'absolute', bottom: 0, left: 8, right: 8 }}
+          testID="set-row-velocity-strip"
+        >
+          <VelocityStrip
+            velocities={velocities}
+            expanded={velocityExpanded}
+            onToggle={onVelocityToggle}
+            variant={onVelocityToggle ? 'full' : 'mini'}
+          />
+        </View>
+      )}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/Sparkline.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/Sparkline.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { Sparkline } from './Sparkline'
+
+const meta: Meta<typeof Sparkline> = {
+  title: 'Custom/Workout/Sparkline',
+  component: Sparkline,
+  tags: ['autodocs'],
+  argTypes: {
+    width: {
+      control: 'number',
+      description: 'Chart width in pixels',
+    },
+    height: {
+      control: 'number',
+      description: 'Chart height in pixels',
+    },
+    color: {
+      control: 'color',
+      description: 'Line and dot color',
+    },
+    showDots: {
+      control: 'boolean',
+      description: 'Show dots at data points',
+    },
+    highlightLast: {
+      control: 'boolean',
+      description: 'Highlight the last data point with a larger dot',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Sparkline>
+
+const ascending = [10, 15, 22, 28, 35, 42, 50]
+const descending = [50, 45, 38, 30, 22, 15, 10]
+const uCurve = [40, 25, 15, 10, 12, 20, 35]
+const flat = [20, 21, 19, 20, 21, 20, 19]
+const volatile = [10, 35, 15, 45, 20, 40, 25]
+
+export const Default: Story = {
+  args: {
+    data: ascending,
+  },
+}
+
+export const Ascending: Story = {
+  args: {
+    data: ascending,
+    showDots: true,
+  },
+}
+
+export const Descending: Story = {
+  args: {
+    data: descending,
+    showDots: true,
+    color: '#ff4757',
+  },
+}
+
+export const UCurve: Story = {
+  args: {
+    data: uCurve,
+    showDots: true,
+    color: '#2ed573',
+  },
+}
+
+export const Flat: Story = {
+  args: {
+    data: flat,
+    showDots: true,
+    color: '#ffd43b',
+  },
+}
+
+export const WithReferenceLines: Story = {
+  args: {
+    data: ascending,
+    showDots: true,
+    referenceLines: [
+      { value: 30, color: '#ff4757', dashed: true },
+      { value: 45, color: '#2ed573', dashed: false },
+    ],
+  },
+}
+
+export const HighlightLast: Story = {
+  args: {
+    data: ascending,
+    highlightLast: true,
+  },
+}
+
+export const DotsAndHighlightLast: Story = {
+  args: {
+    data: volatile,
+    showDots: true,
+    highlightLast: true,
+    color: '#ffa502',
+  },
+}
+
+export const CustomSize: Story = {
+  args: {
+    data: ascending,
+    width: 120,
+    height: 50,
+    showDots: true,
+  },
+}
+
+export const AllShapes: Story = {
+  render: () => (
+    <View style={{ gap: 16, padding: 16 }}>
+      <Sparkline data={ascending} showDots highlightLast />
+      <Sparkline data={descending} showDots color="#ff4757" />
+      <Sparkline data={uCurve} showDots color="#2ed573" />
+      <Sparkline data={flat} showDots color="#ffd43b" />
+      <Sparkline data={volatile} showDots color="#ffa502" highlightLast />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/Sparkline.test.tsx
+++ b/packages/ui/src/components/custom/Workout/Sparkline.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { Sparkline } from './Sparkline'
+
+const sampleData = [10, 25, 15, 30, 20]
+
+describe('Sparkline', () => {
+  it('renders with data points', () => {
+    render(<Sparkline data={sampleData} />)
+    expect(screen.getByTestId('sparkline')).toBeInTheDocument()
+  })
+
+  it('renders empty state for no data', () => {
+    render(<Sparkline data={[]} />)
+    expect(screen.getByTestId('sparkline-empty')).toBeInTheDocument()
+  })
+
+  it('renders line segments between points', () => {
+    render(<Sparkline data={sampleData} />)
+    for (let i = 1; i < sampleData.length; i++) {
+      expect(
+        screen.getByTestId(`sparkline-segment-${i}`),
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('renders dots when showDots is true', () => {
+    render(<Sparkline data={sampleData} showDots />)
+    for (let i = 0; i < sampleData.length; i++) {
+      expect(screen.getByTestId(`sparkline-dot-${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('does not render dots when showDots is false', () => {
+    render(<Sparkline data={sampleData} />)
+    expect(screen.queryByTestId('sparkline-dot-0')).not.toBeInTheDocument()
+  })
+
+  it('highlights last dot when highlightLast is true', () => {
+    render(<Sparkline data={sampleData} highlightLast />)
+    const lastIndex = sampleData.length - 1
+    expect(
+      screen.getByTestId(`sparkline-dot-${lastIndex}`),
+    ).toBeInTheDocument()
+    // Other dots should not be present (showDots is false)
+    expect(screen.queryByTestId('sparkline-dot-0')).not.toBeInTheDocument()
+  })
+
+  it('renders both regular dots and highlighted last', () => {
+    render(<Sparkline data={sampleData} showDots highlightLast />)
+    for (let i = 0; i < sampleData.length; i++) {
+      expect(screen.getByTestId(`sparkline-dot-${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders reference lines', () => {
+    render(
+      <Sparkline
+        data={sampleData}
+        referenceLines={[
+          { value: 20, color: '#ff0000' },
+          { value: 25, color: '#00ff00', dashed: true },
+        ]}
+      />,
+    )
+    expect(screen.getByTestId('sparkline-reference-0')).toBeInTheDocument()
+    expect(screen.getByTestId('sparkline-reference-1')).toBeInTheDocument()
+  })
+
+  it('does not render reference lines when not provided', () => {
+    render(<Sparkline data={sampleData} />)
+    expect(
+      screen.queryByTestId('sparkline-reference-0'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('uses default dimensions', () => {
+    render(<Sparkline data={sampleData} />)
+    const sparkline = screen.getByTestId('sparkline')
+    expect(sparkline).toHaveStyle({ width: '80px', height: '30px' })
+  })
+
+  it('accepts custom dimensions', () => {
+    render(<Sparkline data={sampleData} width={120} height={50} />)
+    const sparkline = screen.getByTestId('sparkline')
+    expect(sparkline).toHaveStyle({ width: '120px', height: '50px' })
+  })
+
+  it('sets accessibility label', () => {
+    render(<Sparkline data={sampleData} />)
+    expect(
+      screen.getByLabelText('Sparkline chart with 5 data points'),
+    ).toBeInTheDocument()
+  })
+
+  it('sets empty accessibility label for no data', () => {
+    render(<Sparkline data={[]} />)
+    expect(
+      screen.getByLabelText('Sparkline chart, no data'),
+    ).toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <Sparkline data={sampleData} showDots highlightLast />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/Sparkline.tsx
+++ b/packages/ui/src/components/custom/Workout/Sparkline.tsx
@@ -1,0 +1,188 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, Text, type ViewProps } from 'react-native'
+import { cn } from '../../../utils/cn'
+
+const BRAND_PRIMARY = '#FF7900'
+
+export interface SparklineProps extends ViewProps {
+  data: number[]
+  width?: number
+  height?: number
+  color?: string
+  showDots?: boolean
+  referenceLines?: Array<{
+    value: number
+    color: string
+    dashed?: boolean
+    label?: string
+  }>
+  highlightLast?: boolean
+  className?: string
+}
+
+function normalizeData(
+  data: number[],
+  height: number,
+): number[] {
+  if (data.length === 0) return []
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+  return data.map((v) => height - ((v - min) / range) * height)
+}
+
+function normalizeValue(
+  value: number,
+  data: number[],
+  height: number,
+): number {
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+  return height - ((value - min) / range) * height
+}
+
+export function Sparkline({
+  data,
+  width = 80,
+  height = 30,
+  color,
+  showDots = false,
+  referenceLines,
+  highlightLast = false,
+  className,
+  ...props
+}: SparklineProps) {
+  if (data.length === 0) {
+    return (
+      <View
+        style={{ width, height }}
+        className={className}
+        testID="sparkline-empty"
+        accessibilityLabel="Sparkline chart, no data"
+        {...props}
+      />
+    )
+  }
+
+  const resolvedColor = color ?? BRAND_PRIMARY
+  const normalized = normalizeData(data, height)
+  const stepX = data.length > 1 ? width / (data.length - 1) : 0
+
+  const dotSize = 3
+  const highlightSize = 6
+
+  return (
+    <View
+      style={{ width, height, position: 'relative' }}
+      className={cn(className)}
+      accessibilityRole="image"
+      accessibilityLabel={`Sparkline chart with ${data.length} data points`}
+      testID="sparkline"
+      {...props}
+    >
+      {referenceLines?.map((line, i) => {
+        const y = normalizeValue(line.value, data, height)
+        return (
+          <View
+            key={`ref-${i}`}
+            style={[
+              {
+                position: 'absolute',
+                top: y,
+                left: 0,
+                right: 0,
+                opacity: 0.6,
+              },
+              line.dashed
+                ? {
+                    height: 0,
+                    borderStyle: 'dashed',
+                    borderTopWidth: 1,
+                    borderTopColor: line.color,
+                  }
+                : {
+                    height: 1,
+                    backgroundColor: line.color,
+                  },
+            ]}
+            accessibilityElementsHidden
+            testID={`sparkline-reference-${i}`}
+          >
+            {line.label && (
+              <Text
+                style={{
+                  position: 'absolute',
+                  right: 0,
+                  top: -10,
+                  fontSize: 7,
+                  color: line.color,
+                  opacity: 1,
+                }}
+                testID={`sparkline-reference-label-${i}`}
+              >
+                {line.label}
+              </Text>
+            )}
+          </View>
+        )
+      })}
+
+      {/* Line segments connecting data points */}
+      {normalized.map((y, i) => {
+        if (i === 0) return null
+        const prevY = normalized[i - 1]
+        const x1 = (i - 1) * stepX
+        const x2 = i * stepX
+        const dx = x2 - x1
+        const dy = y - prevY
+        const length = Math.sqrt(dx * dx + dy * dy)
+        const angle = Math.atan2(dy, dx) * (180 / Math.PI)
+        return (
+          <View
+            key={`line-${i}`}
+            style={{
+              position: 'absolute',
+              left: x1,
+              top: prevY,
+              width: length,
+              height: 1.5,
+              backgroundColor: resolvedColor,
+              transformOrigin: '0 0',
+              transform: [{ rotate: `${angle}deg` }],
+            }}
+            accessibilityElementsHidden
+            testID={`sparkline-segment-${i}`}
+          />
+        )
+      })}
+
+      {/* Data point dots */}
+      {(showDots || highlightLast) &&
+        normalized.map((y, i) => {
+          const isLast = i === data.length - 1
+          const shouldShow = showDots || (highlightLast && isLast)
+          if (!shouldShow) return null
+
+          const size = highlightLast && isLast ? highlightSize : dotSize
+          return (
+            <View
+              key={`dot-${i}`}
+              style={{
+                position: 'absolute',
+                left: i * stepX - size / 2,
+                top: y - size / 2,
+                width: size,
+                height: size,
+                borderRadius: size / 2,
+                backgroundColor: resolvedColor,
+              }}
+              accessibilityElementsHidden
+              testID={`sparkline-dot-${i}`}
+            />
+          )
+        })}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/StatusDot.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.stories.tsx
@@ -1,0 +1,150 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { StatusDot } from './StatusDot'
+
+const meta: Meta<typeof StatusDot> = {
+  title: 'Custom/Workout/StatusDot',
+  component: StatusDot,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['success', 'warning', 'error', 'neutral', 'on-track', 'deviation', 'future'],
+      description: 'Status variant',
+    },
+    icon: {
+      control: 'select',
+      options: [undefined, 'check', 'exclamation', 'dash'],
+      description: 'Icon character inside the dot',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Dot size',
+    },
+    glow: {
+      control: 'boolean',
+      description: 'Subtle glow effect in variant color',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label text next to dot',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StatusDot>
+
+export const Success: Story = {
+  args: {
+    variant: 'success',
+    size: 'md',
+    icon: 'check',
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    size: 'md',
+    icon: 'exclamation',
+  },
+}
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    size: 'md',
+    icon: 'dash',
+  },
+}
+
+export const Neutral: Story = {
+  args: {
+    variant: 'neutral',
+    size: 'sm',
+  },
+}
+
+export const OnTrack: Story = {
+  args: {
+    variant: 'on-track',
+    size: 'md',
+    icon: 'check',
+  },
+}
+
+export const Deviation: Story = {
+  args: {
+    variant: 'deviation',
+    size: 'md',
+    icon: 'exclamation',
+  },
+}
+
+export const Future: Story = {
+  args: {
+    variant: 'future',
+    size: 'md',
+  },
+}
+
+export const WithGlow: Story = {
+  args: {
+    variant: 'success',
+    size: 'md',
+    icon: 'check',
+    glow: true,
+  },
+}
+
+export const WithLabel: Story = {
+  args: {
+    variant: 'success',
+    size: 'md',
+    icon: 'check',
+    label: 'On track',
+  },
+}
+
+export const SmallWithLabel: Story = {
+  args: {
+    variant: 'warning',
+    size: 'sm',
+    label: 'Needs attention',
+  },
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <View style={{ gap: 12 }}>
+      <View style={{ flexDirection: 'row', gap: 16, alignItems: 'center' }}>
+        <StatusDot variant="success" size="sm" />
+        <StatusDot variant="warning" size="sm" />
+        <StatusDot variant="error" size="sm" />
+        <StatusDot variant="neutral" size="sm" />
+        <StatusDot variant="on-track" size="sm" />
+        <StatusDot variant="deviation" size="sm" />
+        <StatusDot variant="future" size="sm" />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 16, alignItems: 'center' }}>
+        <StatusDot variant="success" size="md" icon="check" />
+        <StatusDot variant="warning" size="md" icon="exclamation" />
+        <StatusDot variant="error" size="md" icon="dash" />
+        <StatusDot variant="neutral" size="md" />
+        <StatusDot variant="on-track" size="md" icon="check" />
+        <StatusDot variant="deviation" size="md" icon="exclamation" />
+        <StatusDot variant="future" size="md" />
+      </View>
+      <View style={{ gap: 8 }}>
+        <StatusDot variant="success" size="md" icon="check" label="On track" />
+        <StatusDot variant="on-track" size="md" icon="check" label="On track (ring)" glow />
+        <StatusDot variant="deviation" size="md" icon="exclamation" label="Deviation" glow />
+        <StatusDot variant="future" size="sm" label="Planned" />
+        <StatusDot variant="error" size="md" icon="dash" label="Failed" />
+        <StatusDot variant="neutral" size="sm" label="Planned" />
+      </View>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/StatusDot.test.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { StatusDot } from './StatusDot'
+
+describe('StatusDot', () => {
+  it('renders a dot', () => {
+    render(<StatusDot variant="success" />)
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+  })
+
+  it('shows icon at md size', () => {
+    render(<StatusDot variant="success" size="md" icon="check" />)
+    expect(screen.getByText('\u2713')).toBeInTheDocument()
+  })
+
+  it('does not show icon at sm size', () => {
+    render(<StatusDot variant="success" size="sm" icon="check" />)
+    expect(screen.queryByText('\u2713')).not.toBeInTheDocument()
+  })
+
+  it('renders exclamation icon', () => {
+    render(<StatusDot variant="warning" size="md" icon="exclamation" />)
+    expect(screen.getByText('!')).toBeInTheDocument()
+  })
+
+  it('renders dash icon', () => {
+    render(<StatusDot variant="error" size="md" icon="dash" />)
+    expect(screen.getByText('\u2014')).toBeInTheDocument()
+  })
+
+  it('renders label text when provided', () => {
+    render(<StatusDot variant="success" label="On track" />)
+    expect(screen.getByText('On track')).toBeInTheDocument()
+  })
+
+  it('does not render label when omitted', () => {
+    render(<StatusDot variant="success" />)
+    expect(screen.queryByText('On track')).not.toBeInTheDocument()
+  })
+
+  it('defaults to sm size', () => {
+    render(<StatusDot variant="neutral" />)
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+  })
+
+  it('sets accessibility label with variant', () => {
+    render(<StatusDot variant="warning" />)
+    expect(screen.getByLabelText('warning status')).toBeInTheDocument()
+  })
+
+  describe('solid variants', () => {
+    it('renders all solid variant types without error', () => {
+      const { rerender } = render(<StatusDot variant="success" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+
+      rerender(<StatusDot variant="warning" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+
+      rerender(<StatusDot variant="error" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+
+      rerender(<StatusDot variant="neutral" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+    })
+  })
+
+  describe('ring variants', () => {
+    it('renders on-track variant', () => {
+      render(<StatusDot variant="on-track" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+      expect(screen.getByLabelText('on-track status')).toBeInTheDocument()
+    })
+
+    it('renders deviation variant', () => {
+      render(<StatusDot variant="deviation" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+      expect(screen.getByLabelText('deviation status')).toBeInTheDocument()
+    })
+
+    it('renders future variant', () => {
+      render(<StatusDot variant="future" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+      expect(screen.getByLabelText('future status')).toBeInTheDocument()
+    })
+  })
+
+  describe('md size', () => {
+    it('renders at md size without error', () => {
+      render(<StatusDot variant="success" size="md" />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+    })
+  })
+
+  describe('glow', () => {
+    it('renders with glow prop without error', () => {
+      render(<StatusDot variant="success" glow />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+    })
+
+    it('renders glow on ring variants', () => {
+      render(<StatusDot variant="on-track" glow />)
+      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <StatusDot variant="success" size="md" icon="check" label="On track" />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations for ring variants', async () => {
+      const { container } = render(
+        <StatusDot variant="on-track" size="md" icon="check" label="On track" />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations without label', async () => {
+      const { container } = render(<StatusDot variant="warning" size="md" />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations for all solid variants', async () => {
+      for (const variant of ['success', 'warning', 'error', 'neutral'] as const) {
+        const { container, unmount } = render(<StatusDot variant={variant} />)
+        const results = await axe(container)
+        expect(results).toHaveNoViolations()
+        unmount()
+      }
+    })
+
+    it('sets combined accessibility label when label prop is provided', () => {
+      render(<StatusDot variant="success" label="On track" />)
+      expect(screen.getByLabelText('success status: On track')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/StatusDot.test.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.test.tsx
@@ -83,6 +83,13 @@ describe('StatusDot', () => {
       expect(screen.getByTestId('status-dot')).toBeInTheDocument()
       expect(screen.getByLabelText('future status')).toBeInTheDocument()
     })
+
+    it('renders the future variant with a 1px dashed border', () => {
+      render(<StatusDot variant="future" />)
+      const dot = screen.getByTestId('status-dot')
+      expect(dot.style.borderTopStyle).toBe('dashed')
+      expect(dot.style.borderTopWidth).toBe('1px')
+    })
   })
 
   describe('md size', () => {
@@ -93,14 +100,28 @@ describe('StatusDot', () => {
   })
 
   describe('glow', () => {
-    it('renders with glow prop without error', () => {
+    it('applies a box-shadow when glow is set on a solid variant', () => {
       render(<StatusDot variant="success" glow />)
-      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+      const dot = screen.getByTestId('status-dot')
+      expect(dot.style.boxShadow).toContain('rgba(20,184,166,0.4)')
     })
 
-    it('renders glow on ring variants', () => {
+    it('applies a box-shadow when glow is set on a ring variant', () => {
       render(<StatusDot variant="on-track" glow />)
-      expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+      const dot = screen.getByTestId('status-dot')
+      expect(dot.style.boxShadow).toContain('rgba(20,184,166,0.4)')
+    })
+
+    it('applies a gray box-shadow when glow is set on the future variant', () => {
+      render(<StatusDot variant="future" glow />)
+      const dot = screen.getByTestId('status-dot')
+      expect(dot.style.boxShadow).toContain('rgba(107,114,128,0.4)')
+    })
+
+    it('does not apply a box-shadow when glow is not set', () => {
+      render(<StatusDot variant="on-track" />)
+      const dot = screen.getByTestId('status-dot')
+      expect(dot.style.boxShadow).toBe('')
     })
   })
 

--- a/packages/ui/src/components/custom/Workout/StatusDot.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.tsx
@@ -1,5 +1,4 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React from 'react'
 import { View, Text, type ViewProps } from 'react-native'
 
 export type StatusDotVariant =
@@ -47,14 +46,14 @@ const ringVariantStyles: Record<string, Record<string, unknown>> = {
   },
 }
 
-const glowStyles: Record<StatusDotVariant, Record<string, unknown> | null> = {
+const glowStyles: Record<StatusDotVariant, Record<string, unknown>> = {
   success: { boxShadow: '0 0 4px rgba(20,184,166,0.4)' },
   warning: { boxShadow: '0 0 4px rgba(245,158,11,0.4)' },
   error: { boxShadow: '0 0 4px rgba(239,68,68,0.4)' },
-  neutral: null,
-  'on-track': null,
-  deviation: null,
-  future: null,
+  neutral: { boxShadow: '0 0 4px rgba(107,114,128,0.4)' },
+  'on-track': { boxShadow: '0 0 4px rgba(20,184,166,0.4)' },
+  deviation: { boxShadow: '0 0 4px rgba(245,158,11,0.4)' },
+  future: { boxShadow: '0 0 4px rgba(107,114,128,0.4)' },
 }
 
 const iconChars: Record<string, string> = {

--- a/packages/ui/src/components/custom/Workout/StatusDot.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.tsx
@@ -1,0 +1,160 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React from 'react'
+import { View, Text, type ViewProps } from 'react-native'
+
+export type StatusDotVariant =
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'neutral'
+  | 'on-track'
+  | 'deviation'
+  | 'future'
+
+export interface StatusDotProps extends ViewProps {
+  variant: StatusDotVariant
+  icon?: 'check' | 'exclamation' | 'dash'
+  size?: 'sm' | 'md'
+  /** Adds a subtle glow effect in the variant color */
+  glow?: boolean
+  label?: string
+  className?: string
+}
+
+const solidVariantColors: Record<string, string> = {
+  success: '#14B8A6',
+  warning: '#FFB020',
+  error: '#D14343',
+  neutral: '#6B7280',
+}
+
+const ringVariantStyles: Record<string, Record<string, unknown>> = {
+  'on-track': {
+    backgroundColor: 'rgba(20,184,166,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(20,184,166,0.3)',
+  },
+  deviation: {
+    backgroundColor: 'rgba(245,158,11,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(245,158,11,0.25)',
+  },
+  future: {
+    backgroundColor: 'rgba(107,114,128,0.1)',
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: 'rgba(107,114,128,0.2)',
+  },
+}
+
+const glowStyles: Record<StatusDotVariant, Record<string, unknown> | null> = {
+  success: { boxShadow: '0 0 4px rgba(20,184,166,0.4)' },
+  warning: { boxShadow: '0 0 4px rgba(245,158,11,0.4)' },
+  error: { boxShadow: '0 0 4px rgba(239,68,68,0.4)' },
+  neutral: null,
+  'on-track': null,
+  deviation: null,
+  future: null,
+}
+
+const iconChars: Record<string, string> = {
+  check: '\u2713',
+  exclamation: '!',
+  dash: '\u2014',
+}
+
+/** Color-matched icon colors: dark on solid bg, light on transparent bg */
+const iconColors: Record<StatusDotVariant, string> = {
+  success: '#0A5C52',
+  warning: '#6B4000',
+  error: '#5C1A1A',
+  neutral: '#D1D5DB',
+  'on-track': '#14B8A6',
+  deviation: '#FFB020',
+  future: '#6B7280',
+}
+
+const sizeDimensions = {
+  sm: { size: 8, showIcon: false },
+  md: { size: 18, showIcon: true },
+}
+
+function isSolidVariant(variant: StatusDotVariant): boolean {
+  return variant in solidVariantColors
+}
+
+export function StatusDot({
+  variant,
+  icon,
+  size = 'sm',
+  glow,
+  label,
+  className,
+  ...props
+}: StatusDotProps) {
+  const config = sizeDimensions[size]
+  const solid = isSolidVariant(variant)
+  const ring = ringVariantStyles[variant]
+
+  const glowStyle = glow ? glowStyles[variant] : null
+
+  const dot = (
+    <View
+      style={[
+        {
+          width: config.size,
+          height: config.size,
+          borderRadius: 9999,
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        },
+        solid ? { backgroundColor: solidVariantColors[variant] } : undefined,
+        ring ? (ring as Record<string, unknown>) : undefined,
+        glowStyle ? (glowStyle as Record<string, unknown>) : undefined,
+      ]}
+      accessibilityRole="image"
+      accessibilityLabel={`${variant} status`}
+      testID="status-dot"
+    >
+      {config.showIcon && icon && (
+        <Text
+          style={{
+            fontSize: 11,
+            lineHeight: 11,
+            fontWeight: '900',
+            color: iconColors[variant],
+          }}
+          accessibilityElementsHidden
+        >
+          {iconChars[icon]}
+        </Text>
+      )}
+    </View>
+  )
+
+  if (label) {
+    return (
+      <View
+        className={className}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+        accessibilityLabel={`${variant} status: ${label}`}
+        {...props}
+      >
+        <View accessibilityElementsHidden>{dot}</View>
+        <Text
+          style={{ fontSize: 12, lineHeight: 16, color: '#9CA3AF' }}
+          accessibilityElementsHidden
+        >
+          {label}
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <View className={className} {...props}>
+      {dot}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
+++ b/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
@@ -6,7 +6,6 @@ export interface SupersetWrapperProps {
   label?: string
   color?: string
   children: React.ReactNode
-  syncExpansion?: boolean
 }
 
 const DEFAULTS = {
@@ -31,7 +30,7 @@ export function SupersetWrapper({
         marginBottom: 8,
         overflow: 'visible',
       }}
-      accessibilityRole={"group" as any}
+      accessibilityRole={'group' as never}
       accessibilityLabel={`Superset: ${label}`}
       testID="superset-wrapper"
     >

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
@@ -2,17 +2,16 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View } from 'react-native'
 import { TempoDisplay } from './TempoDisplay'
 
+// tempo = [eccentric, pauseBottom, concentric, pauseTop]
 const meta: Meta<typeof TempoDisplay> = {
   title: 'Custom/Workout/TempoDisplay',
   component: TempoDisplay,
   tags: ['autodocs'],
   argTypes: {
-    concentric: { control: 'number', description: 'Concentric phase duration (seconds)' },
-    hold: { control: 'number', description: 'Hold at top (seconds)' },
-    eccentric: { control: 'number', description: 'Eccentric phase duration (seconds)' },
-    idle: { control: 'number', description: 'Idle between reps (seconds)' },
+    tempo: { control: 'object', description: 'Tempo values [eccentric, pauseBottom, concentric, pauseTop] in seconds' },
     size: { control: 'select', options: ['sm', 'md'], description: 'Size variant' },
     colored: { control: 'boolean', description: 'Colored vs mono display' },
+    showInfo: { control: 'boolean', description: 'Show info tooltip on press' },
   },
 }
 
@@ -20,47 +19,47 @@ export default meta
 type Story = StoryObj<typeof TempoDisplay>
 
 export const ColoredStandard: Story = {
-  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, colored: true },
+  args: { tempo: [3, 1, 1, 0], colored: true },
 }
 
 export const MonoStandard: Story = {
-  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, colored: false },
+  args: { tempo: [3, 1, 1, 0], colored: false },
 }
 
 export const ColoredExplosive: Story = {
-  args: { concentric: 1, hold: 0, eccentric: 1, idle: 0, colored: true },
+  args: { tempo: [1, 0, 1, 0], colored: true },
 }
 
 export const MonoExplosive: Story = {
-  args: { concentric: 1, hold: 0, eccentric: 1, idle: 0, colored: false },
+  args: { tempo: [1, 0, 1, 0], colored: false },
 }
 
 export const ColoredSlowEccentric: Story = {
-  args: { concentric: 1, hold: 2, eccentric: 5, idle: 1, colored: true },
+  args: { tempo: [5, 2, 1, 1], colored: true },
 }
 
 export const SmallColored: Story = {
-  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, size: 'sm', colored: true },
+  args: { tempo: [3, 1, 1, 0], size: 'sm', colored: true },
 }
 
 export const SmallMono: Story = {
-  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, size: 'sm', colored: false },
+  args: { tempo: [3, 1, 1, 0], size: 'sm', colored: false },
 }
 
 export const AllVariants: Story = {
   render: () => (
     <View style={{ gap: 12 }}>
       <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored />
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored={false} />
+        <TempoDisplay tempo={[3, 1, 1, 0]} colored />
+        <TempoDisplay tempo={[3, 1, 1, 0]} colored={false} />
       </View>
       <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-        <TempoDisplay concentric={1} hold={0} eccentric={1} idle={0} colored />
-        <TempoDisplay concentric={1} hold={0} eccentric={1} idle={0} colored={false} />
+        <TempoDisplay tempo={[1, 0, 1, 0]} colored />
+        <TempoDisplay tempo={[1, 0, 1, 0]} colored={false} />
       </View>
       <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" colored />
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" colored={false} />
+        <TempoDisplay tempo={[3, 1, 1, 0]} size="sm" colored />
+        <TempoDisplay tempo={[3, 1, 1, 0]} size="sm" colored={false} />
       </View>
     </View>
   ),

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { TempoDisplay } from './TempoDisplay'
+
+const meta: Meta<typeof TempoDisplay> = {
+  title: 'Custom/Workout/TempoDisplay',
+  component: TempoDisplay,
+  tags: ['autodocs'],
+  argTypes: {
+    concentric: { control: 'number', description: 'Concentric phase duration (seconds)' },
+    hold: { control: 'number', description: 'Hold at top (seconds)' },
+    eccentric: { control: 'number', description: 'Eccentric phase duration (seconds)' },
+    idle: { control: 'number', description: 'Idle between reps (seconds)' },
+    size: { control: 'select', options: ['sm', 'md'], description: 'Size variant' },
+    colored: { control: 'boolean', description: 'Colored vs mono display' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof TempoDisplay>
+
+export const ColoredStandard: Story = {
+  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, colored: true },
+}
+
+export const MonoStandard: Story = {
+  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, colored: false },
+}
+
+export const ColoredExplosive: Story = {
+  args: { concentric: 1, hold: 0, eccentric: 1, idle: 0, colored: true },
+}
+
+export const MonoExplosive: Story = {
+  args: { concentric: 1, hold: 0, eccentric: 1, idle: 0, colored: false },
+}
+
+export const ColoredSlowEccentric: Story = {
+  args: { concentric: 1, hold: 2, eccentric: 5, idle: 1, colored: true },
+}
+
+export const SmallColored: Story = {
+  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, size: 'sm', colored: true },
+}
+
+export const SmallMono: Story = {
+  args: { concentric: 1, hold: 1, eccentric: 3, idle: 0, size: 'sm', colored: false },
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <View style={{ gap: 12 }}>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored />
+        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored={false} />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <TempoDisplay concentric={1} hold={0} eccentric={1} idle={0} colored />
+        <TempoDisplay concentric={1} hold={0} eccentric={1} idle={0} colored={false} />
+      </View>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" colored />
+        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" colored={false} />
+      </View>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
@@ -3,77 +3,86 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { TempoDisplay } from './TempoDisplay'
 
+// tempo = [eccentric, pauseBottom, concentric, pauseTop]
 describe('TempoDisplay', () => {
   it('renders tempo values', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
     expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
-  it('does not render Tempo label prefix', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
-    expect(screen.queryByText('Tempo')).not.toBeInTheDocument()
+  it('renders the TEMPO label prefix', () => {
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
+    expect(screen.getByText('TEMPO')).toBeInTheDocument()
   })
 
   it('renders colored phases by default', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
     const tempoValue = screen.getByTestId('tempo-value')
     expect(tempoValue.children.length).toBeGreaterThan(1)
   })
 
   it('renders mono variant', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored={false} />)
-    expect(screen.getByText('1-1-3-0')).toBeInTheDocument()
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} colored={false} />)
+    expect(screen.getByText('3-1-1-0')).toBeInTheDocument()
   })
 
-  it('renders order: concentric-hold-eccentric-idle', () => {
-    render(<TempoDisplay concentric={2} hold={3} eccentric={4} idle={1} colored={false} />)
-    expect(screen.getByText('2-3-4-1')).toBeInTheDocument()
+  it('renders order: eccentric-pauseBottom-concentric-pauseTop', () => {
+    render(<TempoDisplay tempo={[4, 3, 2, 1]} colored={false} />)
+    expect(screen.getByText('4-3-2-1')).toBeInTheDocument()
   })
 
   it('has correct accessibility label', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
-    expect(screen.getByLabelText(/Tempo: 1 second concentric/)).toBeInTheDocument()
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
+    expect(
+      screen.getByLabelText(
+        'Tempo: 3 second eccentric, 1 second pause, 1 second concentric, 0 second pause'
+      )
+    ).toBeInTheDocument()
   })
 
   it('is always a Pressable for tooltip', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
     const display = screen.getByTestId('tempo-display')
     expect(display).toBeInTheDocument()
   })
 
   it('calls onPress when pressed', () => {
     const onPress = vi.fn()
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} onPress={onPress} />)
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} onPress={onPress} />)
     const display = screen.getByTestId('tempo-display')
     fireEvent.click(display)
     expect(onPress).toHaveBeenCalledOnce()
   })
 
   it('toggles tooltip on press', () => {
-    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
     expect(screen.queryByTestId('tempo-tooltip')).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId('tempo-display'))
     expect(screen.getByTestId('tempo-tooltip')).toBeInTheDocument()
   })
 
+  it('does not show tooltip when showInfo is false', () => {
+    render(<TempoDisplay tempo={[3, 1, 1, 0]} showInfo={false} />)
+    fireEvent.click(screen.getByTestId('tempo-display'))
+    expect(screen.queryByTestId('tempo-tooltip')).not.toBeInTheDocument()
+  })
+
   describe('sizes', () => {
     it('renders at sm size', () => {
-      render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" />)
+      render(<TempoDisplay tempo={[3, 1, 1, 0]} size="sm" />)
       expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
     })
 
     it('renders at md size', () => {
-      render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="md" />)
+      render(<TempoDisplay tempo={[3, 1, 1, 0]} size="md" />)
       expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
     })
   })
 
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
-      const { container } = render(
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />
-      )
+      const { container } = render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
       const results = await axe(container)
       expect(results).toHaveNoViolations()
     })

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { TempoDisplay } from './TempoDisplay'
+
+describe('TempoDisplay', () => {
+  it('renders tempo values', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('does not render Tempo label prefix', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    expect(screen.queryByText('Tempo')).not.toBeInTheDocument()
+  })
+
+  it('renders colored phases by default', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    const tempoValue = screen.getByTestId('tempo-value')
+    expect(tempoValue.children.length).toBeGreaterThan(1)
+  })
+
+  it('renders mono variant', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored={false} />)
+    expect(screen.getByText('1-1-3-0')).toBeInTheDocument()
+  })
+
+  it('renders order: concentric-hold-eccentric-idle', () => {
+    render(<TempoDisplay concentric={2} hold={3} eccentric={4} idle={1} colored={false} />)
+    expect(screen.getByText('2-3-4-1')).toBeInTheDocument()
+  })
+
+  it('has correct accessibility label', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    expect(screen.getByLabelText(/Tempo: 1 second concentric/)).toBeInTheDocument()
+  })
+
+  it('is always a Pressable for tooltip', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    const display = screen.getByTestId('tempo-display')
+    expect(display).toBeInTheDocument()
+  })
+
+  it('calls onPress when pressed', () => {
+    const onPress = vi.fn()
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} onPress={onPress} />)
+    const display = screen.getByTestId('tempo-display')
+    fireEvent.click(display)
+    expect(onPress).toHaveBeenCalledOnce()
+  })
+
+  it('toggles tooltip on press', () => {
+    render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />)
+    expect(screen.queryByTestId('tempo-tooltip')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('tempo-display'))
+    expect(screen.getByTestId('tempo-tooltip')).toBeInTheDocument()
+  })
+
+  describe('sizes', () => {
+    it('renders at sm size', () => {
+      render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" />)
+      expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
+    })
+
+    it('renders at md size', () => {
+      render(<TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="md" />)
+      expect(screen.getByTestId('tempo-value')).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} />
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -1,25 +1,29 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useState, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 
 export interface TempoDisplayProps extends ViewProps {
-  concentric: number
-  hold: number
-  eccentric: number
-  idle: number
+  /** Tempo values: [eccentric, pauseBottom, concentric, pauseTop] in seconds */
+  tempo: [number, number, number, number]
   size?: 'sm' | 'md'
   /** Colored phases or mono (all gray) */
   colored?: boolean
+  /** Show info tooltip on press */
+  showInfo?: boolean
   onPress?: () => void
   className?: string
 }
 
+const INTER = 'Inter, sans-serif'
+const TEXT_TERTIARY = '#6B7280'
+
+// Phase colors: [eccentric, pauseBottom, concentric, pauseTop]
 const phaseColors = {
-  concentric: '#FF7900',
-  hold: '#2196F3',
-  eccentric: '#14B8A6',
-  idle: '#9CA3AF',
-  dash: '#9CA3AF',
+  eccentric: '#FFB020', // status-warning (amber)
+  pauseBottom: TEXT_TERTIARY,
+  concentric: '#14B8A6', // status-success (teal)
+  pauseTop: TEXT_TERTIARY,
+  dash: TEXT_TERTIARY,
 }
 
 function TempoValue({
@@ -34,11 +38,11 @@ function TempoValue({
   return (
     <Text
       style={{
-        fontFamily: '"Nunito Sans", sans-serif',
+        fontFamily: INTER,
         fontSize,
         color,
         fontWeight: '600',
-        letterSpacing: 2,
+        letterSpacing: 1,
       }}
     >
       {value}
@@ -50,11 +54,11 @@ function TempoSeparator({ color, fontSize }: { color: string; fontSize: number }
   return (
     <Text
       style={{
-        fontFamily: '"Nunito Sans", sans-serif',
+        fontFamily: INTER,
         fontSize,
         color,
         fontWeight: '600',
-        letterSpacing: 2,
+        letterSpacing: 1,
       }}
     >
       -
@@ -63,27 +67,28 @@ function TempoSeparator({ color, fontSize }: { color: string; fontSize: number }
 }
 
 export function TempoDisplay({
-  concentric,
-  hold,
-  eccentric,
-  idle,
+  tempo,
   size = 'md',
   colored = true,
+  showInfo = true,
   onPress,
   className,
   ...props
 }: TempoDisplayProps) {
   const [showTooltip, setShowTooltip] = useState(false)
+  const [eccentric, pauseBottom, concentric, pauseTop] = tempo
   const isSm = size === 'sm'
   const fontSize = isSm ? 9 : 11
-  const monoColor = '#9CA3AF'
+  const monoColor = TEXT_TERTIARY
 
   const handlePress = useCallback(() => {
     if (onPress) {
       onPress()
     }
-    setShowTooltip((prev) => !prev)
-  }, [onPress])
+    if (showInfo) {
+      setShowTooltip((prev) => !prev)
+    }
+  }, [onPress, showInfo])
 
   const content = (
     <View
@@ -93,33 +98,46 @@ export function TempoDisplay({
         alignItems: 'center',
         backgroundColor: '#1C1C1C',
         paddingHorizontal: isSm ? 6 : 8,
-        paddingVertical: 2,
-        borderRadius: 2,
+        paddingVertical: 3,
+        borderRadius: 4,
       }}
       {...props}
     >
+      <Text
+        style={{
+          fontFamily: INTER,
+          fontSize: 9,
+          fontWeight: '500',
+          color: TEXT_TERTIARY,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+          marginRight: 6,
+        }}
+      >
+        TEMPO
+      </Text>
       <View style={{ flexDirection: 'row' }} testID="tempo-value">
         {colored ? (
           <>
-            <TempoValue value={concentric} color={phaseColors.concentric} fontSize={fontSize} />
-            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
-            <TempoValue value={hold} color={phaseColors.hold} fontSize={fontSize} />
-            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
             <TempoValue value={eccentric} color={phaseColors.eccentric} fontSize={fontSize} />
             <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
-            <TempoValue value={idle} color={phaseColors.idle} fontSize={fontSize} />
+            <TempoValue value={pauseBottom} color={phaseColors.pauseBottom} fontSize={fontSize} />
+            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
+            <TempoValue value={concentric} color={phaseColors.concentric} fontSize={fontSize} />
+            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
+            <TempoValue value={pauseTop} color={phaseColors.pauseTop} fontSize={fontSize} />
           </>
         ) : (
           <Text
             style={{
-              fontFamily: '"Nunito Sans", sans-serif',
+              fontFamily: INTER,
               fontSize,
               color: monoColor,
               fontWeight: '600',
-              letterSpacing: 2,
+              letterSpacing: 1,
             }}
           >
-            {concentric}-{hold}-{eccentric}-{idle}
+            {eccentric}-{pauseBottom}-{concentric}-{pauseTop}
           </Text>
         )}
       </View>
@@ -128,7 +146,7 @@ export function TempoDisplay({
 
   return (
     <Pressable
-      accessibilityLabel={`Tempo: ${concentric} second concentric, ${hold} second hold, ${eccentric} second eccentric, ${idle} second idle`}
+      accessibilityLabel={`Tempo: ${eccentric} second eccentric, ${pauseBottom} second pause, ${concentric} second concentric, ${pauseTop} second pause`}
       accessibilityRole="button"
       onPress={handlePress}
       testID="tempo-display"
@@ -157,17 +175,17 @@ export function TempoDisplay({
               borderColor: '#2C2C2C',
             }}
           >
-            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
-              Concentric: {concentric}s
-            </Text>
-            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
-              Hold: {hold}s
-            </Text>
-            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: INTER }}>
               Eccentric: {eccentric}s
             </Text>
-            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
-              Idle: {idle}s
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: INTER }}>
+              Pause (bottom): {pauseBottom}s
+            </Text>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: INTER }}>
+              Concentric: {concentric}s
+            </Text>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: INTER }}>
+              Pause (top): {pauseTop}s
             </Text>
           </View>
           <View

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -1,0 +1,189 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useState, useCallback } from 'react'
+import { View, Text, Pressable, type ViewProps } from 'react-native'
+
+export interface TempoDisplayProps extends ViewProps {
+  concentric: number
+  hold: number
+  eccentric: number
+  idle: number
+  size?: 'sm' | 'md'
+  /** Colored phases or mono (all gray) */
+  colored?: boolean
+  onPress?: () => void
+  className?: string
+}
+
+const phaseColors = {
+  concentric: '#FF7900',
+  hold: '#2196F3',
+  eccentric: '#14B8A6',
+  idle: '#9CA3AF',
+  dash: '#9CA3AF',
+}
+
+function TempoValue({
+  value,
+  color,
+  fontSize,
+}: {
+  value: number
+  color: string
+  fontSize: number
+}) {
+  return (
+    <Text
+      style={{
+        fontFamily: '"Nunito Sans", sans-serif',
+        fontSize,
+        color,
+        fontWeight: '600',
+        letterSpacing: 2,
+      }}
+    >
+      {value}
+    </Text>
+  )
+}
+
+function TempoSeparator({ color, fontSize }: { color: string; fontSize: number }) {
+  return (
+    <Text
+      style={{
+        fontFamily: '"Nunito Sans", sans-serif',
+        fontSize,
+        color,
+        fontWeight: '600',
+        letterSpacing: 2,
+      }}
+    >
+      -
+    </Text>
+  )
+}
+
+export function TempoDisplay({
+  concentric,
+  hold,
+  eccentric,
+  idle,
+  size = 'md',
+  colored = true,
+  onPress,
+  className,
+  ...props
+}: TempoDisplayProps) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  const isSm = size === 'sm'
+  const fontSize = isSm ? 9 : 11
+  const monoColor = '#9CA3AF'
+
+  const handlePress = useCallback(() => {
+    if (onPress) {
+      onPress()
+    }
+    setShowTooltip((prev) => !prev)
+  }, [onPress])
+
+  const content = (
+    <View
+      className={className}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: '#1C1C1C',
+        paddingHorizontal: isSm ? 6 : 8,
+        paddingVertical: 2,
+        borderRadius: 2,
+      }}
+      {...props}
+    >
+      <View style={{ flexDirection: 'row' }} testID="tempo-value">
+        {colored ? (
+          <>
+            <TempoValue value={concentric} color={phaseColors.concentric} fontSize={fontSize} />
+            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
+            <TempoValue value={hold} color={phaseColors.hold} fontSize={fontSize} />
+            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
+            <TempoValue value={eccentric} color={phaseColors.eccentric} fontSize={fontSize} />
+            <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />
+            <TempoValue value={idle} color={phaseColors.idle} fontSize={fontSize} />
+          </>
+        ) : (
+          <Text
+            style={{
+              fontFamily: '"Nunito Sans", sans-serif',
+              fontSize,
+              color: monoColor,
+              fontWeight: '600',
+              letterSpacing: 2,
+            }}
+          >
+            {concentric}-{hold}-{eccentric}-{idle}
+          </Text>
+        )}
+      </View>
+    </View>
+  )
+
+  return (
+    <Pressable
+      accessibilityLabel={`Tempo: ${concentric} second concentric, ${hold} second hold, ${eccentric} second eccentric, ${idle} second idle`}
+      accessibilityRole="button"
+      onPress={handlePress}
+      testID="tempo-display"
+    >
+      {content}
+      {showTooltip && (
+        <View
+          style={{
+            position: 'absolute',
+            bottom: '100%',
+            left: '50%',
+            transform: [{ translateX: '-50%' as unknown as number }],
+            marginBottom: 8,
+            zIndex: 20,
+            alignItems: 'center',
+          }}
+          testID="tempo-tooltip"
+        >
+          <View
+            style={{
+              backgroundColor: '#191919',
+              borderRadius: 6,
+              paddingVertical: 8,
+              paddingHorizontal: 12,
+              borderWidth: 1,
+              borderColor: '#2C2C2C',
+            }}
+          >
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
+              Concentric: {concentric}s
+            </Text>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
+              Hold: {hold}s
+            </Text>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
+              Eccentric: {eccentric}s
+            </Text>
+            <Text style={{ fontSize: 10, lineHeight: 16, color: '#9CA3AF', fontFamily: '"Nunito Sans", sans-serif' }}>
+              Idle: {idle}s
+            </Text>
+          </View>
+          <View
+            style={{
+              width: 0,
+              height: 0,
+              borderLeftWidth: 5,
+              borderRightWidth: 5,
+              borderTopWidth: 5,
+              borderLeftColor: 'transparent',
+              borderRightColor: 'transparent',
+              borderTopColor: '#2C2C2C',
+            }}
+          />
+        </View>
+      )}
+    </Pressable>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { VelocityStrip } from './VelocityStrip'
+
+const meta: Meta<typeof VelocityStrip> = {
+  title: 'Custom/Workout/VelocityStrip',
+  component: VelocityStrip,
+  tags: ['autodocs'],
+  argTypes: {
+    expanded: {
+      control: 'boolean',
+      description: 'Whether the strip is expanded into a bar chart',
+    },
+    variant: {
+      control: 'select',
+      options: ['full', 'mini'],
+      description: 'Display variant',
+    },
+    showInfo: {
+      control: 'boolean',
+      description: 'Whether to show the info row (zone name + loss %) in expanded mode',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof VelocityStrip>
+
+const fastSet = [1.15, 1.12, 1.08, 1.05, 1.02]
+const slowSet = [0.65, 0.58, 0.52, 0.48, 0.42]
+const mixedSet = [1.1, 0.95, 0.82, 0.68, 0.55, 0.45]
+const moderateSet = [0.88, 0.85, 0.82, 0.78, 0.76]
+
+export const DefaultCollapsed: Story = {
+  args: {
+    velocities: moderateSet,
+    onToggle: () => {},
+  },
+}
+
+export const Expanded: Story = {
+  args: {
+    velocities: moderateSet,
+    expanded: true,
+    onToggle: () => {},
+  },
+}
+
+export const ExpandedNoInfo: Story = {
+  args: {
+    velocities: moderateSet,
+    expanded: true,
+    showInfo: false,
+    onToggle: () => {},
+  },
+}
+
+export const FastEasySet: Story = {
+  args: {
+    velocities: fastSet,
+    expanded: true,
+    onToggle: () => {},
+  },
+}
+
+export const SlowGrindingSet: Story = {
+  args: {
+    velocities: slowSet,
+    expanded: true,
+    onToggle: () => {},
+  },
+}
+
+export const MixedVelocities: Story = {
+  args: {
+    velocities: mixedSet,
+    expanded: true,
+    onToggle: () => {},
+  },
+}
+
+export const Mini: Story = {
+  args: {
+    velocities: mixedSet,
+    variant: 'mini',
+  },
+}
+
+export const Interactive: Story = {
+  render: () => {
+    const [expanded, setExpanded] = useState(false)
+    return (
+      <View style={{ width: 300, padding: 16 }}>
+        <VelocityStrip
+          velocities={moderateSet}
+          expanded={expanded}
+          onToggle={() => setExpanded(!expanded)}
+          onRepPress={(index, velocity) =>
+            console.log(`Rep ${index + 1}: ${velocity}`)
+          }
+        />
+      </View>
+    )
+  },
+}
+
+export const AllProfiles: Story = {
+  render: () => (
+    <View style={{ gap: 24, padding: 16 }}>
+      <View style={{ gap: 8 }}>
+        <VelocityStrip velocities={fastSet} expanded onToggle={() => {}} />
+        <VelocityStrip
+          velocities={moderateSet}
+          expanded
+          onToggle={() => {}}
+        />
+        <VelocityStrip velocities={slowSet} expanded onToggle={() => {}} />
+        <VelocityStrip velocities={mixedSet} expanded onToggle={() => {}} />
+      </View>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View } from 'react-native'
 import { VelocityStrip } from './VelocityStrip'
@@ -87,22 +87,24 @@ export const Mini: Story = {
   },
 }
 
+function InteractiveVelocityStrip() {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <View style={{ width: 300, padding: 16 }}>
+      <VelocityStrip
+        velocities={moderateSet}
+        expanded={expanded}
+        onToggle={() => setExpanded(!expanded)}
+        onRepPress={(index, velocity) =>
+          console.log(`Rep ${index + 1}: ${velocity}`)
+        }
+      />
+    </View>
+  )
+}
+
 export const Interactive: Story = {
-  render: () => {
-    const [expanded, setExpanded] = useState(false)
-    return (
-      <View style={{ width: 300, padding: 16 }}>
-        <VelocityStrip
-          velocities={moderateSet}
-          expanded={expanded}
-          onToggle={() => setExpanded(!expanded)}
-          onRepPress={(index, velocity) =>
-            console.log(`Rep ${index + 1}: ${velocity}`)
-          }
-        />
-      </View>
-    )
-  },
+  render: () => <InteractiveVelocityStrip />,
 }
 
 export const AllProfiles: Story = {

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import {
+  VelocityStrip,
+  getVelocityZoneColor,
+  getVelocityZoneName,
+  calculateVelocityLoss,
+  calculateMeanVelocity,
+} from './VelocityStrip'
+
+const sampleVelocities = [1.1, 0.95, 0.82, 0.68, 0.45]
+
+describe('VelocityStrip', () => {
+  it('renders correct number of segments', () => {
+    render(<VelocityStrip velocities={sampleVelocities} />)
+    for (let i = 0; i < sampleVelocities.length; i++) {
+      expect(screen.getByTestId(`velocity-bar-${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders with expanded state', () => {
+    render(<VelocityStrip velocities={sampleVelocities} expanded />)
+    expect(screen.getByTestId('velocity-strip')).toBeInTheDocument()
+    expect(screen.getByTestId('velocity-info-row')).toBeInTheDocument()
+  })
+
+  it('shows velocity labels when expanded', () => {
+    render(<VelocityStrip velocities={sampleVelocities} expanded />)
+    for (let i = 0; i < sampleVelocities.length; i++) {
+      expect(screen.getByTestId(`velocity-label-${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('fires onToggle on press', () => {
+    const onToggle = vi.fn()
+    render(
+      <VelocityStrip velocities={sampleVelocities} onToggle={onToggle} />,
+    )
+    const pressable = screen.getByTestId('velocity-strip-pressable')
+    fireEvent.click(pressable)
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('fires onRepPress with correct index when bar is tapped', () => {
+    const onRepPress = vi.fn()
+    render(
+      <VelocityStrip
+        velocities={sampleVelocities}
+        expanded
+        onRepPress={onRepPress}
+      />,
+    )
+    const bar = screen.getByTestId('velocity-bar-pressable-2')
+    fireEvent.click(bar)
+    expect(onRepPress).toHaveBeenCalledWith(2, 0.82)
+  })
+
+  it('sets accessibility role and label', () => {
+    render(<VelocityStrip velocities={sampleVelocities} />)
+    expect(
+      screen.getByLabelText(
+        'Velocity chart for set, 5 reps, tap to expand',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('sets expanded accessibility label when expanded', () => {
+    render(<VelocityStrip velocities={sampleVelocities} expanded />)
+    expect(
+      screen.getByLabelText(
+        'Velocity chart for set, 5 reps, tap to collapse',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  describe('showInfo prop', () => {
+    it('shows info row when expanded and showInfo is true (default)', () => {
+      render(<VelocityStrip velocities={sampleVelocities} expanded />)
+      expect(screen.getByTestId('velocity-info-row')).toBeInTheDocument()
+    })
+
+    it('hides info row when expanded and showInfo is false', () => {
+      render(<VelocityStrip velocities={sampleVelocities} expanded showInfo={false} />)
+      expect(screen.queryByTestId('velocity-info-row')).not.toBeInTheDocument()
+    })
+
+    it('does not show info row when collapsed regardless of showInfo', () => {
+      render(<VelocityStrip velocities={sampleVelocities} showInfo />)
+      expect(screen.queryByTestId('velocity-info-row')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('mini variant', () => {
+    it('renders mini strip', () => {
+      render(<VelocityStrip velocities={sampleVelocities} variant="mini" />)
+      expect(screen.getByTestId('velocity-strip-mini')).toBeInTheDocument()
+    })
+
+    it('does not respond to press', () => {
+      const onToggle = vi.fn()
+      render(
+        <VelocityStrip
+          velocities={sampleVelocities}
+          variant="mini"
+          onToggle={onToggle}
+        />,
+      )
+      expect(
+        screen.queryByTestId('velocity-strip-pressable'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders correct number of segments', () => {
+      render(<VelocityStrip velocities={sampleVelocities} variant="mini" />)
+      for (let i = 0; i < sampleVelocities.length; i++) {
+        expect(screen.getByTestId(`velocity-bar-${i}`)).toBeInTheDocument()
+      }
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <VelocityStrip velocities={sampleVelocities} onToggle={() => {}} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations when expanded', async () => {
+      const { container } = render(
+        <VelocityStrip velocities={sampleVelocities} expanded onToggle={() => {}} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations when expanded with rep press', async () => {
+      const { container } = render(
+        <VelocityStrip
+          velocities={sampleVelocities}
+          expanded
+          onRepPress={() => {}}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations in mini variant', async () => {
+      const { container } = render(
+        <VelocityStrip velocities={sampleVelocities} variant="mini" />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('outer pressable has accessibility label when onToggle provided', () => {
+      render(<VelocityStrip velocities={sampleVelocities} onToggle={() => {}} />)
+      expect(
+        screen.getByLabelText('Velocity chart for set, 5 reps, tap to expand'),
+      ).toBeInTheDocument()
+    })
+
+    it('rep pressables have accessibility labels when expanded with onRepPress', () => {
+      render(
+        <VelocityStrip
+          velocities={sampleVelocities}
+          expanded
+          onRepPress={() => {}}
+        />,
+      )
+      expect(
+        screen.getByLabelText('Rep 1: 1.10 meters per second, tap for details'),
+      ).toBeInTheDocument()
+    })
+  })
+})
+
+describe('getVelocityZoneColor', () => {
+  it('returns vel-green for velocities >= 1.0', () => {
+    expect(getVelocityZoneColor(1.0)).toBe('vel-green')
+    expect(getVelocityZoneColor(1.5)).toBe('vel-green')
+  })
+
+  it('returns vel-yellow for velocities >= 0.75 and < 1.0', () => {
+    expect(getVelocityZoneColor(0.75)).toBe('vel-yellow')
+    expect(getVelocityZoneColor(0.99)).toBe('vel-yellow')
+  })
+
+  it('returns vel-orange for velocities >= 0.50 and < 0.75', () => {
+    expect(getVelocityZoneColor(0.5)).toBe('vel-orange')
+    expect(getVelocityZoneColor(0.74)).toBe('vel-orange')
+  })
+
+  it('returns vel-red for velocities < 0.50', () => {
+    expect(getVelocityZoneColor(0.49)).toBe('vel-red')
+    expect(getVelocityZoneColor(0.1)).toBe('vel-red')
+  })
+})
+
+describe('getVelocityZoneName', () => {
+  it('returns correct zone names', () => {
+    expect(getVelocityZoneName(1.2)).toBe('Speed')
+    expect(getVelocityZoneName(0.85)).toBe('Power')
+    expect(getVelocityZoneName(0.6)).toBe('Strength-Speed')
+    expect(getVelocityZoneName(0.3)).toBe('Strength')
+  })
+})
+
+describe('calculateVelocityLoss', () => {
+  it('calculates percentage loss from first to last rep', () => {
+    expect(calculateVelocityLoss([1.0, 0.8])).toBe(20)
+  })
+
+  it('returns 0 for single rep', () => {
+    expect(calculateVelocityLoss([1.0])).toBe(0)
+  })
+
+  it('returns 0 for empty array', () => {
+    expect(calculateVelocityLoss([])).toBe(0)
+  })
+})
+
+describe('calculateMeanVelocity', () => {
+  it('calculates mean of velocities', () => {
+    expect(calculateMeanVelocity([1.0, 0.8, 0.6])).toBeCloseTo(0.8)
+  })
+
+  it('returns 0 for empty array', () => {
+    expect(calculateMeanVelocity([])).toBe(0)
+  })
+})

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -1,5 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 
 export interface VelocityStripProps extends ViewProps {
@@ -88,9 +88,9 @@ export function VelocityStrip({
   const loss = calculateVelocityLoss(velocities)
   const meanZone = getVelocityZoneName(meanVelocity)
 
-  const heightAnim = useRef(new Animated.Value(expanded ? 60 : 3)).current
-  const labelOpacity = useRef(new Animated.Value(expanded ? 1 : 0)).current
-  const infoOpacity = useRef(new Animated.Value(expanded ? 1 : 0)).current
+  const [heightAnim] = useState(() => new Animated.Value(expanded ? 60 : 3))
+  const [labelOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
+  const [infoOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
 
   useEffect(() => {
     if (variant === 'mini') return

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -1,0 +1,287 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useEffect, useRef } from 'react'
+import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+
+export interface VelocityStripProps extends ViewProps {
+  velocities: number[]
+  expanded?: boolean
+  onToggle?: () => void
+  onRepPress?: (index: number, velocity: number) => void
+  variant?: 'full' | 'mini'
+  showInfo?: boolean
+  className?: string
+}
+
+const VEL_COLORS = {
+  green: '#2ed573',
+  yellow: '#ffd43b',
+  orange: '#ffa502',
+  red: '#ff4757',
+}
+
+export function getVelocityZoneColor(velocity: number): string {
+  if (velocity >= 1.0) return 'vel-green'
+  if (velocity >= 0.75) return 'vel-yellow'
+  if (velocity >= 0.5) return 'vel-orange'
+  return 'vel-red'
+}
+
+export function getVelocityZoneName(velocity: number): string {
+  if (velocity >= 1.0) return 'Speed'
+  if (velocity >= 0.75) return 'Power'
+  if (velocity >= 0.5) return 'Strength-Speed'
+  return 'Strength'
+}
+
+export function calculateVelocityLoss(velocities: number[]): number {
+  if (velocities.length < 2) return 0
+  const first = velocities[0]
+  const last = velocities[velocities.length - 1]
+  if (first === 0) return 0
+  return Math.round(((first - last) / first) * 100)
+}
+
+export function calculateMeanVelocity(velocities: number[]): number {
+  if (velocities.length === 0) return 0
+  const sum = velocities.reduce((acc, v) => acc + v, 0)
+  return sum / velocities.length
+}
+
+function getBarColor(zone: string): string {
+  switch (zone) {
+    case 'vel-green': return VEL_COLORS.green
+    case 'vel-yellow': return VEL_COLORS.yellow
+    case 'vel-orange': return VEL_COLORS.orange
+    case 'vel-red': return VEL_COLORS.red
+    default: return VEL_COLORS.green
+  }
+}
+
+const zoneHexMap: Record<string, string> = {
+  'vel-green': VEL_COLORS.green,
+  'vel-yellow': VEL_COLORS.yellow,
+  'vel-orange': VEL_COLORS.orange,
+  'vel-red': VEL_COLORS.red,
+}
+
+function getLossStyle(loss: number): Record<string, string> | null {
+  if (loss > 25) return { color: VEL_COLORS.red }
+  if (loss > 20) return { color: VEL_COLORS.orange }
+  return null
+}
+
+const ANIMATION_DURATION = 400
+const ANIMATION_EASING = Easing.bezier(0.22, 1, 0.36, 1)
+
+export function VelocityStrip({
+  velocities,
+  expanded = false,
+  onToggle,
+  onRepPress,
+  variant = 'full',
+  showInfo = true,
+  className,
+  ...props
+}: VelocityStripProps) {
+  const maxVelocity = Math.max(...velocities, 0)
+  const meanVelocity = calculateMeanVelocity(velocities)
+  const loss = calculateVelocityLoss(velocities)
+  const meanZone = getVelocityZoneName(meanVelocity)
+
+  const heightAnim = useRef(new Animated.Value(expanded ? 60 : 3)).current
+  const labelOpacity = useRef(new Animated.Value(expanded ? 1 : 0)).current
+  const infoOpacity = useRef(new Animated.Value(expanded ? 1 : 0)).current
+
+  useEffect(() => {
+    if (variant === 'mini') return
+
+    Animated.parallel([
+      Animated.timing(heightAnim, {
+        toValue: expanded ? 60 : 3,
+        duration: ANIMATION_DURATION,
+        easing: ANIMATION_EASING,
+        useNativeDriver: false,
+      }),
+      Animated.timing(labelOpacity, {
+        toValue: expanded ? 1 : 0,
+        duration: 300,
+        delay: expanded ? 150 : 0,
+        useNativeDriver: false,
+      }),
+      Animated.timing(infoOpacity, {
+        toValue: expanded ? 1 : 0,
+        duration: 300,
+        delay: expanded ? 200 : 0,
+        useNativeDriver: false,
+      }),
+    ]).start()
+  }, [expanded, variant, heightAnim, labelOpacity, infoOpacity])
+
+  if (variant === 'mini') {
+    const { style: externalStyle, ...restProps } = props
+    return (
+      <View
+        className={className}
+        style={[{ flexDirection: 'row', height: 3, gap: 2, borderRadius: 2, overflow: 'hidden' }, externalStyle]}
+        accessibilityRole="image"
+        accessibilityLabel={`Velocity strip, ${velocities.length} reps`}
+        testID="velocity-strip-mini"
+        {...restProps}
+      >
+        {velocities.map((v, i) => (
+          <View
+            key={i}
+            style={{
+              flex: 1,
+              backgroundColor: getBarColor(getVelocityZoneColor(v)),
+              borderRadius: 1,
+              minWidth: 4,
+              height: '100%' as unknown as number,
+            }}
+            accessibilityElementsHidden
+            testID={`velocity-bar-${i}`}
+          />
+        ))}
+      </View>
+    )
+  }
+
+  const stripLabel = `Velocity chart for set, ${velocities.length} reps, tap to ${expanded ? 'collapse' : 'expand'}`
+  // When onToggle wraps the strip or individual reps are interactive, the container itself is not a button
+  const hasInteractiveContainer = onToggle != null
+  const hasInteractiveReps = onRepPress != null && expanded
+
+  const stripContent = (
+    <Animated.View
+      className={className}
+      style={[
+        {
+          height: heightAnim,
+          width: '100%',
+          gap: 2,
+          borderRadius: expanded ? 6 : 2,
+          paddingTop: expanded ? 16 : 0,
+          paddingBottom: expanded ? 24 : 0,
+          paddingHorizontal: expanded ? 6 : 0,
+          paddingVertical: expanded ? undefined : 8,
+          backgroundColor: expanded ? '#1C1C1C' : 'transparent',
+          overflow: expanded ? 'visible' : 'hidden',
+        },
+      ]}
+      accessibilityRole={hasInteractiveContainer || hasInteractiveReps ? 'none' : 'button'}
+      accessibilityLabel={hasInteractiveContainer || hasInteractiveReps ? undefined : stripLabel}
+      testID="velocity-strip"
+      {...props}
+    >
+      <View
+        style={{ flexDirection: 'row', flex: 1, gap: 2, alignItems: 'flex-end' }}
+      >
+        {velocities.map((v, i) => {
+          const zone = getVelocityZoneColor(v)
+          const barHeightPct = Math.round((v / (maxVelocity * 1.15)) * 100)
+
+          const bar = (
+            <View
+              key={i}
+              style={{ flex: 1, height: '100%', justifyContent: 'flex-end', position: 'relative' }}
+            >
+              {expanded && (
+                <Animated.View style={{ opacity: labelOpacity, alignItems: 'center', position: 'absolute', top: -13, left: 0, right: 0 }} accessibilityElementsHidden>
+                  <Text
+                    style={{ fontSize: 8, fontWeight: '600', color: '#9CA3AF' }}
+                    testID={`velocity-label-${i}`}
+                  >
+                    {v.toFixed(2)}
+                  </Text>
+                </Animated.View>
+              )}
+              <View
+                style={
+                  expanded
+                    ? { height: `${barHeightPct}%`, minHeight: 2, borderTopLeftRadius: 2, borderTopRightRadius: 2, backgroundColor: zoneHexMap[zone] }
+                    : {
+                        minHeight: '100%' as unknown as number,
+                        borderTopLeftRadius: 2,
+                        borderTopRightRadius: 2,
+                        borderBottomLeftRadius: 0,
+                        borderBottomRightRadius: 0,
+                        backgroundColor: zoneHexMap[zone],
+                      }
+                }
+                testID={`velocity-bar-${i}`}
+                accessibilityRole="image"
+                accessibilityLabel={`Rep ${i + 1}: ${v.toFixed(2)} meters per second`}
+              />
+            </View>
+          )
+
+          if (onRepPress && expanded) {
+            return (
+              <Pressable
+                key={i}
+                style={{ flex: 1, height: '100%' }}
+                onPress={() => onRepPress(i, v)}
+                accessibilityRole="button"
+                accessibilityLabel={`Rep ${i + 1}: ${v.toFixed(2)} meters per second, tap for details`}
+                testID={`velocity-bar-pressable-${i}`}
+              >
+                {bar}
+              </Pressable>
+            )
+          }
+
+          return bar
+        })}
+      </View>
+      {expanded && showInfo && (
+        <Animated.View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            opacity: infoOpacity,
+            position: 'absolute',
+            bottom: 4,
+            left: 6,
+            right: 6,
+          }}
+          testID="velocity-info-row"
+        >
+          <Text
+            style={{
+              fontSize: 10,
+              color: '#9CA3AF',
+              fontFamily: 'Inter, sans-serif',
+            }}
+          >
+            {meanZone} {'\u00B7'} {meanVelocity.toFixed(2)} m/s
+          </Text>
+          <Text
+            style={{
+              fontSize: 10,
+              color: '#9CA3AF',
+              fontFamily: 'Inter, sans-serif',
+              ...getLossStyle(loss),
+            }}
+          >
+            Loss: {loss}%
+          </Text>
+        </Animated.View>
+      )}
+    </Animated.View>
+  )
+
+  if (onToggle) {
+    return (
+      <Pressable
+        onPress={onToggle}
+        accessibilityRole="button"
+        accessibilityLabel={stripLabel}
+        testID="velocity-strip-pressable"
+      >
+        {stripContent}
+      </Pressable>
+    )
+  }
+
+  return stripContent
+}

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { WorkoutPill } from './WorkoutPill'
+
+const meta: Meta<typeof WorkoutPill> = {
+  title: 'Custom/Workout/WorkoutPill',
+  component: WorkoutPill,
+  tags: ['autodocs'],
+  argTypes: {
+    name: { control: 'text', description: 'Workout name' },
+    status: {
+      control: 'select',
+      options: ['completed', 'active', 'next', 'upcoming', 'missed', 'deload'],
+      description: 'Pill status',
+    },
+    pulse: { control: 'boolean', description: 'Pulsing animation (independent of status)' },
+    highlighted: { control: 'boolean', description: 'Highlighted with thicker border and slight scale' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof WorkoutPill>
+
+export const Completed: Story = {
+  args: { name: 'Upper A', status: 'completed' },
+}
+
+export const Active: Story = {
+  args: { name: 'Lower B', status: 'active' },
+}
+
+export const ActivePulsing: Story = {
+  args: { name: 'Lower B', status: 'active', pulse: true },
+}
+
+export const Next: Story = {
+  args: { name: 'Upper B', status: 'next' },
+}
+
+export const Upcoming: Story = {
+  args: { name: 'Lower A', status: 'upcoming' },
+}
+
+export const Missed: Story = {
+  args: { name: 'Rest Day', status: 'missed' },
+}
+
+export const Deload: Story = {
+  args: { name: 'Deload Week', status: 'deload' },
+}
+
+export const AllStatuses: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+      <WorkoutPill name="Upper A" status="completed" />
+      <WorkoutPill name="Lower B" status="active" pulse />
+      <WorkoutPill name="Upper B" status="next" />
+      <WorkoutPill name="Lower A" status="upcoming" />
+      <WorkoutPill name="Rest Day" status="missed" />
+      <WorkoutPill name="Recovery" status="deload" />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof WorkoutPill> = {
     name: { control: 'text', description: 'Workout name' },
     status: {
       control: 'select',
-      options: ['completed', 'active', 'next', 'upcoming', 'missed', 'deload'],
+      options: ['completed', 'current', 'next', 'upcoming', 'missed', 'deload'],
       description: 'Pill status',
     },
     pulse: { control: 'boolean', description: 'Pulsing animation (independent of status)' },
@@ -25,12 +25,12 @@ export const Completed: Story = {
   args: { name: 'Upper A', status: 'completed' },
 }
 
-export const Active: Story = {
-  args: { name: 'Lower B', status: 'active' },
+export const Current: Story = {
+  args: { name: 'Lower B', status: 'current' },
 }
 
-export const ActivePulsing: Story = {
-  args: { name: 'Lower B', status: 'active', pulse: true },
+export const CurrentNoPulse: Story = {
+  args: { name: 'Lower B', status: 'current', pulse: false },
 }
 
 export const Next: Story = {
@@ -53,7 +53,7 @@ export const AllStatuses: Story = {
   render: () => (
     <View style={{ flexDirection: 'row', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
       <WorkoutPill name="Upper A" status="completed" />
-      <WorkoutPill name="Lower B" status="active" pulse />
+      <WorkoutPill name="Lower B" status="current" />
       <WorkoutPill name="Upper B" status="next" />
       <WorkoutPill name="Lower A" status="upcoming" />
       <WorkoutPill name="Rest Day" status="missed" />

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.test.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { WorkoutPill } from './WorkoutPill'
+
+describe('WorkoutPill', () => {
+  it('renders the workout name', () => {
+    render(<WorkoutPill name="Upper A" status="completed" />)
+    expect(screen.getByText('Upper A')).toBeInTheDocument()
+  })
+
+  it('shows checkmark for completed status', () => {
+    render(<WorkoutPill name="Upper A" status="completed" />)
+    expect(screen.getByTestId('workout-pill-check')).toBeInTheDocument()
+  })
+
+  it('shows dash for missed status', () => {
+    render(<WorkoutPill name="Rest Day" status="missed" />)
+    expect(screen.getByTestId('workout-pill-dash')).toBeInTheDocument()
+  })
+
+  it('does not show checkmark for active status', () => {
+    render(<WorkoutPill name="Lower B" status="active" />)
+    expect(screen.queryByTestId('workout-pill-check')).not.toBeInTheDocument()
+  })
+
+  it('does not show checkmark for next status', () => {
+    render(<WorkoutPill name="Upper B" status="next" />)
+    expect(screen.queryByTestId('workout-pill-check')).not.toBeInTheDocument()
+  })
+
+  it('does not show checkmark for upcoming status', () => {
+    render(<WorkoutPill name="Lower A" status="upcoming" />)
+    expect(screen.queryByTestId('workout-pill-check')).not.toBeInTheDocument()
+  })
+
+  it('does not show checkmark for deload status', () => {
+    render(<WorkoutPill name="Deload Week" status="deload" />)
+    expect(screen.queryByTestId('workout-pill-check')).not.toBeInTheDocument()
+  })
+
+  it('wraps in Pressable when onPress is provided', () => {
+    render(<WorkoutPill name="Upper A" status="completed" onPress={() => {}} />)
+    expect(screen.getByTestId('workout-pill-pressable')).toBeInTheDocument()
+  })
+
+  it('does not wrap in Pressable when onPress is omitted', () => {
+    render(<WorkoutPill name="Upper A" status="completed" />)
+    expect(screen.queryByTestId('workout-pill-pressable')).not.toBeInTheDocument()
+  })
+
+  it('calls onPress when pressed', () => {
+    const onPress = vi.fn()
+    render(<WorkoutPill name="Upper A" status="completed" onPress={onPress} />)
+    fireEvent.click(screen.getByTestId('workout-pill-pressable'))
+    expect(onPress).toHaveBeenCalledOnce()
+  })
+
+  it('has correct accessibility label', () => {
+    render(<WorkoutPill name="Upper A" status="active" />)
+    expect(screen.getByLabelText('Upper A workout, active')).toBeInTheDocument()
+  })
+
+  it('has correct accessibility label for missed', () => {
+    render(<WorkoutPill name="Rest Day" status="missed" />)
+    expect(screen.getByLabelText('Rest Day workout, missed')).toBeInTheDocument()
+  })
+
+  it('has correct accessibility label for deload', () => {
+    render(<WorkoutPill name="Recovery" status="deload" />)
+    expect(screen.getByLabelText('Recovery workout, deload')).toBeInTheDocument()
+  })
+
+  it('renders all status variants without error', () => {
+    const statuses = ['completed', 'active', 'next', 'upcoming', 'missed', 'deload'] as const
+    for (const status of statuses) {
+      const { unmount } = render(<WorkoutPill name="Test" status={status} />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  describe('pulse prop', () => {
+    it('does not pulse by default', () => {
+      render(<WorkoutPill name="Upper A" status="active" />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    })
+
+    it('pulses when pulse is true', () => {
+      render(<WorkoutPill name="Upper A" status="active" pulse />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    })
+
+    it('pulse is independent of status', () => {
+      render(<WorkoutPill name="Upper A" status="upcoming" pulse />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    })
+  })
+
+  describe('highlighted prop', () => {
+    it('renders without highlighted by default', () => {
+      render(<WorkoutPill name="Upper A" status="active" />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    })
+
+    it('renders with highlighted prop', () => {
+      render(<WorkoutPill name="Upper A" status="active" highlighted />)
+      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <WorkoutPill name="Upper A" status="completed" onPress={() => {}} />
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations as static pill', async () => {
+      const { container } = render(
+        <WorkoutPill name="Lower B" status="upcoming" />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations for missed status', async () => {
+      const { container } = render(
+        <WorkoutPill name="Rest Day" status="missed" onPress={() => {}} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('pressable has correct accessibility label', () => {
+      render(<WorkoutPill name="Upper A" status="completed" onPress={() => {}} />)
+      expect(
+        screen.getByLabelText('Upper A workout, completed'),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.test.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.test.tsx
@@ -19,8 +19,8 @@ describe('WorkoutPill', () => {
     expect(screen.getByTestId('workout-pill-dash')).toBeInTheDocument()
   })
 
-  it('does not show checkmark for active status', () => {
-    render(<WorkoutPill name="Lower B" status="active" />)
+  it('does not show checkmark for current status', () => {
+    render(<WorkoutPill name="Lower B" status="current" />)
     expect(screen.queryByTestId('workout-pill-check')).not.toBeInTheDocument()
   })
 
@@ -57,8 +57,8 @@ describe('WorkoutPill', () => {
   })
 
   it('has correct accessibility label', () => {
-    render(<WorkoutPill name="Upper A" status="active" />)
-    expect(screen.getByLabelText('Upper A workout, active')).toBeInTheDocument()
+    render(<WorkoutPill name="Upper A" status="current" />)
+    expect(screen.getByLabelText('Upper A workout, current')).toBeInTheDocument()
   })
 
   it('has correct accessibility label for missed', () => {
@@ -72,7 +72,7 @@ describe('WorkoutPill', () => {
   })
 
   it('renders all status variants without error', () => {
-    const statuses = ['completed', 'active', 'next', 'upcoming', 'missed', 'deload'] as const
+    const statuses = ['completed', 'current', 'next', 'upcoming', 'missed', 'deload'] as const
     for (const status of statuses) {
       const { unmount } = render(<WorkoutPill name="Test" status={status} />)
       expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
@@ -80,31 +80,40 @@ describe('WorkoutPill', () => {
     }
   })
 
-  describe('pulse prop', () => {
-    it('does not pulse by default', () => {
-      render(<WorkoutPill name="Upper A" status="active" />)
-      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+  describe('pulse', () => {
+    it('pulses by default on current status', () => {
+      render(<WorkoutPill name="Upper A" status="current" />)
+      const pill = screen.getByTestId('workout-pill')
+      expect(pill).toBeInTheDocument()
+      expect(pill).toHaveStyle({ opacity: 1 })
     })
 
-    it('pulses when pulse is true', () => {
-      render(<WorkoutPill name="Upper A" status="active" pulse />)
-      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+    it('does not pulse on non-current statuses by default', () => {
+      render(<WorkoutPill name="Upper A" status="upcoming" />)
+      const pill = screen.getByTestId('workout-pill')
+      expect(pill).toBeInTheDocument()
+      expect(pill.style.opacity).toBe('')
     })
 
-    it('pulse is independent of status', () => {
+    it('can force pulse on a non-current status', () => {
       render(<WorkoutPill name="Upper A" status="upcoming" pulse />)
-      expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
+      expect(screen.getByTestId('workout-pill')).toHaveStyle({ opacity: 1 })
+    })
+
+    it('can disable pulse on current status', () => {
+      render(<WorkoutPill name="Upper A" status="current" pulse={false} />)
+      expect(screen.getByTestId('workout-pill').style.opacity).toBe('')
     })
   })
 
   describe('highlighted prop', () => {
     it('renders without highlighted by default', () => {
-      render(<WorkoutPill name="Upper A" status="active" />)
+      render(<WorkoutPill name="Upper A" status="current" />)
       expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
     })
 
     it('renders with highlighted prop', () => {
-      render(<WorkoutPill name="Upper A" status="active" highlighted />)
+      render(<WorkoutPill name="Upper A" status="current" highlighted />)
       expect(screen.getByTestId('workout-pill')).toBeInTheDocument()
     })
   })

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
@@ -1,13 +1,17 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 
-export type WorkoutPillStatus = 'completed' | 'active' | 'next' | 'upcoming' | 'missed' | 'deload'
+/**
+ * Spec statuses: completed | current | upcoming | deload.
+ * `next` and `missed` are additive extras supported by this implementation.
+ */
+export type WorkoutPillStatus = 'completed' | 'current' | 'upcoming' | 'deload' | 'next' | 'missed'
 
 export interface WorkoutPillProps extends ViewProps {
   name: string
   status: WorkoutPillStatus
-  /** Pulsing animation, independent of status */
+  /** Force pulsing animation. Defaults to pulsing only on `current` status. */
   pulse?: boolean
   onPress?: () => void
   highlighted?: boolean
@@ -16,7 +20,7 @@ export interface WorkoutPillProps extends ViewProps {
 
 const statusBgColors: Record<WorkoutPillStatus, string> = {
   completed: 'rgba(20,184,166,0.15)',
-  active: 'rgba(255,121,0,0.15)',
+  current: 'rgba(255,121,0,0.15)',
   next: 'transparent',
   upcoming: '#1C1C1C',
   missed: 'rgba(209,67,67,0.1)',
@@ -25,7 +29,7 @@ const statusBgColors: Record<WorkoutPillStatus, string> = {
 
 const statusBorderStyles: Record<WorkoutPillStatus, Record<string, unknown>> = {
   completed: { borderWidth: 1, borderColor: 'rgba(20,184,166,0.3)' },
-  active: { borderWidth: 1, borderColor: 'rgba(255,121,0,0.3)' },
+  current: { borderWidth: 1, borderColor: 'rgba(255,121,0,0.3)' },
   next: { borderWidth: 1, borderColor: 'rgba(255,121,0,0.4)' },
   upcoming: { borderWidth: 1, borderColor: '#1F1F1F' },
   missed: { borderWidth: 1, borderColor: 'rgba(209,67,67,0.25)' },
@@ -34,7 +38,7 @@ const statusBorderStyles: Record<WorkoutPillStatus, Record<string, unknown>> = {
 
 const textColors: Record<WorkoutPillStatus, string> = {
   completed: '#14B8A6',
-  active: '#FF7900',
+  current: '#FF7900',
   next: '#FF7900',
   upcoming: '#6B7280',
   missed: 'rgba(209,67,67,0.7)',
@@ -42,7 +46,7 @@ const textColors: Record<WorkoutPillStatus, string> = {
 }
 
 function usePulse(enabled: boolean) {
-  const opacity = useRef(new Animated.Value(1)).current
+  const [opacity] = useState(() => new Animated.Value(1))
 
   useEffect(() => {
     if (!enabled) {
@@ -77,19 +81,20 @@ function usePulse(enabled: boolean) {
 export function WorkoutPill({
   name,
   status,
-  pulse = false,
+  pulse,
   onPress,
   highlighted = false,
   className,
   ...props
 }: WorkoutPillProps) {
-  const pulseOpacity = usePulse(pulse)
+  const shouldPulse = pulse ?? status === 'current'
+  const pulseOpacity = usePulse(shouldPulse)
   const isCompleted = status === 'completed'
   const isMissed = status === 'missed'
 
   const pill = (
     <Animated.View
-      style={pulse ? { opacity: pulseOpacity } : undefined}
+      style={shouldPulse ? { opacity: pulseOpacity } : undefined}
       testID="workout-pill"
     >
       <View

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
@@ -1,0 +1,172 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import React, { useEffect, useRef } from 'react'
+import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+
+export type WorkoutPillStatus = 'completed' | 'active' | 'next' | 'upcoming' | 'missed' | 'deload'
+
+export interface WorkoutPillProps extends ViewProps {
+  name: string
+  status: WorkoutPillStatus
+  /** Pulsing animation, independent of status */
+  pulse?: boolean
+  onPress?: () => void
+  highlighted?: boolean
+  className?: string
+}
+
+const statusBgColors: Record<WorkoutPillStatus, string> = {
+  completed: 'rgba(20,184,166,0.15)',
+  active: 'rgba(255,121,0,0.15)',
+  next: 'transparent',
+  upcoming: '#1C1C1C',
+  missed: 'rgba(209,67,67,0.1)',
+  deload: 'rgba(147,51,234,0.15)',
+}
+
+const statusBorderStyles: Record<WorkoutPillStatus, Record<string, unknown>> = {
+  completed: { borderWidth: 1, borderColor: 'rgba(20,184,166,0.3)' },
+  active: { borderWidth: 1, borderColor: 'rgba(255,121,0,0.3)' },
+  next: { borderWidth: 1, borderColor: 'rgba(255,121,0,0.4)' },
+  upcoming: { borderWidth: 1, borderColor: '#1F1F1F' },
+  missed: { borderWidth: 1, borderColor: 'rgba(209,67,67,0.25)' },
+  deload: { borderWidth: 1, borderColor: 'rgba(147,51,234,0.3)' },
+}
+
+const textColors: Record<WorkoutPillStatus, string> = {
+  completed: '#14B8A6',
+  active: '#FF7900',
+  next: '#FF7900',
+  upcoming: '#6B7280',
+  missed: 'rgba(209,67,67,0.7)',
+  deload: '#9333ea',
+}
+
+function usePulse(enabled: boolean) {
+  const opacity = useRef(new Animated.Value(1)).current
+
+  useEffect(() => {
+    if (!enabled) {
+      opacity.setValue(1)
+      return
+    }
+
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.7,
+          duration: 1000,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 1000,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]),
+    )
+    animation.start()
+
+    return () => animation.stop()
+  }, [enabled, opacity])
+
+  return opacity
+}
+
+export function WorkoutPill({
+  name,
+  status,
+  pulse = false,
+  onPress,
+  highlighted = false,
+  className,
+  ...props
+}: WorkoutPillProps) {
+  const pulseOpacity = usePulse(pulse)
+  const isCompleted = status === 'completed'
+  const isMissed = status === 'missed'
+
+  const pill = (
+    <Animated.View
+      style={pulse ? { opacity: pulseOpacity } : undefined}
+      testID="workout-pill"
+    >
+      <View
+        className={className}
+        style={[
+          {
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: 10,
+            paddingVertical: 4,
+            borderRadius: 6,
+            backgroundColor: statusBgColors[status],
+          },
+          statusBorderStyles[status] as Record<string, unknown>,
+          highlighted ? { borderWidth: 2, transform: [{ scale: 1.02 }] } : undefined,
+        ]}
+        accessibilityLabel={onPress ? undefined : `${name} workout, ${status}`}
+        {...props}
+      >
+        {isCompleted && (
+          <Text
+            style={{
+              fontWeight: '600',
+              fontFamily: '"Nunito Sans", sans-serif',
+              fontSize: 11,
+              color: textColors[status],
+              marginRight: 4,
+            }}
+            accessibilityElementsHidden
+            testID="workout-pill-check"
+          >
+            {'\u2713'}
+          </Text>
+        )}
+        {isMissed && (
+          <Text
+            style={{
+              fontWeight: '600',
+              fontFamily: '"Nunito Sans", sans-serif',
+              fontSize: 11,
+              color: textColors[status],
+              marginRight: 4,
+            }}
+            accessibilityElementsHidden
+            testID="workout-pill-dash"
+          >
+            {'\u2014'}
+          </Text>
+        )}
+        <Text
+          style={{
+            fontWeight: '600',
+            fontFamily: '"Nunito Sans", sans-serif',
+            fontSize: 11,
+            color: textColors[status],
+          }}
+          accessibilityElementsHidden={onPress != null}
+          testID="workout-pill-name"
+        >
+          {name}
+        </Text>
+      </View>
+    </Animated.View>
+  )
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`${name} workout, ${status}`}
+        testID="workout-pill-pressable"
+      >
+        {pill}
+      </Pressable>
+    )
+  }
+
+  return pill
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -1,2 +1,27 @@
+export { E1rmBadge, type E1rmBadgeProps, type E1rmBadgeSize } from './E1rmBadge'
+export { PrBadge, type PrBadgeProps, type PRType } from './PrBadge'
+export { StatusDot, type StatusDotVariant, type StatusDotProps } from './StatusDot'
+export { PlaceholderStrip, type PlaceholderStripProps } from './PlaceholderStrip'
+export { TempoDisplay, type TempoDisplayProps } from './TempoDisplay'
+export { DeviationBar, type DeviationBarProps } from './DeviationBar'
+export { IntensityBar, type IntensityBarProps } from './IntensityBar'
+export { WorkoutPill, type WorkoutPillProps, type WorkoutPillStatus } from './WorkoutPill'
+export {
+  VelocityStrip,
+  type VelocityStripProps,
+  getVelocityZoneColor,
+  getVelocityZoneName,
+  calculateVelocityLoss,
+  calculateMeanVelocity,
+} from './VelocityStrip'
+export {
+  MuscleGroupChip,
+  type MuscleGroupChipProps,
+  type VolumeStatus,
+} from './MuscleGroupChip'
+export { Sparkline, type SparklineProps } from './Sparkline'
+export { SetRow, type SetRowProps, type SetRowMode } from './SetRow'
+export { InputBar, type InputBarProps } from './InputBar'
 export { RestTimer, type RestTimerProps } from './RestTimer'
+export { ExerciseCard, type ExerciseCardProps, type ExerciseCardState } from './ExerciseCard'
 export { SupersetWrapper, type SupersetWrapperProps } from './SupersetWrapper'

--- a/packages/ui/src/theme/workout-tokens.ts
+++ b/packages/ui/src/theme/workout-tokens.ts
@@ -1,0 +1,50 @@
+/**
+ * Workout-specific tokens not yet in the main Tailwind config.
+ * Use these inline instead of Tailwind classes.
+ */
+export const WORKOUT_TOKENS = {
+  // Velocity zones (not in Tailwind)
+  velocity: {
+    green: '#2ed573',
+    yellow: '#ffd43b',
+    orange: '#ffa502',
+    red: '#ff4757',
+  },
+
+  // Badge border-radius (rounded-sm is 4px, we need 2px)
+  badgeRadius: 2,
+
+  // Border colors (use inline to avoid 'border' class pitfall)
+  border: {
+    default: '#1F1F1F',
+    strong: '#2C2C2C',
+    subtle: '#1C1C1C',
+  },
+
+  // Surface colors for inline use
+  surface: {
+    raised: '#1C1C1C',
+    elevated: '#191919',
+  },
+
+  // Intensity bar specific
+  intensity: {
+    track: '#333333',
+    over1: '#D14343',
+    over2: '#A62626',
+    over3: '#7A1C1C',
+    targetLine: 'rgba(33, 150, 243, 0.5)',
+    atTargetGlow:
+      '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(33, 150, 243, 0.15)',
+  },
+
+  // Placeholder strip
+  placeholder: {
+    fill: '#3A3A3A',
+  },
+
+  // Deviation bar
+  deviation: {
+    track: '#333333',
+  },
+} as const


### PR DESCRIPTION
## Summary

Lands the **titan-design workout component library** — 12 atoms + 5 molecules, each with component + unit/a11y tests + Storybook stories. This work already existed (fully built) on the long-lived `feat/workout-organisms` branch but was never merged; this PR **extracts just the `Workout/` components** onto a fresh branch off `main`, leaving the unrelated work (AppBar, AudioPlayer, DataTable, web-jsx infra, version bumps) behind, then remediates it to a clean, spec-conformant state.

See the audit that motivated this: `coordination/contract-audits/TD-workout-organisms-branch-audit-2026-06-23.md` (in the voltras-workspace coordination repo).

### Components
- **Atoms (§1–§12):** E1rmBadge, VelocityStrip, PlaceholderStrip, IntensityBar, StatusDot, WorkoutPill, MuscleGroupChip, TempoDisplay, DeviationBar, PrBadge, Sparkline
- **Molecules (§13–§21):** SetRow, ExerciseCard, InputBar, RestTimer, SupersetWrapper

(Brain tickets TD-03.01–03.10 atoms; TD-03.12–03.16 molecules.)

## Commit 1 — extraction
Cherry-picks `Workout/` + `theme/workout-tokens.ts` onto `main`, keeping **main's** web-jsx runtime (the branch carried the pre-fix version that had 10 type errors main already fixed).

## Commit 2 — remediation
Brought the extracted code to DoD:
- **Lint:** fixed all **30 eslint errors** — the recurring `react-hooks/refs` (`useRef(new Animated.Value()).current` → `useState` lazy init) across 5 animated components, + 1 `rules-of-hooks` in a story.
- **TempoDisplay (correctness bug):** props were `concentric/hold/eccentric/idle` in the **wrong order**; corrected to the spec tuple `[eccentric, pauseBottom, concentric, pauseTop]`, added the TEMPO label, fixed phase colors / font / a11y terminology. **ExerciseCard** caller updated to match.
- **IntensityBar (major gap):** `level` now `0..1` (was `0..100`), added `threshold`/MRV line + `orientation`, spec zone colors (teal/amber/red), dropped the non-spec bulge/glow logic.
- **Spec reconciliation:** WorkoutPill `active`→`current` (+ pulse on current); E1rmBadge PR-state border token; PrBadge 10px font; StatusDot glow + dashed future border; DeviationBar gradient track + bordered dot; PlaceholderStrip dashed; MuscleGroupChip Inter + semantic tokens; RestTimer semantic tokens; SupersetWrapper dropped unimplemented `syncExpansion`.

Documented-intentional deviations were **kept** (e.g. badge radius 2px per `workout-tokens.ts`; inline hex for workout-specific zone colors).

## Verification
- ✅ `pnpm type-check` clean
- ✅ `pnpm test` — **1107 tests pass** (63 files)
- ✅ `pnpm lint` — **0 errors** (4 pre-existing `React`-unused warnings in out-of-scope CONFORMS components)

## Not included / follow-ups
- Out-of-scope branch components (AppBar, AudioPlayer, DataTable, StatusPill, StepProgress, ToastProvider) — left on `feat/workout-organisms`, unreviewed.
- Visual/Storybook screenshot baselines (Playwright `test:visual`) — deferred (needs a single Storybook server; not run in this pass).
- MuscleGroupChip `volumeStatus` enum-name divergence from spec kept (renaming the public union is breaking) — follow-up ticket candidate.
- Genuinely-missing Wave-1 components (WeekRow, WorkoutCard, MesoCard, MesoProgressBar, badge refactor TD-03.34) — separate build effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
