### PR TITLE
Program-planning molecules: WeekRow, WorkoutCard, MesoProgressBar, MesoCard

### DIFF
--- a/packages/ui/src/components/custom/Workout/MesoCard.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { View } from 'react-native'
+import { MesoCard } from './MesoCard'
+import type { WeekRowProps } from './WeekRow'
+
+const weeks: WeekRowProps[] = [
+  {
+    weekNumber: 1,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'completed' },
+      { name: 'Lower', status: 'completed' },
+    ],
+    intensityLevel: 0.4,
+    intensityThreshold: 0.85,
+  },
+  {
+    weekNumber: 2,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'current' },
+      { name: 'Lower', status: 'upcoming' },
+    ],
+    intensityLevel: 0.6,
+    intensityThreshold: 0.85,
+  },
+  {
+    weekNumber: 3,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'upcoming' },
+      { name: 'Lower', status: 'upcoming' },
+    ],
+    intensityLevel: 0.8,
+    intensityThreshold: 0.85,
+  },
+  {
+    weekNumber: 4,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'upcoming' },
+      { name: 'Lower', status: 'upcoming' },
+    ],
+    intensityLevel: 0.35,
+    isDeload: true,
+  },
+]
+
+const meta: Meta<typeof MesoCard> = {
+  title: 'Custom/Workout/MesoCard',
+  component: MesoCard,
+  tags: ['autodocs'],
+  argTypes: {
+    goal: {
+      control: 'select',
+      options: ['Hypertrophy', 'Strength', 'Peaking'],
+      description: 'Training goal shown in the badge',
+    },
+    expanded: {
+      control: 'boolean',
+      description: 'Whether the week list is revealed',
+    },
+    highlighted: {
+      control: 'boolean',
+      description: 'Synced highlight with the MesoProgressBar',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof MesoCard>
+
+export const Collapsed: Story = {
+  args: {
+    name: 'Accumulation',
+    goal: 'Hypertrophy',
+    split: 'Upper/Lower',
+    weekRange: 'Weeks 1-4',
+    currentWeek: 2,
+    totalWeeks: 4,
+    weeks,
+    volumeHeatmap: [
+      { group: 'chest', percentage: 80 },
+      { group: 'back', percentage: 70 },
+      { group: 'legs', percentage: 90 },
+      { group: 'shoulders', percentage: 45 },
+      { group: 'arms', percentage: 35 },
+    ],
+  },
+}
+
+export const Expanded: Story = {
+  args: {
+    ...Collapsed.args,
+    expanded: true,
+  },
+}
+
+export const Highlighted: Story = {
+  args: {
+    ...Collapsed.args,
+    expanded: true,
+    highlighted: true,
+  },
+}
+
+export const StrengthBlock: Story = {
+  args: {
+    name: 'Intensification',
+    goal: 'Strength',
+    split: 'Push/Pull/Legs',
+    weekRange: 'Weeks 5-8',
+    currentWeek: 6,
+    totalWeeks: 4,
+    weeks: weeks.map((w) => ({ ...w, weekNumber: w.weekNumber + 4 })),
+    volumeHeatmap: [
+      { group: 'chest', percentage: 60 },
+      { group: 'back', percentage: 65 },
+      { group: 'legs', percentage: 75 },
+    ],
+    expanded: true,
+  },
+}
+
+function InteractiveMesoCard() {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <View style={{ maxWidth: 420, padding: 16 }}>
+      <MesoCard
+        name="Accumulation"
+        goal="Hypertrophy"
+        split="Upper/Lower"
+        weekRange="Weeks 1-4"
+        currentWeek={2}
+        totalWeeks={4}
+        weeks={weeks}
+        volumeHeatmap={[
+          { group: 'chest', percentage: 80 },
+          { group: 'back', percentage: 70 },
+          { group: 'legs', percentage: 90 },
+        ]}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
+    </View>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveMesoCard />,
+}

--- a/packages/ui/src/components/custom/Workout/MesoCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { MesoCard } from './MesoCard'
+import type { WeekRowProps } from './WeekRow'
+
+const weeks: WeekRowProps[] = [
+  {
+    weekNumber: 1,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'completed' },
+      { name: 'Lower', status: 'completed' },
+    ],
+    intensityLevel: 0.4,
+  },
+  {
+    weekNumber: 2,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'current' },
+      { name: 'Lower', status: 'upcoming' },
+    ],
+    intensityLevel: 0.6,
+  },
+]
+
+const baseProps = {
+  name: 'Accumulation',
+  goal: 'Hypertrophy',
+  split: 'Upper/Lower',
+  weekRange: 'Weeks 1-4',
+  totalWeeks: 4,
+  weeks,
+}
+
+describe('MesoCard', () => {
+  describe('rendering', () => {
+    it('renders name, goal badge, and sub-header', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(screen.getByTestId('meso-card')).toBeInTheDocument()
+      expect(screen.getByTestId('meso-card-name')).toHaveTextContent(
+        'Accumulation',
+      )
+      expect(screen.getByTestId('meso-card-goal-badge')).toHaveTextContent(
+        'Hypertrophy',
+      )
+      expect(screen.getByTestId('meso-card-subheader')).toHaveTextContent(
+        'Upper/Lower · Weeks 1-4',
+      )
+    })
+
+    it('renders the 3px gradient top accent', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(screen.getByTestId('meso-card-accent')).toBeInTheDocument()
+    })
+  })
+
+  describe('expansion', () => {
+    it('does not render week list when collapsed', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(screen.queryByTestId('meso-card-weeks')).not.toBeInTheDocument()
+    })
+
+    it('renders the week list when expanded', () => {
+      render(<MesoCard {...baseProps} expanded />)
+      expect(screen.getByTestId('meso-card-weeks')).toBeInTheDocument()
+      expect(screen.getAllByTestId('week-row')).toHaveLength(2)
+    })
+
+    it('marks header as a button and fires onToggle', () => {
+      const onToggle = vi.fn()
+      render(<MesoCard {...baseProps} onToggle={onToggle} />)
+      const toggle = screen.getByTestId('meso-card-toggle')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      fireEvent.click(toggle)
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+
+    it('reflects expanded state via aria-expanded', () => {
+      const onToggle = vi.fn()
+      render(<MesoCard {...baseProps} onToggle={onToggle} expanded />)
+      expect(screen.getByTestId('meso-card-toggle')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
+    })
+
+    it('renders a static container when not expandable', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(screen.getByTestId('meso-card-static')).toBeInTheDocument()
+      expect(screen.queryByTestId('meso-card-toggle')).not.toBeInTheDocument()
+    })
+
+    it('derives current week marker from currentWeek prop', () => {
+      render(<MesoCard {...baseProps} currentWeek={2} expanded />)
+      expect(screen.getByTestId('week-row-current-dot')).toBeInTheDocument()
+    })
+  })
+
+  describe('volume heatmap', () => {
+    it('renders a heatmap cell per muscle group', () => {
+      render(
+        <MesoCard
+          {...baseProps}
+          volumeHeatmap={[
+            { group: 'chest', percentage: 80 },
+            { group: 'back', percentage: 50 },
+            { group: 'legs', percentage: 30 },
+          ]}
+        />,
+      )
+      expect(screen.getByTestId('meso-card-heatmap')).toBeInTheDocument()
+      expect(screen.getAllByTestId('meso-card-heatmap-cell')).toHaveLength(3)
+    })
+
+    it('does not render heatmap when no data provided', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(screen.queryByTestId('meso-card-heatmap')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('highlighted state', () => {
+    it('applies a brand-primary border color when highlighted', () => {
+      render(<MesoCard {...baseProps} highlighted />)
+      const card = screen.getByTestId('meso-card')
+      const style = card.getAttribute('style') ?? ''
+      expect(style).toContain('box-shadow')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has an accessible label describing the meso', () => {
+      render(<MesoCard {...baseProps} />)
+      expect(
+        screen.getByLabelText('Accumulation, Hypertrophy, Weeks 1-4'),
+      ).toBeInTheDocument()
+    })
+
+    it('exposes the label on the button when expandable', () => {
+      render(<MesoCard {...baseProps} onToggle={vi.fn()} />)
+      const toggle = screen.getByLabelText('Accumulation, Hypertrophy, Weeks 1-4')
+      expect(toggle).toHaveAttribute('role', 'button')
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(<MesoCard {...baseProps} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations when expanded with all features', async () => {
+      const { container } = render(
+        <MesoCard
+          {...baseProps}
+          currentWeek={2}
+          onToggle={vi.fn()}
+          expanded
+          highlighted
+          volumeHeatmap={[
+            { group: 'chest', percentage: 80 },
+            { group: 'back', percentage: 50 },
+          ]}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/MesoCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.tsx
@@ -1,0 +1,235 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useEffect, useState } from 'react'
+import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { Card } from '../../ui/card'
+import { Badge } from '../../ui/badge'
+import { WeekRow, type WeekRowProps } from './WeekRow'
+
+const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY_DARK = '#C45E00'
+const BRAND_PRIMARY_LIGHT = '#FFB066'
+const BORDER_DEFAULT = '#1F1F1F'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+
+/** Gradient stops for the 3px top accent: dark -> primary -> light. */
+const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]
+
+export interface MesoVolumeHeatmapEntry {
+  /** Muscle group identifier (free-form to match plan data). */
+  group: string
+  /** Planned volume intensity for the group, 0-100. */
+  percentage: number
+}
+
+export interface MesoCardProps extends ViewProps {
+  /** Mesocycle name, e.g. "Accumulation". */
+  name: string
+  /** Training goal, e.g. "Hypertrophy", "Strength", "Peaking". */
+  goal: string
+  /** Training split, e.g. "Upper/Lower", "Push/Pull/Legs". */
+  split: string
+  /** Week range label, e.g. "Weeks 1-4". */
+  weekRange: string
+  /** Current week within the mesocycle (1-based). */
+  currentWeek?: number
+  /** Total weeks in the mesocycle. */
+  totalWeeks: number
+  /** Weeks rendered as a WeekRow list when expanded. */
+  weeks: WeekRowProps[]
+  /** Whether the card is expanded to reveal the week list. */
+  expanded?: boolean
+  /** Toggles expansion; makes the header a button when provided. */
+  onToggle?: () => void
+  /** Whether this meso is highlighted in the MesoProgressBar. */
+  highlighted?: boolean
+  /** Volume heatmap data per muscle group for the meso. */
+  volumeHeatmap?: MesoVolumeHeatmapEntry[]
+  className?: string
+}
+
+/**
+ * Maps a 0-100 volume percentage onto a brand-primary tint whose opacity
+ * tracks intensity, keeping a visible floor so low-volume groups stay legible.
+ */
+function heatmapColor(percentage: number): string {
+  const clamped = Math.max(0, Math.min(100, percentage))
+  const opacity = 0.12 + (clamped / 100) * 0.78
+  return `rgba(255,121,0,${opacity.toFixed(3)})`
+}
+
+/**
+ * A mesocycle card with name, goal, split, week range, an optional volume
+ * heatmap strip, and an expandable WeekRow list. Highlighting animates the
+ * border toward brand-primary with a subtle glow to stay in sync with the
+ * MesoProgressBar.
+ *
+ * @example
+ * <MesoCard
+ *   name="Accumulation"
+ *   goal="Hypertrophy"
+ *   split="Upper/Lower"
+ *   weekRange="Weeks 1-4"
+ *   currentWeek={2}
+ *   totalWeeks={4}
+ *   weeks={weeks}
+ *   volumeHeatmap={[{ group: 'chest', percentage: 80 }]}
+ *   expanded
+ *   onToggle={() => {}}
+ *   highlighted
+ * />
+ */
+export function MesoCard({
+  name,
+  goal,
+  split,
+  weekRange,
+  currentWeek,
+  totalWeeks,
+  weeks,
+  expanded = false,
+  onToggle,
+  highlighted = false,
+  volumeHeatmap,
+  className,
+  ...props
+}: MesoCardProps) {
+  const isExpandable = onToggle != null
+  const [highlight] = useState(() => new Animated.Value(highlighted ? 1 : 0))
+
+  useEffect(() => {
+    const animation = Animated.timing(highlight, {
+      toValue: highlighted ? 1 : 0,
+      duration: 250,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: false,
+    })
+    animation.start()
+    return () => animation.stop()
+  }, [highlighted, highlight])
+
+  const borderColor = highlight.interpolate({
+    inputRange: [0, 1],
+    outputRange: [BORDER_DEFAULT, BRAND_PRIMARY],
+  })
+
+  const header = (
+    <View style={{ paddingHorizontal: 14, paddingTop: 12, paddingBottom: 10 }} testID="meso-card-body">
+      <View className="flex-row items-center" style={{ gap: 8 }} testID="meso-card-header">
+        <Text
+          style={{
+            fontSize: 15,
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontWeight: '700',
+            color: TEXT_PRIMARY,
+          }}
+          testID="meso-card-name"
+        >
+          {name}
+        </Text>
+        <Badge variant="subtle" color="primary" size="sm" testID="meso-card-goal-badge">
+          {goal}
+        </Badge>
+      </View>
+
+      <Text
+        style={{
+          marginTop: 4,
+          fontSize: 12,
+          fontFamily: 'Inter, sans-serif',
+          color: TEXT_SECONDARY,
+        }}
+        testID="meso-card-subheader"
+      >
+        {`${split} · ${weekRange}`}
+      </Text>
+
+      {volumeHeatmap && volumeHeatmap.length > 0 && (
+        <View
+          className="flex-row items-center"
+          style={{ marginTop: 10, gap: 3 }}
+          accessibilityElementsHidden
+          testID="meso-card-heatmap"
+        >
+          {volumeHeatmap.map((entry) => (
+            <View
+              key={entry.group}
+              style={{
+                flex: 1,
+                height: 8,
+                borderRadius: 2,
+                backgroundColor: heatmapColor(entry.percentage),
+              }}
+              testID="meso-card-heatmap-cell"
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+
+  return (
+    <Animated.View style={highlighted ? { transform: [{ scale: 1.0 }] } : undefined} testID="meso-card-wrapper">
+      <Card
+        variant="outline"
+        elevation={2}
+        borderColor={highlighted ? BRAND_PRIMARY : BORDER_DEFAULT}
+        className={className}
+        style={[
+          { borderColor: borderColor as unknown as string },
+          highlighted
+            ? { boxShadow: '0 0 12px 2px rgba(255,121,0,0.25)' }
+            : undefined,
+        ]}
+        testID="meso-card"
+        {...props}
+      >
+        <View
+          className="flex-row"
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 3, zIndex: 1 }}
+          accessibilityElementsHidden
+          testID="meso-card-accent"
+        >
+          {ACCENT_STOPS.map((color) => (
+            <View key={color} style={{ flex: 1, backgroundColor: color }} />
+          ))}
+        </View>
+
+        {isExpandable ? (
+          <Pressable
+            onPress={onToggle}
+            accessibilityRole="button"
+            accessibilityLabel={`${name}, ${goal}, ${weekRange}`}
+            aria-expanded={expanded}
+            testID="meso-card-toggle"
+          >
+            {header}
+          </Pressable>
+        ) : (
+          <View
+            accessibilityLabel={`${name}, ${goal}, ${weekRange}`}
+            testID="meso-card-static"
+          >
+            {header}
+          </View>
+        )}
+
+        {expanded && weeks.length > 0 && (
+          <View
+            style={{ borderTopWidth: 1, borderTopColor: BORDER_DEFAULT }}
+            testID="meso-card-weeks"
+          >
+            {weeks.map((week) => (
+              <WeekRow
+                key={week.weekNumber}
+                {...week}
+                totalWeeks={week.totalWeeks ?? totalWeeks}
+                isCurrent={week.isCurrent ?? week.weekNumber === currentWeek}
+              />
+            ))}
+          </View>
+        )}
+      </Card>
+    </Animated.View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { View } from 'react-native'
+import { MesoProgressBar, type Meso } from './MesoProgressBar'
+
+const meta: Meta<typeof MesoProgressBar> = {
+  title: 'Custom/Workout/MesoProgressBar',
+  component: MesoProgressBar,
+  tags: ['autodocs'],
+  argTypes: {
+    activeMesoId: {
+      control: 'text',
+      description: 'Id of the highlighted meso, synced with MesoCard selection',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof MesoProgressBar>
+
+const sampleMesos: Meso[] = [
+  { id: 'm1', name: 'Accumulation', weekCount: 4, status: 'completed' },
+  { id: 'm2', name: 'Intensification', weekCount: 3, status: 'current', currentWeek: 2 },
+  { id: 'm3', name: 'Peak', weekCount: 2, status: 'upcoming' },
+  { id: 'm4', name: 'Deload', weekCount: 1, status: 'upcoming' },
+]
+
+export const Default: Story = {
+  args: {
+    mesos: sampleMesos,
+    activeMesoId: null,
+    onMesoPress: () => {},
+  },
+  render: (args) => (
+    <View style={{ paddingVertical: 24, width: 480 }}>
+      <MesoProgressBar {...args} />
+    </View>
+  ),
+}
+
+export const ActiveCurrent: Story = {
+  args: {
+    mesos: sampleMesos,
+    activeMesoId: 'm2',
+    onMesoPress: () => {},
+  },
+  render: (args) => (
+    <View style={{ paddingVertical: 24, width: 480 }}>
+      <MesoProgressBar {...args} />
+    </View>
+  ),
+}
+
+export const FirstWeekProgress: Story = {
+  args: {
+    mesos: [
+      { id: 'a', name: 'Base', weekCount: 5, status: 'current', currentWeek: 1 },
+      { id: 'b', name: 'Build', weekCount: 4, status: 'upcoming' },
+    ],
+    activeMesoId: 'a',
+    onMesoPress: () => {},
+  },
+  render: (args) => (
+    <View style={{ paddingVertical: 24, width: 480 }}>
+      <MesoProgressBar {...args} />
+    </View>
+  ),
+}
+
+function InteractiveDemo() {
+  const [activeMesoId, setActiveMesoId] = useState<string | null>('m2')
+  return (
+    <View style={{ paddingVertical: 24, width: 480 }}>
+      <MesoProgressBar
+        mesos={sampleMesos}
+        activeMesoId={activeMesoId}
+        onMesoPress={setActiveMesoId}
+      />
+    </View>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
+}

--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { MesoProgressBar, type Meso } from './MesoProgressBar'
+
+const mesos: Meso[] = [
+  { id: 'm1', name: 'Accumulation', weekCount: 4, status: 'completed' },
+  { id: 'm2', name: 'Intensification', weekCount: 3, status: 'current', currentWeek: 2 },
+  { id: 'm3', name: 'Peak', weekCount: 2, status: 'upcoming' },
+]
+
+describe('MesoProgressBar', () => {
+  describe('rendering', () => {
+    it('renders the container', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-progress-bar')).toBeInTheDocument()
+    })
+
+    it('renders one segment per meso', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-m1')).toBeInTheDocument()
+      expect(screen.getByTestId('meso-segment-m2')).toBeInTheDocument()
+      expect(screen.getByTestId('meso-segment-m3')).toBeInTheDocument()
+    })
+
+    it('sets flex proportional to weekCount', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-m1')).toHaveStyle({ flex: 4 })
+      expect(screen.getByTestId('meso-segment-m2')).toHaveStyle({ flex: 3 })
+      expect(screen.getByTestId('meso-segment-m3')).toHaveStyle({ flex: 2 })
+    })
+
+    it('renders no segments for an empty mesos array', () => {
+      render(<MesoProgressBar mesos={[]} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-progress-bar')).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('status colors', () => {
+    it('applies completed color at 0.3 alpha', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-inner-m1')).toHaveStyle({
+        backgroundColor: 'rgba(20,184,166,0.3)',
+      })
+    })
+
+    it('applies current color at 0.5 alpha', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-inner-m2')).toHaveStyle({
+        backgroundColor: 'rgba(255,121,0,0.5)',
+      })
+    })
+
+    it('applies upcoming color', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-inner-m3')).toHaveStyle({
+        backgroundColor: 'rgba(255,255,255,0.06)',
+      })
+    })
+  })
+
+  describe('current week progress fill', () => {
+    it('renders a solid fill for the current meso when progress > 0', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      const fill = screen.getByTestId('meso-segment-fill-m2')
+      expect(fill).toBeInTheDocument()
+      expect(fill).toHaveStyle({ width: '66.66666666666666%' })
+    })
+
+    it('does not render a fill for completed or upcoming mesos', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.queryByTestId('meso-segment-fill-m1')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('meso-segment-fill-m3')).not.toBeInTheDocument()
+    })
+
+    it('does not render a fill when current meso has no currentWeek', () => {
+      const noProgress: Meso[] = [
+        { id: 'c', name: 'Current', weekCount: 3, status: 'current' },
+      ]
+      render(<MesoProgressBar mesos={noProgress} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.queryByTestId('meso-segment-fill-c')).not.toBeInTheDocument()
+    })
+
+    it('clamps progress to 100% when currentWeek exceeds weekCount', () => {
+      const overflow: Meso[] = [
+        { id: 'c', name: 'Current', weekCount: 3, status: 'current', currentWeek: 5 },
+      ]
+      render(<MesoProgressBar mesos={overflow} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByTestId('meso-segment-fill-c')).toHaveStyle({ width: '100%' })
+    })
+  })
+
+  describe('active highlighting', () => {
+    it('applies a brand border to the active segment', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId="m2" onMesoPress={vi.fn()} />)
+      const style = screen.getByTestId('meso-segment-inner-m2').getAttribute('style') ?? ''
+      expect(style).toContain('border-top-width: 2px')
+      expect(style).toContain('border-top-color: rgb(255, 121, 0)')
+    })
+
+    it('does not apply a border to inactive segments', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId="m2" onMesoPress={vi.fn()} />)
+      const inner = screen.getByTestId('meso-segment-inner-m1')
+      const style = inner.getAttribute('style') ?? ''
+      expect(style).not.toContain('border-top-width: 2px')
+    })
+
+    it('highlights nothing when activeMesoId is null', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      const inner = screen.getByTestId('meso-segment-inner-m2')
+      const style = inner.getAttribute('style') ?? ''
+      expect(style).not.toContain('border-top-width: 2px')
+    })
+  })
+
+  describe('interaction', () => {
+    it('calls onMesoPress with the meso id when a segment is pressed', () => {
+      const onMesoPress = vi.fn()
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={onMesoPress} />)
+      fireEvent.click(screen.getByTestId('meso-segment-m3'))
+      expect(onMesoPress).toHaveBeenCalledWith('m3')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('exposes each segment as a button with name and status', () => {
+      render(<MesoProgressBar mesos={mesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+      expect(screen.getByLabelText('Accumulation, completed')).toBeInTheDocument()
+      expect(screen.getByLabelText('Intensification, current')).toBeInTheDocument()
+      expect(screen.getByLabelText('Peak, upcoming')).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <MesoProgressBar mesos={mesos} activeMesoId="m2" onMesoPress={vi.fn()} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
@@ -1,0 +1,161 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useState } from 'react'
+import { View, Pressable, Animated, type ViewProps } from 'react-native'
+
+const BRAND_PRIMARY = '#FF7900'
+
+export type MesoStatus = 'completed' | 'current' | 'upcoming'
+
+export interface Meso {
+  id: string
+  name: string
+  weekCount: number
+  status: MesoStatus
+  /**
+   * 1-based week index of progress within a `current` meso.
+   * Drives the solid fill width. Ignored for non-current mesos.
+   */
+  currentWeek?: number
+}
+
+export interface MesoProgressBarProps extends ViewProps {
+  mesos: Meso[]
+  activeMesoId: string | null
+  onMesoPress: (mesoId: string) => void
+  className?: string
+}
+
+const segmentBgColors: Record<MesoStatus, string> = {
+  completed: 'rgba(20,184,166,0.3)',
+  current: 'rgba(255,121,0,0.5)',
+  upcoming: 'rgba(255,255,255,0.06)',
+}
+
+function clampProgress(currentWeek: number | undefined, weekCount: number): number {
+  if (currentWeek == null || weekCount <= 0) return 0
+  const ratio = currentWeek / weekCount
+  return Math.max(0, Math.min(1, ratio))
+}
+
+interface SegmentProps {
+  meso: Meso
+  isActive: boolean
+  onPress: (id: string) => void
+}
+
+function MesoSegment({ meso, isActive, onPress }: SegmentProps) {
+  const [pressScale] = useState(() => new Animated.Value(1))
+
+  const handlePressIn = () => {
+    Animated.timing(pressScale, {
+      toValue: 0.98,
+      duration: 150,
+      useNativeDriver: true,
+    }).start()
+  }
+
+  const handlePressOut = () => {
+    Animated.timing(pressScale, {
+      toValue: 1,
+      duration: 150,
+      useNativeDriver: true,
+    }).start()
+  }
+
+  const progress = meso.status === 'current'
+    ? clampProgress(meso.currentWeek, meso.weekCount)
+    : 0
+
+  return (
+    <Pressable
+      style={{ flex: meso.weekCount }}
+      onPress={() => onPress(meso.id)}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      accessibilityRole="button"
+      accessibilityLabel={`${meso.name}, ${meso.status}`}
+      testID={`meso-segment-${meso.id}`}
+    >
+      <Animated.View
+        style={[
+          {
+            height: 8,
+            borderRadius: 4,
+            overflow: 'hidden',
+            backgroundColor: segmentBgColors[meso.status],
+            transform: [{ scale: pressScale }],
+          },
+          isActive
+            ? {
+                borderWidth: 2,
+                borderColor: BRAND_PRIMARY,
+                transform: [{ scale: 1.02 }, { scale: pressScale }],
+              }
+            : undefined,
+        ]}
+        testID={`meso-segment-inner-${meso.id}`}
+      >
+        {meso.status === 'current' && progress > 0 && (
+          <View
+            style={{
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: `${progress * 100}%`,
+              backgroundColor: BRAND_PRIMARY,
+            }}
+            testID={`meso-segment-fill-${meso.id}`}
+          />
+        )}
+      </Animated.View>
+    </Pressable>
+  )
+}
+
+/**
+ * Segmented horizontal bar of mesocycles. Each segment is tappable and its
+ * flex width is proportional to the meso's `weekCount`. The active segment is
+ * highlighted with a 2px brand border to stay in sync with MesoCard selection.
+ *
+ * @example
+ * <MesoProgressBar
+ *   mesos={[
+ *     { id: 'm1', name: 'Accumulation', weekCount: 4, status: 'completed' },
+ *     { id: 'm2', name: 'Intensification', weekCount: 3, status: 'current', currentWeek: 2 },
+ *     { id: 'm3', name: 'Peak', weekCount: 2, status: 'upcoming' },
+ *   ]}
+ *   activeMesoId="m2"
+ *   onMesoPress={(id) => console.log(id)}
+ * />
+ */
+export function MesoProgressBar({
+  mesos,
+  activeMesoId,
+  onMesoPress,
+  className,
+  ...props
+}: MesoProgressBarProps) {
+  return (
+    <View
+      className={className}
+      style={{
+        flexDirection: 'row',
+        gap: 2,
+        paddingHorizontal: 16,
+        alignItems: 'center',
+      }}
+      testID="meso-progress-bar"
+      {...props}
+    >
+      {mesos.map((meso) => (
+        <MesoSegment
+          key={meso.id}
+          meso={meso}
+          isActive={meso.id === activeMesoId}
+          onPress={onMesoPress}
+        />
+      ))}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/WeekRow.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { WeekRow } from './WeekRow'
+
+const meta: Meta<typeof WeekRow> = {
+  title: 'Custom/Workout/WeekRow',
+  component: WeekRow,
+  tags: ['autodocs'],
+  argTypes: {
+    weekNumber: { control: 'number', description: 'Week index (1-based)' },
+    totalWeeks: { control: 'number', description: 'Weeks in the mesocycle' },
+    intensityLevel: {
+      control: { type: 'range', min: 0, max: 1, step: 0.05 },
+      description: 'Planned intensity, 0-1',
+    },
+    intensityThreshold: {
+      control: { type: 'range', min: 0, max: 1, step: 0.05 },
+      description: 'MRV/overexertion threshold, 0-1',
+    },
+    isCurrent: { control: 'boolean', description: 'Active week highlight' },
+    isDeload: { control: 'boolean', description: 'Deload week styling' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof WeekRow>
+
+export const Default: Story = {
+  args: {
+    weekNumber: 1,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'completed' },
+      { name: 'Lower', status: 'completed' },
+      { name: 'Full', status: 'upcoming' },
+    ],
+    intensityLevel: 0.45,
+    intensityThreshold: 0.8,
+  },
+}
+
+export const CurrentWeek: Story = {
+  args: {
+    weekNumber: 3,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Push', status: 'completed' },
+      { name: 'Pull', status: 'current' },
+      { name: 'Legs', status: 'upcoming' },
+    ],
+    intensityLevel: 0.75,
+    intensityThreshold: 0.8,
+    isCurrent: true,
+  },
+}
+
+export const DeloadWeek: Story = {
+  args: {
+    weekNumber: 4,
+    totalWeeks: 4,
+    workouts: [
+      { name: 'Upper', status: 'upcoming' },
+      { name: 'Lower', status: 'upcoming' },
+    ],
+    intensityLevel: 0.3,
+    intensityThreshold: 0.8,
+    isDeload: true,
+  },
+}
+
+export const MesocycleProgression: Story = {
+  render: () => (
+    <View style={{ gap: 2, padding: 16, maxWidth: 420 }}>
+      <WeekRow
+        weekNumber={1}
+        totalWeeks={4}
+        workouts={[
+          { name: 'Upper', status: 'completed' },
+          { name: 'Lower', status: 'completed' },
+          { name: 'Full', status: 'completed' },
+        ]}
+        intensityLevel={0.45}
+        intensityThreshold={0.8}
+      />
+      <WeekRow
+        weekNumber={2}
+        totalWeeks={4}
+        workouts={[
+          { name: 'Upper', status: 'completed' },
+          { name: 'Lower', status: 'completed' },
+          { name: 'Full', status: 'completed' },
+        ]}
+        intensityLevel={0.6}
+        intensityThreshold={0.8}
+      />
+      <WeekRow
+        weekNumber={3}
+        totalWeeks={4}
+        workouts={[
+          { name: 'Upper', status: 'completed' },
+          { name: 'Lower', status: 'current' },
+          { name: 'Full', status: 'upcoming' },
+        ]}
+        intensityLevel={0.78}
+        intensityThreshold={0.8}
+        isCurrent
+      />
+      <WeekRow
+        weekNumber={4}
+        totalWeeks={4}
+        workouts={[
+          { name: 'Upper', status: 'upcoming' },
+          { name: 'Lower', status: 'upcoming' },
+        ]}
+        intensityLevel={0.3}
+        intensityThreshold={0.8}
+        isDeload
+      />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/WeekRow.test.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { WeekRow } from './WeekRow'
+import type { WeekRowWorkout } from './WeekRow'
+
+const workouts: WeekRowWorkout[] = [
+  { name: 'Upper', status: 'completed' },
+  { name: 'Lower', status: 'current' },
+  { name: 'Full', status: 'upcoming' },
+]
+
+const baseProps = {
+  weekNumber: 1,
+  totalWeeks: 4,
+  workouts,
+  intensityLevel: 0.55,
+}
+
+describe('WeekRow', () => {
+  describe('rendering', () => {
+    it('renders the week number label', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(screen.getByTestId('week-row-number')).toHaveTextContent('W1')
+    })
+
+    it('renders a workout pill for each workout', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(screen.getAllByTestId('workout-pill')).toHaveLength(3)
+    })
+
+    it('renders the intensity bar', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(screen.getByTestId('week-row-intensity')).toBeInTheDocument()
+      expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
+    })
+
+    it('passes the threshold through to the intensity bar', () => {
+      render(<WeekRow {...baseProps} intensityThreshold={0.8} />)
+      expect(screen.getByTestId('intensity-threshold')).toBeInTheDocument()
+    })
+
+    it('omits the threshold line when not provided', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(screen.queryByTestId('intensity-threshold')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('current week', () => {
+    it('renders the current week marker dot', () => {
+      render(<WeekRow {...baseProps} isCurrent />)
+      expect(screen.getByTestId('week-row-current-dot')).toBeInTheDocument()
+    })
+
+    it('does not render the marker dot when not current', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(screen.queryByTestId('week-row-current-dot')).not.toBeInTheDocument()
+    })
+
+    it('applies the current-week tint and left border', () => {
+      render(<WeekRow {...baseProps} isCurrent />)
+      const style = screen.getByTestId('week-row').getAttribute('style') ?? ''
+      expect(style).toContain('background-color')
+      expect(style).toContain('border-left')
+    })
+  })
+
+  describe('deload week', () => {
+    it('renders all pills with the deload status', () => {
+      render(<WeekRow {...baseProps} isDeload />)
+      expect(screen.getAllByLabelText(/workout, deload/)).toHaveLength(3)
+    })
+
+    it('applies a purple tint to the row', () => {
+      render(<WeekRow {...baseProps} isDeload />)
+      const style = screen.getByTestId('week-row').getAttribute('style') ?? ''
+      expect(style).toContain('background-color')
+    })
+  })
+
+  describe('interaction', () => {
+    it('invokes onPress for a pressable workout', () => {
+      const onPress = vi.fn()
+      render(
+        <WeekRow
+          {...baseProps}
+          workouts={[{ name: 'Upper', status: 'current', onPress }]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('workout-pill-pressable'))
+      expect(onPress).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has a descriptive accessibility label', () => {
+      render(<WeekRow {...baseProps} />)
+      expect(
+        screen.getByLabelText('Week 1 of 4, 3 workouts'),
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(<WeekRow {...baseProps} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations as a current deload week', async () => {
+      const { container } = render(
+        <WeekRow {...baseProps} isCurrent isDeload intensityThreshold={0.8} />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/WeekRow.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.tsx
@@ -1,0 +1,140 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, type ViewProps } from 'react-native'
+import { WorkoutPill, type WorkoutPillStatus } from './WorkoutPill'
+import { IntensityBar } from './IntensityBar'
+
+const BRAND_PRIMARY = '#FF7900'
+
+export interface WeekRowWorkout {
+  name: string
+  status: WorkoutPillStatus
+  onPress?: () => void
+}
+
+export interface WeekRowProps extends ViewProps {
+  /** Week index within the mesocycle (1-based) */
+  weekNumber: number
+  /** Total weeks in the mesocycle */
+  totalWeeks: number
+  /** Workouts scheduled for this week */
+  workouts: WeekRowWorkout[]
+  /** Planned intensity for the week, 0-1 */
+  intensityLevel: number
+  /** Optional MRV/overexertion threshold, 0-1 */
+  intensityThreshold?: number
+  /** Highlights this row as the active week */
+  isCurrent?: boolean
+  /** Renders this row as a deload week (purple tint, deload pills) */
+  isDeload?: boolean
+  className?: string
+}
+
+/**
+ * A single week within a mesocycle, showing the week number, its workout pills,
+ * and a right-aligned vertical intensity indicator.
+ *
+ * @example
+ * <WeekRow
+ *   weekNumber={1}
+ *   totalWeeks={4}
+ *   workouts={[
+ *     { name: 'Upper', status: 'completed' },
+ *     { name: 'Lower', status: 'current' },
+ *   ]}
+ *   intensityLevel={0.55}
+ *   intensityThreshold={0.8}
+ *   isCurrent
+ * />
+ */
+export function WeekRow({
+  weekNumber,
+  totalWeeks,
+  workouts,
+  intensityLevel,
+  intensityThreshold,
+  isCurrent = false,
+  isDeload = false,
+  className,
+  ...props
+}: WeekRowProps) {
+  const rowStyle: Record<string, unknown> = {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    gap: 12,
+  }
+
+  if (isDeload) {
+    rowStyle.backgroundColor = 'rgba(147,51,234,0.06)'
+  }
+
+  if (isCurrent) {
+    rowStyle.backgroundColor = 'rgba(255,121,0,0.04)'
+    rowStyle.borderLeftWidth = 2
+    rowStyle.borderLeftColor = BRAND_PRIMARY
+  }
+
+  return (
+    <View
+      className={className}
+      style={rowStyle}
+      accessibilityLabel={`Week ${weekNumber} of ${totalWeeks}, ${workouts.length} workouts`}
+      testID="week-row"
+      {...props}
+    >
+      <View
+        style={{ flexDirection: 'row', alignItems: 'center', width: 32, gap: 4 }}
+        testID="week-row-number"
+      >
+        {isCurrent && (
+          <View
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 3,
+              backgroundColor: BRAND_PRIMARY,
+            }}
+            accessibilityElementsHidden
+            testID="week-row-current-dot"
+          />
+        )}
+        <Text
+          style={{
+            fontSize: 13,
+            fontWeight: '700',
+            fontFamily: 'Inter, sans-serif',
+            color: isCurrent ? BRAND_PRIMARY : '#F3F4F6',
+          }}
+          accessibilityElementsHidden
+        >
+          {`W${weekNumber}`}
+        </Text>
+      </View>
+
+      <View
+        style={{ flex: 1, flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6 }}
+        testID="week-row-pills"
+      >
+        {workouts.map((workout, i) => (
+          <WorkoutPill
+            key={i}
+            name={workout.name}
+            status={isDeload ? 'deload' : workout.status}
+            onPress={workout.onPress}
+          />
+        ))}
+      </View>
+
+      <View testID="week-row-intensity">
+        <IntensityBar
+          level={intensityLevel}
+          threshold={intensityThreshold}
+          orientation="vertical"
+          size={24}
+          thickness={6}
+        />
+      </View>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { WorkoutCard } from './WorkoutCard'
+import type { ExerciseCardProps } from './ExerciseCard'
+
+const meta: Meta<typeof WorkoutCard> = {
+  title: 'Custom/Workout/WorkoutCard',
+  component: WorkoutCard,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['completed', 'today', 'upcoming'],
+      description: 'Drives left-border color, tint, and opacity',
+    },
+    unit: {
+      control: 'select',
+      options: ['lbs', 'kg'],
+      description: 'Weight unit',
+    },
+    expanded: {
+      control: 'boolean',
+      description: 'Whether contained ExerciseCards are shown',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ padding: 16, maxWidth: 420 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof WorkoutCard>
+
+const sampleExercises: ExerciseCardProps[] = [
+  {
+    name: 'Bench Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 8, weight: 175, unit: 'lbs' },
+    e1rm: { value: 225, unit: 'lbs' },
+    setVelocities: [
+      [1.1, 0.95, 0.82],
+      [0.95, 0.88, 0.78],
+    ],
+    totalPlannedSets: 3,
+  },
+  {
+    name: 'Incline DB Press',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3×10-12 @ RPE 8',
+    previousBest: '70 lbs × 11',
+  },
+]
+
+const muscleGroups = [
+  { group: 'chest', label: 'Chest', volumeStatus: 'productive' as const },
+  { group: 'front-delts', label: 'Front Delts', volumeStatus: 'maintenance' as const },
+  { group: 'triceps', label: 'Triceps', volumeStatus: 'under' as const },
+]
+
+export const Today: Story = {
+  args: {
+    name: 'Upper A',
+    date: 'Mon, Jun 23',
+    duration: '45 min',
+    status: 'today',
+    muscleGroups,
+    totalSets: 18,
+    totalVolume: 12450,
+    unit: 'lbs',
+  },
+}
+
+export const Completed: Story = {
+  args: {
+    name: 'Lower B',
+    date: 'Sat, Jun 21',
+    duration: '52 min',
+    status: 'completed',
+    muscleGroups: [
+      { group: 'quads', label: 'Quads', volumeStatus: 'over' },
+      { group: 'hamstrings', label: 'Hamstrings', volumeStatus: 'productive' },
+      { group: 'glutes', label: 'Glutes', volumeStatus: 'maintenance' },
+    ],
+    totalSets: 20,
+    totalVolume: 18200,
+    unit: 'lbs',
+  },
+}
+
+export const Upcoming: Story = {
+  args: {
+    name: 'Push B',
+    date: 'Wed, Jun 25',
+    status: 'upcoming',
+    muscleGroups,
+    totalSets: 16,
+    unit: 'lbs',
+  },
+}
+
+export const Expanded: Story = {
+  args: {
+    name: 'Upper A',
+    date: 'Mon, Jun 23',
+    duration: '45 min',
+    status: 'today',
+    muscleGroups,
+    totalSets: 18,
+    totalVolume: 12450,
+    unit: 'lbs',
+    expanded: true,
+    onToggle: () => {},
+    exercises: sampleExercises,
+  },
+}
+
+export const NoToggle: Story = {
+  args: {
+    name: 'Pull A',
+    date: 'Thu, Jun 26',
+    status: 'upcoming',
+    muscleGroups: [
+      { group: 'back', label: 'Back', volumeStatus: 'productive' },
+      { group: 'biceps', label: 'Biceps', volumeStatus: 'maintenance' },
+    ],
+    totalSets: 17,
+    unit: 'kg',
+  },
+}

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { WorkoutCard, type WorkoutCardProps } from './WorkoutCard'
+import type { ExerciseCardProps } from './ExerciseCard'
+
+const baseProps: WorkoutCardProps = {
+  name: 'Upper A',
+  date: 'Mon, Jun 23',
+  status: 'today',
+  muscleGroups: [
+    { group: 'chest', label: 'Chest', volumeStatus: 'productive' },
+    { group: 'back', label: 'Back', volumeStatus: 'maintenance' },
+  ],
+  totalSets: 18,
+  unit: 'lbs',
+}
+
+const exercises: ExerciseCardProps[] = [
+  {
+    name: 'Bench Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 8, weight: 175, unit: 'lbs' },
+  },
+  {
+    name: 'Row',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3×10 @ RPE 8',
+  },
+]
+
+describe('WorkoutCard', () => {
+  describe('rendering', () => {
+    it('renders name and date', () => {
+      render(<WorkoutCard {...baseProps} />)
+      expect(screen.getByTestId('workout-card-name')).toHaveTextContent(
+        'Upper A',
+      )
+      expect(screen.getByTestId('workout-card-date')).toHaveTextContent(
+        'Mon, Jun 23',
+      )
+    })
+
+    it('renders the set count in the stats row', () => {
+      render(<WorkoutCard {...baseProps} />)
+      expect(screen.getByTestId('workout-card-stats')).toHaveTextContent(
+        '18 sets',
+      )
+    })
+
+    it('includes duration in stats when provided', () => {
+      render(<WorkoutCard {...baseProps} duration="45 min" />)
+      expect(screen.getByTestId('workout-card-stats')).toHaveTextContent(
+        '45 min',
+      )
+    })
+
+    it('includes total volume with unit when provided', () => {
+      render(<WorkoutCard {...baseProps} totalVolume={12450} unit="lbs" />)
+      expect(screen.getByTestId('workout-card-stats')).toHaveTextContent(
+        '12450 lbs',
+      )
+    })
+
+    it('omits volume from stats when not provided', () => {
+      render(<WorkoutCard {...baseProps} />)
+      expect(screen.getByTestId('workout-card-stats')).not.toHaveTextContent(
+        'lbs',
+      )
+    })
+  })
+
+  describe('muscle groups', () => {
+    it('renders a chip per muscle group', () => {
+      render(<WorkoutCard {...baseProps} />)
+      expect(screen.getAllByTestId('muscle-group-chip')).toHaveLength(2)
+    })
+
+    it('renders chip labels', () => {
+      render(<WorkoutCard {...baseProps} />)
+      const row = screen.getByTestId('workout-card-muscle-groups')
+      expect(row).toHaveTextContent('Chest')
+      expect(row).toHaveTextContent('Back')
+    })
+
+    it('does not render the muscle group row when empty', () => {
+      render(<WorkoutCard {...baseProps} muscleGroups={[]} />)
+      expect(
+        screen.queryByTestId('workout-card-muscle-groups'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('expansion', () => {
+    it('renders exercises when expanded', () => {
+      render(
+        <WorkoutCard
+          {...baseProps}
+          expanded
+          onToggle={() => {}}
+          exercises={exercises}
+        />,
+      )
+      expect(screen.getByTestId('workout-card-exercises')).toBeInTheDocument()
+      expect(screen.getAllByTestId('exercise-card')).toHaveLength(2)
+    })
+
+    it('does not render exercises when collapsed', () => {
+      render(
+        <WorkoutCard
+          {...baseProps}
+          expanded={false}
+          onToggle={() => {}}
+          exercises={exercises}
+        />,
+      )
+      expect(
+        screen.queryByTestId('workout-card-exercises'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('calls onToggle when pressed', () => {
+      const onToggle = vi.fn()
+      render(<WorkoutCard {...baseProps} onToggle={onToggle} />)
+      fireEvent.click(screen.getByTestId('workout-card-toggle'))
+      expect(onToggle).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('status styling', () => {
+    it('dims the card when upcoming', () => {
+      render(<WorkoutCard {...baseProps} status="upcoming" />)
+      expect(screen.getByTestId('workout-card')).toHaveStyle({ opacity: 0.6 })
+    })
+
+    it('does not dim a completed card', () => {
+      render(<WorkoutCard {...baseProps} status="completed" />)
+      expect(screen.getByTestId('workout-card')).not.toHaveStyle({
+        opacity: 0.6,
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('exposes button role and expanded state when expandable', () => {
+      render(
+        <WorkoutCard {...baseProps} expanded onToggle={() => {}} />,
+      )
+      const card = screen.getByRole('button', {
+        name: 'Upper A workout, Mon, Jun 23, today',
+      })
+      expect(card).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <WorkoutCard
+          {...baseProps}
+          duration="45 min"
+          totalVolume={12450}
+          onToggle={() => {}}
+          expanded
+          exercises={exercises}
+        />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
@@ -1,0 +1,226 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, ScrollView, Pressable, type ViewProps } from 'react-native'
+import { Card } from '../../ui/card'
+import { ExerciseCard, type ExerciseCardProps } from './ExerciseCard'
+import {
+  MuscleGroupChip,
+  type VolumeStatus,
+} from './MuscleGroupChip'
+
+export type WorkoutStatus = 'completed' | 'today' | 'upcoming'
+
+/** Spec volume-status vocabulary; mapped to MuscleGroupChip's VolumeStatus internally. */
+export type WorkoutMuscleVolumeStatus =
+  | 'under'
+  | 'maintenance'
+  | 'productive'
+  | 'over'
+
+export interface WorkoutMuscleGroup {
+  /** Muscle group identifier (free-form to match plan data). */
+  group: string
+  /** Display label, may be abbreviated. */
+  label: string
+  /** Volume status relative to landmarks. */
+  volumeStatus?: WorkoutMuscleVolumeStatus
+}
+
+export interface WorkoutCardProps extends ViewProps {
+  name: string
+  date: string
+  /** e.g. "45 min" */
+  duration?: string
+  status: WorkoutStatus
+  muscleGroups: WorkoutMuscleGroup[]
+  totalSets: number
+  /** Total lbs/kg moved across the workout. */
+  totalVolume?: number
+  unit: 'lbs' | 'kg'
+  exercises?: ExerciseCardProps[]
+  expanded?: boolean
+  onToggle?: () => void
+  className?: string
+}
+
+const COLORS = {
+  textPrimary: '#F3F4F6',
+  textSecondary: '#9CA3AF',
+  textTertiary: '#6B7280',
+  statusSuccess: '#14B8A6',
+  brandPrimary: '#FF7900',
+  borderDefault: '#1F1F1F',
+  brandPrimarySubtle: 'rgba(255,121,0,0.06)',
+}
+
+const statusBorderColors: Record<WorkoutStatus, string> = {
+  completed: COLORS.statusSuccess,
+  today: COLORS.brandPrimary,
+  upcoming: COLORS.borderDefault,
+}
+
+/** Maps the spec's volume-status vocabulary onto MuscleGroupChip's enum. */
+const volumeStatusMap: Record<WorkoutMuscleVolumeStatus, VolumeStatus> = {
+  under: 'behind',
+  maintenance: 'ontrack',
+  productive: 'target',
+  over: 'over',
+}
+
+function formatStats(
+  totalSets: number,
+  totalVolume: number | undefined,
+  unit: 'lbs' | 'kg',
+  duration: string | undefined,
+): string {
+  const parts = [`${totalSets} sets`]
+  if (totalVolume != null) parts.push(`${totalVolume} ${unit}`)
+  if (duration) parts.push(duration)
+  return parts.join(' · ')
+}
+
+/**
+ * A workout within a week: name, date, duration, muscle-group pills, and a
+ * stats summary. When expandable it renders contained ExerciseCards on expand.
+ * Status drives a colored left border, today adds a brand tint, and upcoming
+ * is dimmed.
+ *
+ * @example
+ * <WorkoutCard
+ *   name="Upper A"
+ *   date="Mon, Jun 23"
+ *   duration="45 min"
+ *   status="today"
+ *   muscleGroups={[{ group: 'chest', label: 'Chest', volumeStatus: 'productive' }]}
+ *   totalSets={18}
+ *   totalVolume={12450}
+ *   unit="lbs"
+ *   expanded
+ *   onToggle={() => {}}
+ *   exercises={exercises}
+ * />
+ */
+export function WorkoutCard({
+  name,
+  date,
+  duration,
+  status,
+  muscleGroups,
+  totalSets,
+  totalVolume,
+  unit,
+  exercises,
+  expanded = false,
+  onToggle,
+  className,
+  ...props
+}: WorkoutCardProps) {
+  const isExpandable = onToggle != null
+  const isUpcoming = status === 'upcoming'
+  const isToday = status === 'today'
+
+  const summary = (
+    <View style={{ padding: 14 }} testID="workout-card-body">
+      <View className="flex-row items-center" testID="workout-card-header">
+        <Text
+          style={{
+            fontSize: 15,
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontWeight: '700',
+            color: COLORS.textPrimary,
+          }}
+          testID="workout-card-name"
+        >
+          {name}
+        </Text>
+        <View className="flex-1" />
+        <Text
+          style={{
+            fontSize: 11,
+            fontFamily: 'Inter, sans-serif',
+            color: COLORS.textTertiary,
+          }}
+          testID="workout-card-date"
+        >
+          {date}
+        </Text>
+      </View>
+
+      <Text
+        style={{
+          marginTop: 4,
+          fontSize: 12,
+          fontFamily: 'Inter, sans-serif',
+          color: COLORS.textSecondary,
+        }}
+        testID="workout-card-stats"
+      >
+        {formatStats(totalSets, totalVolume, unit, duration)}
+      </Text>
+
+      {muscleGroups.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 5 }}
+          style={{ marginTop: 8 }}
+          testID="workout-card-muscle-groups"
+        >
+          {muscleGroups.map((muscle) => (
+            <MuscleGroupChip
+              key={muscle.group}
+              name={muscle.label}
+              volumeStatus={
+                muscle.volumeStatus
+                  ? volumeStatusMap[muscle.volumeStatus]
+                  : undefined
+              }
+            />
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  )
+
+  return (
+    <Card
+      variant="accent"
+      elevation={1}
+      accentColor={statusBorderColors[status]}
+      bgColor={isToday ? COLORS.brandPrimarySubtle : undefined}
+      className={className}
+      style={isUpcoming ? { opacity: 0.6 } : undefined}
+      testID="workout-card"
+      {...props}
+    >
+      {isExpandable ? (
+        <Pressable
+          onPress={onToggle}
+          accessibilityRole="button"
+          accessibilityLabel={`${name} workout, ${date}, ${status}`}
+          aria-expanded={expanded}
+          testID="workout-card-toggle"
+        >
+          {summary}
+        </Pressable>
+      ) : (
+        <View
+          accessibilityLabel={`${name} workout, ${date}, ${status}`}
+          testID="workout-card-static"
+        >
+          {summary}
+        </View>
+      )}
+
+      {expanded && exercises && exercises.length > 0 && (
+        <View
+          style={{ paddingHorizontal: 8, paddingBottom: 8, gap: 6 }}
+          testID="workout-card-exercises"
+        >
+          {exercises.map((exercise, i) => (
+            <ExerciseCard key={i} {...exercise} />
+          ))}
+        </View>
+      )}
+    </Card>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -25,3 +25,22 @@ export { InputBar, type InputBarProps } from './InputBar'
 export { RestTimer, type RestTimerProps } from './RestTimer'
 export { ExerciseCard, type ExerciseCardProps, type ExerciseCardState } from './ExerciseCard'
 export { SupersetWrapper, type SupersetWrapperProps } from './SupersetWrapper'
+export {
+  MesoProgressBar,
+  type MesoProgressBarProps,
+  type Meso,
+  type MesoStatus,
+} from './MesoProgressBar'
+export { WeekRow, type WeekRowProps, type WeekRowWorkout } from './WeekRow'
+export {
+  WorkoutCard,
+  type WorkoutCardProps,
+  type WorkoutStatus,
+  type WorkoutMuscleGroup,
+  type WorkoutMuscleVolumeStatus,
+} from './WorkoutCard'
+export {
+  MesoCard,
+  type MesoCardProps,
+  type MesoVolumeHeatmapEntry,
+} from './MesoCard'


### PR DESCRIPTION
## Summary

Builds the **4 genuinely-missing Wave-1 program-planning molecules** — the components that were *not* on the `feat/workout-organisms` branch and had to be written from scratch. Completes the molecule layer (§13–§21) alongside PR #27.

> **Stacked on #27** — base is `feat/td-workout-extract` because these compose atoms (WorkoutPill, IntensityBar, MuscleGroupChip) and molecules (ExerciseCard) that land in #27. Retarget to `main` once #27 merges.

### Components (built to spec §15–§18, via a dependency-ordered parallel Workflow)
- **MesoProgressBar §18** — segmented, tappable mesocycle bar (no atom deps; RN View/Pressable). 17 tests.
- **WeekRow §16** — composes WorkoutPill + IntensityBar (vertical); current-week + deload tints. 14 tests.
- **WorkoutCard §15** — titan `Card` + ExerciseCard + MuscleGroupChip; header-only `Pressable` toggle (avoids a nested-interactive a11y violation since ExerciseCards inside are themselves pressable). 15 tests.
- **MesoCard §17** — titan `Card` + WeekRow + `Badge`; 3px gradient accent, volume heatmap strip, highlight-sync state. 15 tests.

Each follows the established `Workout/` pattern: component + unit/jest-axe tests + CSF3 story, `useState` lazy-init for `Animated.Value` (the `react-hooks/refs` rule), inline workout tokens, `testID` targeting.

### Spec gaps resolved (consistently across all 4)
- **No `MuscleGroup` type is exported** anywhere in the repo, though the spec references it. Muscle-group / heatmap keys are typed as `string` (matches plan data).
- **MuscleGroupChip API mismatch**: WorkoutCard keeps the spec's `volumeStatus` vocabulary (`under|maintenance|productive|over`) on its own prop and maps internally to MuscleGroupChip's enum (`behind|ontrack|target|over`) — same alias the chip documents.
- **MesoProgressBar** spec requires a "week progress" fill but gives no progress input — added an optional `currentWeek` per-meso field driving the fill (additive, no required-prop change).

## Verification
- ✅ `pnpm type-check` clean
- ✅ `pnpm test` — **1168 tests pass** (67 files; +61 new)
- ✅ `pnpm lint` — **0 errors** (4 pre-existing `React`-unused warnings, out of scope)

## Follow-ups (unchanged from #27)
- **TD-03.34 badge refactor** (WeightBadge replaces E1rmBadge) — deliberately split out; its own PR after #27 merges (breaking ripple into SetRow/ExerciseCard).
- Visual/Storybook screenshot baselines (Playwright `test:visual`) — deferred.
- Organisms §22–28 + templates §29–33 — later waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
