### PR TITLE
Add MesoStatusCard organism (TD-03.22)

### DIFF
--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { MesoStatusCard } from './MesoStatusCard'
+
+const meta: Meta<typeof MesoStatusCard> = {
+  title: 'Custom/Workout/MesoStatusCard',
+  component: MesoStatusCard,
+  tags: ['autodocs'],
+  argTypes: {
+    mesoName: {
+      control: 'text',
+      description: 'Mesocycle name shown in the header',
+    },
+    mesoSubtitle: {
+      control: 'text',
+      description: 'Context line, e.g. "Week 6 of 8 · Upper/Lower"',
+    },
+    statusBadge: {
+      control: 'object',
+      description: 'Header status pill { label, variant }',
+    },
+    metrics: {
+      control: 'object',
+      description: 'Prescription-vs-actual metrics, rendered as a 2x2 grid',
+    },
+    gauges: {
+      control: 'object',
+      description: 'Intensity / volume gauges (level 0-1, optional sublabel)',
+    },
+    coaching: {
+      control: 'object',
+      description: 'Optional coaching box with optional bold highlights',
+    },
+    nextTarget: {
+      control: 'object',
+      description: 'Optional next-session target box { icon, text }',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ maxWidth: 380, padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof MesoStatusCard>
+
+export const Default: Story = {
+  args: {
+    mesoName: 'Hypertrophy Block',
+    mesoSubtitle: 'Week 6 of 8 · Upper/Lower',
+    statusBadge: { label: 'On Track', variant: 'success' },
+    metrics: [
+      { label: 'Prescribed', value: '3×8 @ RPE 8' },
+      { label: 'Actual', value: '3×8 @ 185 lbs' },
+      { label: 'Volume', value: '+12% vs wk 1' },
+      { label: 'e1RM', value: '232 lbs' },
+    ],
+    gauges: [
+      { label: 'Intensity', level: 0.68, sublabel: 'Actual' },
+      { label: 'Volume', level: 0.82, sublabel: 'vs MRV' },
+    ],
+    coaching: {
+      text: 'Velocity is holding well — add load next session to keep intensity progressive.',
+      highlights: ['add load'],
+    },
+    nextTarget: { icon: '→', text: 'Next: 190 lbs × 8 @ RPE 8.5' },
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    ...Default.args,
+    mesoName: 'Intensification',
+    mesoSubtitle: 'Week 7 of 8 · Push/Pull/Legs',
+    statusBadge: { label: 'Watch Fatigue', variant: 'warning' },
+    gauges: [
+      { label: 'Intensity', level: 0.78, sublabel: 'Actual' },
+      { label: 'Volume', level: 0.94, sublabel: 'vs MRV' },
+    ],
+    coaching: {
+      text: 'Velocity loss is creeping up. Hold load and reduce one set to manage fatigue.',
+      highlights: ['Hold load', 'reduce one set'],
+    },
+  },
+}
+
+export const Overreaching: Story = {
+  args: {
+    ...Default.args,
+    mesoName: 'Peaking Block',
+    mesoSubtitle: 'Week 8 of 8 · Upper/Lower',
+    statusBadge: { label: 'Deload Soon', variant: 'error' },
+    metrics: [
+      { label: 'Prescribed', value: '4×5 @ RPE 9' },
+      { label: 'Actual', value: '4×4 @ 205 lbs' },
+      { label: 'Volume', value: '−8% vs wk 6' },
+      { label: 'e1RM', value: '241 lbs' },
+    ],
+    gauges: [
+      { label: 'Intensity', level: 0.92, sublabel: 'Actual' },
+      { label: 'Volume', level: 0.45, sublabel: 'vs MRV' },
+    ],
+    coaching: {
+      text: 'Bar speed has dropped sharply across sessions. Schedule a deload next week.',
+      highlights: ['deload'],
+    },
+    nextTarget: { icon: '↓', text: 'Next: deload — 60% × 3×5' },
+  },
+}
+
+export const Minimal: Story = {
+  args: {
+    mesoName: 'Base Phase',
+    mesoSubtitle: 'Week 2 of 6 · Full Body',
+    statusBadge: { label: 'On Track', variant: 'success' },
+    metrics: [
+      { label: 'Prescribed', value: '3×10 @ RPE 7' },
+      { label: 'Actual', value: '3×10 @ 135 lbs' },
+    ],
+    gauges: [{ label: 'Intensity', level: 0.5 }],
+  },
+}

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { MesoStatusCard, type MesoStatusCardProps } from './MesoStatusCard'
+
+const baseProps: MesoStatusCardProps = {
+  mesoName: 'Hypertrophy Block',
+  mesoSubtitle: 'Week 6 of 8 · Upper/Lower',
+  statusBadge: { label: 'On Track', variant: 'success' },
+  metrics: [
+    { label: 'Prescribed', value: '3×8 @ RPE 8' },
+    { label: 'Actual', value: '3×8 @ 185 lbs' },
+    { label: 'Volume', value: '+12% vs wk 1' },
+    { label: 'e1RM', value: '232 lbs' },
+  ],
+  gauges: [
+    { label: 'Intensity', level: 0.68, sublabel: 'Actual' },
+    { label: 'Volume', level: 0.82, sublabel: 'vs MRV' },
+  ],
+  coaching: {
+    text: 'Velocity is holding — add load next session.',
+    highlights: ['add load'],
+  },
+  nextTarget: { icon: '→', text: 'Next: 190 lbs × 8' },
+}
+
+describe('MesoStatusCard', () => {
+  describe('rendering', () => {
+    it('renders the card, name, and subtitle', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      expect(screen.getByTestId('meso-status-card')).toBeInTheDocument()
+      expect(screen.getByTestId('meso-status-card-name')).toHaveTextContent(
+        'Hypertrophy Block',
+      )
+      expect(screen.getByTestId('meso-status-card-subtitle')).toHaveTextContent(
+        'Week 6 of 8 · Upper/Lower',
+      )
+    })
+
+    it('renders the 3px gradient top accent', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      expect(screen.getByTestId('meso-status-card-accent')).toBeInTheDocument()
+    })
+
+    it('renders the status badge with its label', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      expect(screen.getByTestId('meso-status-card-badge')).toHaveTextContent(
+        'On Track',
+      )
+    })
+  })
+
+  describe('metrics grid', () => {
+    it('renders one cell per metric with label and value', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      const cells = screen.getAllByTestId('meso-status-card-metric')
+      expect(cells).toHaveLength(4)
+      expect(screen.getByText('Prescribed')).toBeInTheDocument()
+      expect(screen.getByText('3×8 @ 185 lbs')).toBeInTheDocument()
+    })
+
+    it('does not render the metrics grid when empty', () => {
+      render(<MesoStatusCard {...baseProps} metrics={[]} />)
+      expect(
+        screen.queryByTestId('meso-status-card-metrics'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('gauges', () => {
+    it('renders one gauge per entry with a marker', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      expect(screen.getAllByTestId('meso-status-card-gauge')).toHaveLength(2)
+      expect(
+        screen.getAllByTestId('meso-status-card-gauge-marker'),
+      ).toHaveLength(2)
+    })
+
+    it('renders a 50% center line per gauge', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      const center = screen.getAllByTestId('meso-status-card-gauge-center')[0]
+      expect(center).toHaveStyle({ left: '50%' })
+    })
+
+    it('exposes gauge level via progressbar value', () => {
+      render(
+        <MesoStatusCard
+          {...baseProps}
+          gauges={[{ label: 'Intensity', level: 0.7 }]}
+        />,
+      )
+      const gauge = screen.getByLabelText('Intensity: 70%')
+      expect(gauge).toHaveAttribute('role', 'progressbar')
+      expect(gauge).toHaveAttribute('aria-valuenow', '70')
+    })
+
+    it('clamps out-of-range levels', () => {
+      render(
+        <MesoStatusCard
+          {...baseProps}
+          gauges={[{ label: 'Volume', level: 1.7 }]}
+        />,
+      )
+      expect(screen.getByLabelText('Volume: 100%')).toBeInTheDocument()
+    })
+  })
+
+  describe('coaching', () => {
+    it('renders coaching copy with bolded highlights', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      const box = screen.getByTestId('meso-status-card-coaching')
+      expect(box).toHaveTextContent('Velocity is holding — add load next session.')
+      expect(screen.getByText('add load')).toBeInTheDocument()
+    })
+
+    it('omits the coaching box when not provided', () => {
+      render(<MesoStatusCard {...baseProps} coaching={undefined} />)
+      expect(
+        screen.queryByTestId('meso-status-card-coaching'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('next target', () => {
+    it('renders the next-target box with icon and text', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      const box = screen.getByTestId('meso-status-card-next-target')
+      expect(box).toHaveTextContent('Next: 190 lbs × 8')
+    })
+
+    it('omits the next-target box when not provided', () => {
+      render(<MesoStatusCard {...baseProps} nextTarget={undefined} />)
+      expect(
+        screen.queryByTestId('meso-status-card-next-target'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('exposes the card as an article with a descriptive label', () => {
+      render(<MesoStatusCard {...baseProps} />)
+      const article = screen.getByRole('article')
+      expect(article).toHaveAttribute(
+        'aria-label',
+        'Mesocycle status for Hypertrophy Block',
+      )
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(<MesoStatusCard {...baseProps} />)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with all features and every badge variant', async () => {
+      const { container } = render(
+        <>
+          <MesoStatusCard
+            {...baseProps}
+            statusBadge={{ label: 'Watch Fatigue', variant: 'warning' }}
+          />
+          <MesoStatusCard
+            {...baseProps}
+            statusBadge={{ label: 'Deload Soon', variant: 'error' }}
+            coaching={undefined}
+            nextTarget={undefined}
+          />
+        </>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
@@ -1,0 +1,455 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { Fragment, type ReactNode } from 'react'
+import { View, Text, type ViewProps, type ViewStyle } from 'react-native'
+import { Card } from '../../ui/card'
+import { StatusDot } from './StatusDot'
+
+const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY_DARK = '#C45E00'
+const BRAND_PRIMARY_LIGHT = '#FFB066'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+const TEXT_TERTIARY = '#6B7280'
+
+const SUCCESS = '#14B8A6'
+const WARNING = '#FFB020'
+const ERROR = '#D14343'
+
+/** Gradient stops for the 3px top accent: dark -> primary -> light (matches MesoCard). */
+const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]
+
+/** Card surface gradient: surface-elevated -> near-black at 135deg. */
+const CARD_GRADIENT =
+  'linear-gradient(135deg, #191919 0%, rgba(25,25,25,0.95) 100%)'
+
+/** Gauge track gradient (teal -> amber -> red) at 0.25 alpha. */
+const GAUGE_GRADIENT =
+  'linear-gradient(90deg, rgba(20,184,166,0.25) 0%, rgba(255,176,32,0.25) 50%, rgba(209,67,67,0.25) 100%)'
+
+export type MesoStatusBadgeVariant = 'success' | 'warning' | 'error'
+
+const STATUS_VARIANTS: Record<
+  MesoStatusBadgeVariant,
+  { bg: string; border: string; text: string }
+> = {
+  success: { bg: 'rgba(20,184,166,0.15)', border: 'rgba(20,184,166,0.3)', text: SUCCESS },
+  warning: { bg: 'rgba(255,176,32,0.15)', border: 'rgba(255,176,32,0.3)', text: WARNING },
+  error: { bg: 'rgba(209,67,67,0.15)', border: 'rgba(209,67,67,0.25)', text: ERROR },
+}
+
+export interface MesoStatusBadge {
+  /** Short status label, e.g. "On Track". */
+  label: string
+  /** Color treatment for the badge. */
+  variant: MesoStatusBadgeVariant
+}
+
+export interface MesoStatusMetric {
+  /** Cell label, e.g. "Prescribed". */
+  label: string
+  /** Cell value, e.g. "3×8 @ RPE 8". */
+  value: string
+}
+
+export interface MesoStatusGauge {
+  /** Gauge label, e.g. "Intensity". */
+  label: string
+  /** Fill position 0-1; the 14px marker sits at this level. */
+  level: number
+  /** Optional right-aligned sublabel, e.g. "Prescribed". */
+  sublabel?: string
+}
+
+export interface MesoStatusCoaching {
+  /** Coaching recommendation copy. */
+  text: string
+  /** Substrings within `text` to render in bold. */
+  highlights?: string[]
+}
+
+export interface MesoStatusNextTarget {
+  /** Leading glyph/emoji, e.g. "→" or "🎯". */
+  icon: string
+  /** Next-session target copy. */
+  text: string
+}
+
+export interface MesoStatusCardProps extends ViewProps {
+  /** Mesocycle name, e.g. "Hypertrophy Block". */
+  mesoName: string
+  /** Context line, e.g. "Week 6 of 8 · Upper/Lower". */
+  mesoSubtitle: string
+  /** Status pill in the header. */
+  statusBadge: MesoStatusBadge
+  /** Prescription-vs-actual metrics rendered as a 2x2 grid. */
+  metrics: MesoStatusMetric[]
+  /** Intensity / volume gauges stacked vertically. */
+  gauges: MesoStatusGauge[]
+  /** Optional coaching recommendation box. */
+  coaching?: MesoStatusCoaching
+  /** Optional next-session target box. */
+  nextTarget?: MesoStatusNextTarget
+  className?: string
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+/** Marker fill color by gauge zone: teal 0-0.4, amber 0.4-0.7, red 0.7-1.0. */
+function getGaugeZoneColor(level: number): string {
+  if (level >= 0.7) return ERROR
+  if (level >= 0.4) return WARNING
+  return SUCCESS
+}
+
+/** Splits `text` into nodes, bolding any segment that exactly matches a highlight. */
+function renderCoachingText(text: string, highlights?: string[]): ReactNode {
+  if (!highlights || highlights.length === 0) return text
+  const escaped = highlights
+    .filter(Boolean)
+    .map((h) => h.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  if (escaped.length === 0) return text
+  const regex = new RegExp(`(${escaped.join('|')})`, 'g')
+  return text.split(regex).map((part, index) =>
+    highlights.includes(part) ? (
+      <Text
+        key={`${part}-${index}`}
+        style={{ fontWeight: '700', color: TEXT_PRIMARY }}
+      >
+        {part}
+      </Text>
+    ) : (
+      <Fragment key={`t-${index}`}>{part}</Fragment>
+    ),
+  )
+}
+
+function StatusPill({ badge }: { badge: MesoStatusBadge }) {
+  const colors = STATUS_VARIANTS[badge.variant]
+  return (
+    <View
+      className="flex-row items-center"
+      style={{
+        gap: 5,
+        paddingVertical: 3,
+        paddingHorizontal: 8,
+        borderRadius: 4,
+        borderWidth: 1,
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+      }}
+      testID="meso-status-card-badge"
+    >
+      <View accessibilityElementsHidden>
+        <StatusDot variant={badge.variant} size="sm" />
+      </View>
+      <Text
+        style={{
+          fontSize: 10,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: '700',
+          letterSpacing: 0.3,
+          color: colors.text,
+        }}
+      >
+        {badge.label}
+      </Text>
+    </View>
+  )
+}
+
+function MetricCell({ metric }: { metric: MesoStatusMetric }) {
+  return (
+    <View style={{ width: '48%' }} testID="meso-status-card-metric">
+      <Text
+        style={{
+          fontSize: 10,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: '600',
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+          color: TEXT_TERTIARY,
+        }}
+      >
+        {metric.label}
+      </Text>
+      <Text
+        style={{
+          marginTop: 2,
+          fontSize: 13,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: '600',
+          color: TEXT_PRIMARY,
+        }}
+      >
+        {metric.value}
+      </Text>
+    </View>
+  )
+}
+
+function Gauge({ gauge }: { gauge: MesoStatusGauge }) {
+  const level = clamp01(gauge.level)
+  const percentage = Math.round(level * 100)
+  const markerColor = getGaugeZoneColor(level)
+  return (
+    <View
+      style={{ gap: 6 }}
+      accessibilityRole="progressbar"
+      accessibilityValue={{ min: 0, max: 100, now: percentage }}
+      accessibilityLabel={`${gauge.label}: ${percentage}%`}
+      aria-valuenow={percentage}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      testID="meso-status-card-gauge"
+    >
+      <View
+        className="flex-row items-center justify-between"
+        accessibilityElementsHidden
+      >
+        <Text
+          style={{
+            fontSize: 10,
+            fontFamily: 'Inter, sans-serif',
+            fontWeight: '500',
+            letterSpacing: 0.5,
+            textTransform: 'uppercase',
+            color: TEXT_SECONDARY,
+          }}
+        >
+          {gauge.label}
+        </Text>
+        {gauge.sublabel != null && (
+          <Text
+            style={{
+              fontSize: 10,
+              fontFamily: 'Inter, sans-serif',
+              fontWeight: '500',
+              color: TEXT_TERTIARY,
+            }}
+          >
+            {gauge.sublabel}
+          </Text>
+        )}
+      </View>
+
+      <View
+        style={
+          {
+            height: 8,
+            borderRadius: 4,
+            position: 'relative',
+            backgroundImage: GAUGE_GRADIENT,
+          } as ViewStyle
+        }
+        accessibilityElementsHidden
+      >
+        <View
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: 0,
+            bottom: 0,
+            width: 1,
+            marginLeft: -0.5,
+            backgroundColor: 'rgba(255,255,255,0.3)',
+          }}
+          testID="meso-status-card-gauge-center"
+        />
+        <View
+          style={{
+            position: 'absolute',
+            left: `${percentage}%`,
+            top: -3,
+            marginLeft: -7,
+            width: 14,
+            height: 14,
+            borderRadius: 9999,
+            borderWidth: 2,
+            borderColor: TEXT_PRIMARY,
+            backgroundColor: markerColor,
+            boxShadow: '0 0 4px rgba(0,0,0,0.5)',
+          }}
+          testID="meso-status-card-gauge-marker"
+        />
+      </View>
+    </View>
+  )
+}
+
+/**
+ * Mesocycle context card for a specific exercise: prescription vs actual
+ * metrics, intensity/volume gauges, and coaching guidance. Composes the titan
+ * `Card` plus the Workout `StatusDot`, and renders the §25 gauge (8px track,
+ * 50% center line, 14px marker) inline since that visual differs from the
+ * IntensityBar/DeviationBar primitives.
+ *
+ * @example
+ * <MesoStatusCard
+ *   mesoName="Hypertrophy Block"
+ *   mesoSubtitle="Week 6 of 8 · Upper/Lower"
+ *   statusBadge={{ label: 'On Track', variant: 'success' }}
+ *   metrics={[
+ *     { label: 'Prescribed', value: '3×8 @ RPE 8' },
+ *     { label: 'Actual', value: '3×8 @ 185 lbs' },
+ *   ]}
+ *   gauges={[{ label: 'Intensity', level: 0.7, sublabel: 'Actual' }]}
+ *   coaching={{ text: 'Add load next session.', highlights: ['Add load'] }}
+ *   nextTarget={{ icon: '→', text: '190 lbs × 8' }}
+ * />
+ */
+export function MesoStatusCard({
+  mesoName,
+  mesoSubtitle,
+  statusBadge,
+  metrics,
+  gauges,
+  coaching,
+  nextTarget,
+  className,
+  ...props
+}: MesoStatusCardProps) {
+  return (
+    <Card
+      variant="outline"
+      elevation={1}
+      borderColor={BRAND_PRIMARY_DARK}
+      className={className}
+      style={
+        {
+          borderColor: BRAND_PRIMARY_DARK,
+          borderWidth: 1,
+          backgroundImage: CARD_GRADIENT,
+        } as ViewStyle
+      }
+      role="article"
+      aria-label={`Mesocycle status for ${mesoName}`}
+      testID="meso-status-card"
+      {...props}
+    >
+      <View
+        className="flex-row"
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 3, zIndex: 1 }}
+        accessibilityElementsHidden
+        testID="meso-status-card-accent"
+      >
+        {ACCENT_STOPS.map((color) => (
+          <View key={color} style={{ flex: 1, backgroundColor: color }} />
+        ))}
+      </View>
+
+      <View style={{ padding: 14, gap: 14 }} testID="meso-status-card-body">
+        <View testID="meso-status-card-header">
+          <View
+            className="flex-row items-center justify-between"
+            style={{ gap: 8 }}
+          >
+            <Text
+              style={{
+                flexShrink: 1,
+                fontSize: 15,
+                fontFamily: '"Space Grotesk", sans-serif',
+                fontWeight: '700',
+                color: TEXT_PRIMARY,
+              }}
+              testID="meso-status-card-name"
+            >
+              {mesoName}
+            </Text>
+            <StatusPill badge={statusBadge} />
+          </View>
+          <Text
+            style={{
+              marginTop: 4,
+              fontSize: 12,
+              fontFamily: 'Inter, sans-serif',
+              color: TEXT_SECONDARY,
+            }}
+            testID="meso-status-card-subtitle"
+          >
+            {mesoSubtitle}
+          </Text>
+        </View>
+
+        {metrics.length > 0 && (
+          <View
+            className="flex-row flex-wrap"
+            style={{ gap: 8 }}
+            testID="meso-status-card-metrics"
+          >
+            {metrics.map((metric) => (
+              <MetricCell key={metric.label} metric={metric} />
+            ))}
+          </View>
+        )}
+
+        {gauges.length > 0 && (
+          <View style={{ gap: 12 }} testID="meso-status-card-gauges">
+            {gauges.map((gauge) => (
+              <Gauge key={gauge.label} gauge={gauge} />
+            ))}
+          </View>
+        )}
+
+        {coaching != null && (
+          <View
+            style={{
+              backgroundColor: 'rgba(255,176,32,0.06)',
+              borderWidth: 1,
+              borderColor: 'rgba(255,176,32,0.15)',
+              borderRadius: 8,
+              paddingVertical: 10,
+              paddingHorizontal: 12,
+            }}
+            testID="meso-status-card-coaching"
+          >
+            <Text
+              style={{
+                fontSize: 12,
+                lineHeight: 17,
+                fontFamily: 'Inter, sans-serif',
+                color: TEXT_SECONDARY,
+              }}
+            >
+              {renderCoachingText(coaching.text, coaching.highlights)}
+            </Text>
+          </View>
+        )}
+
+        {nextTarget != null && (
+          <View
+            className="flex-row items-center"
+            style={{
+              gap: 8,
+              backgroundColor: 'rgba(20,184,166,0.06)',
+              borderWidth: 1,
+              borderColor: 'rgba(20,184,166,0.2)',
+              borderRadius: 8,
+              paddingVertical: 10,
+              paddingHorizontal: 12,
+            }}
+            testID="meso-status-card-next-target"
+          >
+            <Text style={{ fontSize: 14, color: SUCCESS }} accessibilityElementsHidden>
+              {nextTarget.icon}
+            </Text>
+            <Text
+              style={{
+                flexShrink: 1,
+                fontSize: 12,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '600',
+                color: SUCCESS,
+              }}
+            >
+              {nextTarget.text}
+            </Text>
+          </View>
+        )}
+      </View>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -54,3 +54,13 @@ export {
   type MesoCardProps,
   type MesoVolumeHeatmapEntry,
 } from './MesoCard'
+export {
+  MesoStatusCard,
+  type MesoStatusCardProps,
+  type MesoStatusBadge,
+  type MesoStatusBadgeVariant,
+  type MesoStatusMetric,
+  type MesoStatusGauge,
+  type MesoStatusCoaching,
+  type MesoStatusNextTarget,
+} from './MesoStatusCard'


### PR DESCRIPTION
## MesoStatusCard (TD-03.22, spec §25)

A "organism"-tier card giving **mesocycle context for a specific exercise**: prescription vs actual, intensity/volume gauges, and coaching guidance. Used on the Exercise Detail page (Progress tab).

### Composition
- Builds on the titan **Card** (gradient `surface-elevated → rgba(25,25,25,0.95)` at 135deg, 1px `brand-primary-dark` border, 3px gradient top accent — same technique as `MesoCard`).
- Reuses the Workout **StatusDot** inside the header status pill.
- The §25 gauge (full-width 8px track, 0.25-alpha gradient, 50% center line, 14px circle marker) is rendered inline because its visual differs from the existing IntensityBar (vertical fill) and DeviationBar (fixed 40px, no center line) primitives. The authoritative §25 spec text was followed over the summary's "builds on" list.

### Props
`mesoName`, `mesoSubtitle`, `statusBadge {label, variant: success|warning|error}`, `metrics: {label,value}[]` (2×2 grid), `gauges: {label, level 0-1, sublabel?}[]` (stacked), `coaching? {text, highlights?}` (bolded substrings), `nextTarget? {icon, text}`.

### States covered (stories)
- **Default** — success badge, 4 metrics, 2 gauges, coaching + next target
- **Warning** — fatigue watch, near-MRV volume
- **Overreaching** — error badge, deload recommendation
- **Minimal** — 2 metrics, single gauge, no coaching/next-target

### Accessibility
- Card exposed as `role="article"` with `aria-label="Mesocycle status for {mesoName}"`.
- Each gauge is a `progressbar` with `aria-valuenow/min/max` + descriptive label.
- Decorative accent/center-line/marker hidden from the a11y tree.

### Verify
- `pnpm type-check` → 0 errors
- `pnpm lint` (eslint on the 3 new files) → 0 errors / 0 warnings
- `pnpm test --run MesoStatusCard` → **16 passed** (incl. 2 jest-axe runs)
- `pnpm-lock.yaml` unchanged (no new deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
