### PR TITLE
Add ReadinessCheck organism (TD-03.26)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useMemo, useState } from 'react'
+import { View } from 'react-native'
+import { ReadinessCheck, type ReadinessFactor } from './ReadinessCheck'
+
+const FACTOR_SEED: Array<{ id: string; label: string; value: number }> = [
+  { id: 'sleep', label: 'Sleep', value: 4 },
+  { id: 'soreness', label: 'Soreness', value: 3 },
+  { id: 'motivation', label: 'Motivation', value: 5 },
+  { id: 'stress', label: 'Stress', value: 3 },
+]
+
+const staticFactors: ReadinessFactor[] = FACTOR_SEED.map((f) => ({
+  ...f,
+  onChange: () => {},
+}))
+
+const meta: Meta<typeof ReadinessCheck> = {
+  title: 'Custom/Workout/ReadinessCheck',
+  component: ReadinessCheck,
+  tags: ['autodocs'],
+  argTypes: {
+    score: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+      description: 'Computed overall readiness score (0-100), colors the gauge',
+    },
+    warmUpCompleted: {
+      control: 'boolean',
+      description: 'Whether the VBT warm-up set has been performed',
+    },
+    onConfirm: {
+      description: 'Called when the assessment is confirmed and the workout begins',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ReadinessCheck>
+
+export const Default: Story = {
+  args: {
+    factors: staticFactors,
+    score: 78,
+    warmUpCompleted: false,
+    onConfirm: () => {},
+  },
+}
+
+export const HighReadiness: Story = {
+  args: {
+    ...Default.args,
+    score: 92,
+  },
+}
+
+export const LowReadiness: Story = {
+  args: {
+    ...Default.args,
+    factors: FACTOR_SEED.map((f) => ({ ...f, value: 2, onChange: () => {} })),
+    score: 34,
+  },
+}
+
+export const WithWarmUpGood: Story = {
+  args: {
+    ...Default.args,
+    score: 81,
+    warmUpCompleted: true,
+    warmUpValidation: {
+      velocityDeficit: 3,
+      recommendation: 'Velocity on target — proceed with the planned loads.',
+      status: 'good',
+    },
+  },
+}
+
+export const WithWarmUpCaution: Story = {
+  args: {
+    ...Default.args,
+    score: 52,
+    warmUpCompleted: true,
+    warmUpValidation: {
+      velocityDeficit: 18,
+      recommendation: 'Significant velocity loss — consider reducing load 5-10% today.',
+      status: 'caution',
+    },
+  },
+}
+
+function InteractiveReadinessCheck() {
+  const [values, setValues] = useState<Record<string, number>>(
+    Object.fromEntries(FACTOR_SEED.map((f) => [f.id, f.value])),
+  )
+
+  const factors: ReadinessFactor[] = FACTOR_SEED.map((f) => ({
+    id: f.id,
+    label: f.label,
+    value: values[f.id],
+    onChange: (value) => setValues((prev) => ({ ...prev, [f.id]: value })),
+  }))
+
+  const score = useMemo(() => {
+    const total = FACTOR_SEED.reduce((sum, f) => sum + values[f.id], 0)
+    return Math.round((total / (FACTOR_SEED.length * 5)) * 100)
+  }, [values])
+
+  return (
+    <View style={{ maxWidth: 420, padding: 16 }}>
+      <ReadinessCheck
+        factors={factors}
+        score={score}
+        warmUpCompleted
+        warmUpValidation={{
+          velocityDeficit: 6,
+          recommendation: 'Velocity slightly down — warm up thoroughly before top sets.',
+          status: 'moderate',
+        }}
+        onConfirm={() => {}}
+      />
+    </View>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveReadinessCheck />,
+}

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { ReadinessCheck, type ReadinessFactor } from './ReadinessCheck'
+
+function makeFactors(overrides: Partial<Record<string, number>> = {}): ReadinessFactor[] {
+  return [
+    { id: 'sleep', label: 'Sleep', value: overrides.sleep ?? 4, onChange: vi.fn() },
+    { id: 'soreness', label: 'Soreness', value: overrides.soreness ?? 3, onChange: vi.fn() },
+    { id: 'motivation', label: 'Motivation', value: overrides.motivation ?? 5, onChange: vi.fn() },
+    { id: 'stress', label: 'Stress', value: overrides.stress ?? 3, onChange: vi.fn() },
+  ]
+}
+
+const baseProps = {
+  score: 78,
+  warmUpCompleted: false,
+  onConfirm: vi.fn(),
+}
+
+describe('ReadinessCheck', () => {
+  describe('rendering', () => {
+    it('renders the title and one row per factor', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} />)
+      expect(screen.getByTestId('readiness-check-title')).toHaveTextContent(
+        'How are you feeling?',
+      )
+      expect(screen.getByTestId('readiness-check-factor-sleep')).toBeInTheDocument()
+      expect(screen.getByTestId('readiness-check-factor-stress')).toBeInTheDocument()
+    })
+
+    it('renders five emoji options per factor', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} />)
+      // 4 factors x 5 options
+      expect(screen.getAllByTestId('readiness-check-emoji')).toHaveLength(20)
+    })
+
+    it('shows the score in the gauge', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} score={64} />)
+      expect(screen.getByTestId('readiness-check-score-value')).toHaveTextContent('64')
+    })
+  })
+
+  describe('interaction', () => {
+    it('calls the factor onChange with the tapped 1-5 level', () => {
+      const factors = makeFactors()
+      render(<ReadinessCheck {...baseProps} factors={factors} />)
+      const sleepOptions = screen
+        .getByTestId('readiness-check-factor-sleep')
+        .querySelectorAll('[data-testid="readiness-check-emoji"]')
+      fireEvent.click(sleepOptions[0])
+      expect(factors[0].onChange).toHaveBeenCalledWith(1)
+      fireEvent.click(sleepOptions[4])
+      expect(factors[0].onChange).toHaveBeenCalledWith(5)
+    })
+
+    it('marks the selected level as checked', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors({ sleep: 2 })} />)
+      const sleepOptions = screen
+        .getByTestId('readiness-check-factor-sleep')
+        .querySelectorAll('[data-testid="readiness-check-emoji"]')
+      expect(sleepOptions[1]).toHaveAttribute('aria-checked', 'true')
+      expect(sleepOptions[0]).toHaveAttribute('aria-checked', 'false')
+    })
+
+    it('fires onConfirm when the start button is pressed', () => {
+      const onConfirm = vi.fn()
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} onConfirm={onConfirm} />)
+      fireEvent.click(screen.getByTestId('readiness-check-confirm'))
+      expect(onConfirm).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('warm-up validation', () => {
+    it('does not render the warm-up card until completed', () => {
+      render(
+        <ReadinessCheck
+          {...baseProps}
+          factors={makeFactors()}
+          warmUpValidation={{ velocityDeficit: 5, recommendation: 'OK', status: 'good' }}
+        />,
+      )
+      expect(screen.queryByTestId('readiness-check-warmup')).not.toBeInTheDocument()
+    })
+
+    it('renders deficit, recommendation, and status badge once completed', () => {
+      render(
+        <ReadinessCheck
+          {...baseProps}
+          factors={makeFactors()}
+          warmUpCompleted
+          warmUpValidation={{
+            velocityDeficit: 18,
+            recommendation: 'Reduce load today.',
+            status: 'caution',
+          }}
+        />,
+      )
+      expect(screen.getByTestId('readiness-check-warmup-deficit')).toHaveTextContent(
+        '18% below 14-day average',
+      )
+      expect(screen.getByTestId('readiness-check-warmup-recommendation')).toHaveTextContent(
+        'Reduce load today.',
+      )
+      expect(screen.getByTestId('readiness-check-warmup-badge')).toHaveTextContent('Caution')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('labels each emoji as a radio with level and factor', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} />)
+      const radio = screen.getByLabelText('Sleep level 3 of 5')
+      expect(radio).toHaveAttribute('role', 'radio')
+    })
+
+    it('groups each factor as a radiogroup', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} />)
+      const groups = screen.getAllByRole('radiogroup')
+      expect(groups).toHaveLength(4)
+    })
+
+    it('exposes the readiness score on the gauge', () => {
+      render(<ReadinessCheck {...baseProps} factors={makeFactors()} score={78} />)
+      expect(
+        screen.getByLabelText('Readiness score: 78 out of 100'),
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <ReadinessCheck {...baseProps} factors={makeFactors()} />,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with warm-up and all features', async () => {
+      const { container } = render(
+        <ReadinessCheck
+          factors={makeFactors()}
+          score={88}
+          warmUpCompleted
+          warmUpValidation={{
+            velocityDeficit: 6,
+            recommendation: 'Warm up thoroughly.',
+            status: 'moderate',
+          }}
+          onConfirm={vi.fn()}
+        />,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
@@ -1,0 +1,258 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, Pressable } from 'react-native'
+import { Card } from '../../ui/card'
+import { Badge, type BadgeColor } from '../../ui/badge'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY_SUBTLE = 'rgba(255,121,0,0.12)'
+const STATUS_SUCCESS = '#14B8A6'
+const STATUS_WARNING = '#FFB020'
+const STATUS_ERROR = '#D14343'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+
+/** Emoji option sets per known factor, keyed by lowercase id/label. */
+const EMOJI_SETS: Record<string, readonly string[]> = {
+  sleep: ['😴', '😐', '🙂', '😊', '🤩'],
+  soreness: ['😵', '😣', '😐', '🙂', '💪'],
+  motivation: ['😑', '😐', '🙂', '😄', '🔥'],
+  stress: ['😰', '😟', '😐', '😌', '😎'],
+}
+const DEFAULT_EMOJI_SET = ['😞', '😕', '😐', '🙂', '😄'] as const
+
+export type WarmUpStatus = 'good' | 'moderate' | 'caution'
+
+export interface ReadinessFactor {
+  /** Stable identifier; also used to pick the emoji set (sleep/soreness/motivation/stress). */
+  id: string
+  /** Human label, e.g. "Sleep". */
+  label: string
+  /** Selected level, 1-5. */
+  value: number
+  /** Called with the new 1-5 level when an emoji is tapped. */
+  onChange: (value: number) => void
+}
+
+export interface WarmUpValidation {
+  /** Percent below the 14-day rolling velocity average. */
+  velocityDeficit: number
+  /** Short human recommendation, e.g. "Velocity on target — proceed as planned". */
+  recommendation: string
+  /** Severity of the deficit. */
+  status: WarmUpStatus
+}
+
+export interface ReadinessCheckProps {
+  /** Subjective readiness factors (Sleep, Soreness, Motivation, Stress). */
+  factors: ReadinessFactor[]
+  /** Computed overall readiness score, 0-100. */
+  score: number
+  /** VBT warm-up validation result, shown once the warm-up set is performed. */
+  warmUpValidation?: WarmUpValidation
+  /** Whether the VBT warm-up has been performed. */
+  warmUpCompleted: boolean
+  /** Called when the assessment is confirmed and the workout can begin. */
+  onConfirm: () => void
+  className?: string
+}
+
+/** Maps a 0-100 readiness score onto a status color. */
+function scoreColor(score: number): string {
+  if (score < 40) return STATUS_ERROR
+  if (score < 70) return STATUS_WARNING
+  return STATUS_SUCCESS
+}
+
+const WARMUP_BADGE: Record<WarmUpStatus, { color: BadgeColor; label: string }> = {
+  good: { color: 'success', label: 'Good' },
+  moderate: { color: 'warning', label: 'Moderate' },
+  caution: { color: 'error', label: 'Caution' },
+}
+
+function emojiSet(factor: ReadinessFactor): readonly string[] {
+  return EMOJI_SETS[factor.id.toLowerCase()] ?? EMOJI_SETS[factor.label.toLowerCase()] ?? DEFAULT_EMOJI_SET
+}
+
+interface EmojiSliderProps {
+  factor: ReadinessFactor
+}
+
+/** One factor row: label plus a radiogroup of five tappable emoji. */
+function EmojiSlider({ factor }: EmojiSliderProps) {
+  const emojis = emojiSet(factor)
+  return (
+    <View style={{ marginTop: 14 }} testID={`readiness-check-factor-${factor.id}`}>
+      <Text
+        style={{ fontSize: 12, fontWeight: '500', fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+        testID="readiness-check-factor-label"
+      >
+        {factor.label}
+      </Text>
+      <View
+        className="flex-row items-center"
+        style={{ marginTop: 6, gap: 6 }}
+        accessibilityRole="radiogroup"
+        aria-label={factor.label}
+        testID="readiness-check-factor-options"
+      >
+        {emojis.map((emoji, index) => {
+          const level = index + 1
+          const selected = factor.value === level
+          return (
+            <Pressable
+              key={level}
+              onPress={() => factor.onChange(level)}
+              accessibilityRole="radio"
+              accessibilityLabel={`${factor.label} level ${level} of 5`}
+              aria-checked={selected}
+              testID="readiness-check-emoji"
+              style={({ pressed }) => ({
+                flex: 1,
+                alignItems: 'center',
+                paddingVertical: 8,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: selected ? BRAND_PRIMARY : WORKOUT_TOKENS.border.default,
+                backgroundColor: selected ? BRAND_PRIMARY_SUBTLE : WORKOUT_TOKENS.surface.raised,
+                opacity: selected ? 1 : pressed ? 0.8 : 0.55,
+                transform: [{ scale: selected ? 1.06 : 1 }],
+              })}
+            >
+              <Text style={{ fontSize: 20 }}>{emoji}</Text>
+            </Pressable>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+/** Circular score gauge: 60px ring colored by range with the score centered. */
+function ScoreGauge({ score }: { score: number }) {
+  const color = scoreColor(score)
+  return (
+    <View
+      accessibilityRole="image"
+      accessibilityLabel={`Readiness score: ${score} out of 100`}
+      testID="readiness-check-score"
+      style={{
+        width: 60,
+        height: 60,
+        borderRadius: 30,
+        borderWidth: 4,
+        borderColor: color,
+        backgroundColor: WORKOUT_TOKENS.surface.raised,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Text
+        style={{ fontSize: 20, fontWeight: '700', fontFamily: '"Space Grotesk", sans-serif', color }}
+        testID="readiness-check-score-value"
+      >
+        {score}
+      </Text>
+    </View>
+  )
+}
+
+/** VBT warm-up validation card with status badge and recommendation. */
+function WarmUpCard({ validation }: { validation: WarmUpValidation }) {
+  const badge = WARMUP_BADGE[validation.status]
+  return (
+    <View
+      style={{
+        marginTop: 16,
+        padding: 12,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: WORKOUT_TOKENS.border.default,
+        backgroundColor: WORKOUT_TOKENS.surface.raised,
+      }}
+      testID="readiness-check-warmup"
+    >
+      <View className="flex-row items-center justify-between" style={{ gap: 8 }}>
+        <Text
+          style={{ fontSize: 12, fontWeight: '600', fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+          testID="readiness-check-warmup-deficit"
+        >
+          {`Velocity ${validation.velocityDeficit}% below 14-day average`}
+        </Text>
+        <Badge variant="subtle" color={badge.color} size="sm" testID="readiness-check-warmup-badge">
+          {badge.label}
+        </Badge>
+      </View>
+      <Text
+        style={{ marginTop: 6, fontSize: 13, fontFamily: 'Inter, sans-serif', color: TEXT_PRIMARY }}
+        testID="readiness-check-warmup-recommendation"
+      >
+        {validation.recommendation}
+      </Text>
+    </View>
+  )
+}
+
+/**
+ * Pre-workout readiness assessment combining subjective emoji sliders with an
+ * objective VBT warm-up validation and a computed readiness score.
+ *
+ * @example
+ * <ReadinessCheck
+ *   factors={[{ id: 'sleep', label: 'Sleep', value: 4, onChange: setSleep }]}
+ *   score={78}
+ *   warmUpCompleted
+ *   warmUpValidation={{ velocityDeficit: 4, recommendation: 'On target', status: 'good' }}
+ *   onConfirm={start}
+ * />
+ */
+export function ReadinessCheck({
+  factors,
+  score,
+  warmUpValidation,
+  warmUpCompleted,
+  onConfirm,
+  className,
+}: ReadinessCheckProps) {
+  return (
+    <Card variant="outline" elevation={2} className={className} testID="readiness-check">
+      <View style={{ padding: 16 }}>
+        <View className="flex-row items-center justify-between" style={{ gap: 12 }}>
+          <Text
+            style={{ fontSize: 18, fontWeight: '700', fontFamily: '"Space Grotesk", sans-serif', color: TEXT_PRIMARY }}
+            testID="readiness-check-title"
+          >
+            How are you feeling?
+          </Text>
+          <ScoreGauge score={score} />
+        </View>
+
+        {factors.map((factor) => (
+          <EmojiSlider key={factor.id} factor={factor} />
+        ))}
+
+        {warmUpCompleted && warmUpValidation && <WarmUpCard validation={warmUpValidation} />}
+
+        <Pressable
+          onPress={onConfirm}
+          accessibilityRole="button"
+          accessibilityLabel="Confirm readiness and start workout"
+          testID="readiness-check-confirm"
+          style={({ pressed }) => ({
+            marginTop: 16,
+            width: '100%',
+            alignItems: 'center',
+            backgroundColor: BRAND_PRIMARY,
+            borderRadius: 8,
+            paddingVertical: 12,
+            opacity: pressed ? 0.8 : 1,
+          })}
+        >
+          <Text style={{ fontSize: 13, fontWeight: '700', fontFamily: 'Inter, sans-serif', color: '#FFFFFF' }}>
+            Start Workout
+          </Text>
+        </Pressable>
+      </View>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -54,3 +54,10 @@ export {
   type MesoCardProps,
   type MesoVolumeHeatmapEntry,
 } from './MesoCard'
+export {
+  ReadinessCheck,
+  type ReadinessCheckProps,
+  type ReadinessFactor,
+  type WarmUpValidation,
+  type WarmUpStatus,
+} from './ReadinessCheck'


### PR DESCRIPTION
## ReadinessCheck (TD-03.26, spec §27)

A new **organism**-tier component: a pre-workout readiness assessment that composes the titan `Card` and `Badge`. It combines subjective emoji sliders, a computed score gauge, and an objective VBT warm-up validation, with a full-width confirm button to begin the workout.

### What it does
- **Title** "How are you feeling?" (18px Space Grotesk 700) beside a **circular score gauge** (60px) colored by range (error <40, warning <70, success ≥70).
- **Per-factor emoji sliders** — Sleep / Soreness / Motivation / Stress, each a horizontal row of 5 tappable emoji using the spec emoji sets. Selected option is brand-highlighted and scaled.
- **Warm-up validation card** (when `warmUpCompleted` + `warmUpValidation`) showing the velocity deficit vs 14-day average, a status badge (Good/Moderate/Caution), and a recommendation.
- **Confirm button** — full-width brand-primary, fires `onConfirm`.

### Props
`factors[]` ({ id, label, value 1-5, onChange }), `score` (0-100), `warmUpValidation?` ({ velocityDeficit, recommendation, status }), `warmUpCompleted`, `onConfirm`.

### Stories
Default, HighReadiness, LowReadiness, WithWarmUpGood, WithWarmUpCaution, and a stateful **Interactive** demo (emoji selection recomputes the score live).

### Accessibility
- Each factor row is a `radiogroup`; each emoji is a `radio` with `aria-checked` and label "{factor} level {n} of 5".
- Score gauge: `role="image"` with "Readiness score: {score} out of 100".
- Confirm button: proper button role + label.

### Verify
- `pnpm type-check` → 0 errors
- `pnpm lint` (eslint) → 0 warnings/errors in the 3 new files
- `pnpm test -- --run ReadinessCheck` → 13 passed (incl. 2 jest-axe checks)
- `pnpm-lock.yaml` unchanged (no new deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
