### PR TITLE
Add StrengthTrendChart organism (TD-03.21)

### DIFF
--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { View, Text } from 'react-native'
+import { StrengthTrendChart } from './StrengthTrendChart'
+import type { StrengthTrendDataPoint } from './StrengthTrendChart'
+
+const actual: StrengthTrendDataPoint[] = [
+  { date: '2026-01-06', e1rm: 215, sessionLabel: 'Jan 6' },
+  { date: '2026-01-20', e1rm: 222, sessionLabel: 'Jan 20' },
+  { date: '2026-02-03', e1rm: 228, isPR: true, sessionLabel: 'Feb 3' },
+  { date: '2026-02-17', e1rm: 226, sessionLabel: 'Feb 17' },
+  { date: '2026-03-03', e1rm: 235, sessionLabel: 'Mar 3' },
+  { date: '2026-03-17', e1rm: 244, isPR: true, sessionLabel: 'Mar 17' },
+]
+
+const projection: StrengthTrendDataPoint[] = [
+  { date: '2026-03-17', e1rm: 244 },
+  { date: '2026-03-31', e1rm: 252 },
+  { date: '2026-04-14', e1rm: 261 },
+]
+
+const mesoBoundaries = [
+  { date: '2026-02-03', label: 'Intensify' },
+  { date: '2026-03-17', label: 'Peak' },
+]
+
+const decline: StrengthTrendDataPoint[] = [
+  { date: '2026-03-03', e1rm: 248 },
+  { date: '2026-03-10', e1rm: 244 },
+  { date: '2026-03-17', e1rm: 239 },
+  { date: '2026-03-24', e1rm: 235 },
+]
+
+const meta: Meta<typeof StrengthTrendChart> = {
+  title: 'Custom/Workout/StrengthTrendChart',
+  component: StrengthTrendChart,
+  tags: ['autodocs'],
+  argTypes: {
+    width: { control: { type: 'range', min: 160, max: 480, step: 10 }, description: 'Plot width in px' },
+    height: { control: { type: 'range', min: 100, max: 220, step: 10 }, description: 'Plot height in px (120-160 for compact)' },
+    unit: { control: 'inline-radio', options: ['lbs', 'kg'], description: 'Display unit' },
+    animateOnMount: { control: 'boolean', description: 'Left-to-right draw animation on mount' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StrengthTrendChart>
+
+export const Default: Story = {
+  args: {
+    data: actual,
+    projection,
+    mesoBoundaries,
+    width: 340,
+    height: 150,
+    unit: 'lbs',
+    animateOnMount: false,
+  },
+}
+
+export const Compact: Story = {
+  args: {
+    ...Default.args,
+    width: 240,
+    height: 120,
+  },
+}
+
+export const WithoutProjection: Story = {
+  args: {
+    ...Default.args,
+    projection: undefined,
+    mesoBoundaries: undefined,
+  },
+}
+
+export const Declining: Story = {
+  args: {
+    data: decline,
+    width: 340,
+    height: 150,
+    unit: 'lbs',
+    animateOnMount: false,
+  },
+}
+
+export const SinglePoint: Story = {
+  args: {
+    data: [{ date: '2026-03-17', e1rm: 244, isPR: true, sessionLabel: 'Mar 17' }],
+    width: 340,
+    height: 150,
+    unit: 'kg',
+    animateOnMount: false,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    data: [],
+    width: 340,
+    height: 150,
+    unit: 'lbs',
+  },
+}
+
+function InteractiveChart() {
+  const [selected, setSelected] = useState<StrengthTrendDataPoint | null>(null)
+  return (
+    <View style={{ maxWidth: 380, padding: 16 }}>
+      <StrengthTrendChart
+        data={actual}
+        projection={projection}
+        mesoBoundaries={mesoBoundaries}
+        width={340}
+        height={150}
+        unit="lbs"
+        onPointPress={setSelected}
+      />
+      <Text style={{ marginTop: 12, fontSize: 12, color: '#9CA3AF' }}>
+        {selected
+          ? `Tapped ${selected.sessionLabel ?? selected.date}: ${selected.e1rm} lbs`
+          : 'Tap a point on the chart.'}
+      </Text>
+    </View>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveChart />,
+}

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.test.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { StrengthTrendChart } from './StrengthTrendChart'
+import type { StrengthTrendDataPoint } from './StrengthTrendChart'
+
+const data: StrengthTrendDataPoint[] = [
+  { date: '2026-01-06', e1rm: 215, sessionLabel: 'Jan 6' },
+  { date: '2026-02-03', e1rm: 228, isPR: true, sessionLabel: 'Feb 3' },
+  { date: '2026-03-17', e1rm: 244, isPR: true, sessionLabel: 'Mar 17' },
+]
+
+const projection: StrengthTrendDataPoint[] = [
+  { date: '2026-03-17', e1rm: 244 },
+  { date: '2026-04-14', e1rm: 261 },
+]
+
+const mesoBoundaries = [
+  { date: '2026-02-03', label: 'Intensify' },
+  { date: '2026-03-17', label: 'Peak' },
+]
+
+const baseProps = {
+  data,
+  width: 340,
+  height: 150,
+  unit: 'lbs' as const,
+  animateOnMount: false,
+}
+
+describe('StrengthTrendChart', () => {
+  describe('rendering', () => {
+    it('renders the chart container and labelled canvas', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      expect(screen.getByTestId('strength-trend-chart')).toBeInTheDocument()
+      expect(screen.getByTestId('strength-trend-chart-canvas')).toBeInTheDocument()
+    })
+
+    it('renders a pressable point per actual data point', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      expect(screen.getAllByTestId('strength-trend-chart-point')).toHaveLength(3)
+    })
+
+    it('renders the actual line as connecting segments', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      // Two segments connect three points.
+      expect(
+        screen.getAllByTestId('strength-trend-chart-actual-segment'),
+      ).toHaveLength(2)
+    })
+
+    it('renders subtle horizontal gridlines', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      const grid = screen.getAllByTestId('strength-trend-chart-gridline')
+      expect(grid.length).toBeGreaterThanOrEqual(2)
+      expect(grid.length).toBeLessThanOrEqual(3)
+    })
+
+    it('renders a star marker for each PR point', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      expect(screen.getAllByTestId('strength-trend-chart-pr-star')).toHaveLength(2)
+    })
+
+    it('renders an Actual / Projected / PR legend', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      const legend = screen.getByTestId('strength-trend-chart-legend')
+      expect(legend).toHaveTextContent('Actual')
+      expect(legend).toHaveTextContent('Projected')
+      expect(legend).toHaveTextContent('PR')
+    })
+  })
+
+  describe('projection and meso boundaries', () => {
+    it('renders dashed projection segments when projection is provided', () => {
+      render(<StrengthTrendChart {...baseProps} projection={projection} />)
+      expect(
+        screen.getAllByTestId('strength-trend-chart-projection-segment'),
+      ).toHaveLength(1)
+    })
+
+    it('omits projection segments when none provided', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      expect(
+        screen.queryByTestId('strength-trend-chart-projection-segment'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders a boundary marker and axis label per meso boundary', () => {
+      render(<StrengthTrendChart {...baseProps} mesoBoundaries={mesoBoundaries} />)
+      expect(
+        screen.getAllByTestId('strength-trend-chart-meso-boundary'),
+      ).toHaveLength(2)
+      expect(
+        screen.getAllByTestId('strength-trend-chart-axis-label'),
+      ).toHaveLength(2)
+    })
+  })
+
+  describe('trend pill', () => {
+    it('shows a positive percentage for an improving series', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      const pill = screen.getByTestId('strength-trend-chart-trend-pill')
+      expect(pill).toHaveTextContent('this meso')
+      expect(pill.textContent?.startsWith('+')).toBe(true)
+    })
+
+    it('shows a negative percentage for a declining series', () => {
+      render(
+        <StrengthTrendChart
+          {...baseProps}
+          data={[
+            { date: '2026-03-03', e1rm: 248 },
+            { date: '2026-03-17', e1rm: 235 },
+          ]}
+        />,
+      )
+      const pill = screen.getByTestId('strength-trend-chart-trend-pill')
+      expect(pill.textContent?.startsWith('-')).toBe(true)
+    })
+  })
+
+  describe('interaction', () => {
+    it('fires onPointPress with the tapped point', () => {
+      const onPointPress = vi.fn()
+      render(<StrengthTrendChart {...baseProps} onPointPress={onPointPress} />)
+      fireEvent.click(screen.getAllByTestId('strength-trend-chart-point')[1])
+      expect(onPointPress).toHaveBeenCalledWith(
+        expect.objectContaining({ e1rm: 228 }),
+      )
+    })
+
+    it('shows a tooltip with value and unit after a point is tapped', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      expect(
+        screen.queryByTestId('strength-trend-chart-tooltip'),
+      ).not.toBeInTheDocument()
+      fireEvent.click(screen.getAllByTestId('strength-trend-chart-point')[2])
+      const tooltip = screen.getByTestId('strength-trend-chart-tooltip')
+      expect(tooltip).toHaveTextContent('244 lbs')
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders an empty placeholder when there is no data', () => {
+      render(<StrengthTrendChart {...baseProps} data={[]} />)
+      expect(
+        screen.getByTestId('strength-trend-chart-empty'),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('strength-trend-chart-canvas'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('labels the chart as an image with current value and trend', () => {
+      render(<StrengthTrendChart {...baseProps} />)
+      const canvas = screen.getByTestId('strength-trend-chart-canvas')
+      expect(canvas).toHaveAttribute('role', 'img')
+      expect(canvas.getAttribute('aria-label')).toContain('Current: 244 lbs')
+      expect(canvas.getAttribute('aria-label')).toContain('Trend:')
+    })
+
+    it('labels the empty state accessibly', () => {
+      render(<StrengthTrendChart {...baseProps} data={[]} />)
+      expect(
+        screen.getByLabelText('Strength trend chart, no data'),
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = render(<StrengthTrendChart {...baseProps} />)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations with all features enabled', async () => {
+      const { container } = render(
+        <StrengthTrendChart
+          {...baseProps}
+          projection={projection}
+          mesoBoundaries={mesoBoundaries}
+          onPointPress={vi.fn()}
+          unit="kg"
+        />,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
@@ -1,0 +1,622 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useEffect, useMemo, useState } from 'react'
+import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { cn } from '../../../utils/cn'
+
+const BRAND_PRIMARY = '#FF7900'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+const TEXT_TERTIARY = '#6B7280'
+const BORDER_STRONG = '#2C2C2C'
+const STATUS_SUCCESS = '#14B8A6'
+const STATUS_ERROR = '#D14343'
+const STATUS_WARNING = '#FFB020'
+const GRID_LINE = 'rgba(255,255,255,0.06)'
+const TOOLTIP_BG = 'rgba(28,28,28,0.95)'
+const SUCCESS_PILL_BG = 'rgba(20,184,166,0.10)'
+const SUCCESS_PILL_BORDER = 'rgba(20,184,166,0.20)'
+const ERROR_PILL_BG = 'rgba(209,67,67,0.10)'
+const ERROR_PILL_BORDER = 'rgba(209,67,67,0.20)'
+
+/** Left gutter reserved for y-axis value labels. */
+const PLOT_LEFT = 26
+/** Approximate tooltip width used for edge clamping. */
+const TOOLTIP_WIDTH = 124
+
+export interface StrengthTrendDataPoint {
+  /** ISO date string for the session. */
+  date: string
+  /** Estimated one-rep max in the chart's unit. */
+  e1rm: number
+  /** Marks a personal-record session (rendered with a star). */
+  isPR?: boolean
+  /** Optional human label shown in the tooltip instead of the raw date. */
+  sessionLabel?: string
+}
+
+export interface StrengthTrendChartMesoBoundary {
+  /** ISO date where the mesocycle boundary falls. */
+  date: string
+  /** Short label, e.g. "Hypertrophy". */
+  label: string
+}
+
+export interface StrengthTrendChartProps extends ViewProps {
+  /** Actual e1RM data points, chronological. */
+  data: StrengthTrendDataPoint[]
+  /** Projected/planned e1RM trajectory, drawn as a dashed line. */
+  projection?: StrengthTrendDataPoint[]
+  /** Chart plot width in pixels. */
+  width: number
+  /** Chart plot height in pixels (120-160 for the compact variant). */
+  height: number
+  /** Mesocycle boundary markers (vertical guides + labels). */
+  mesoBoundaries?: StrengthTrendChartMesoBoundary[]
+  /** Called when an actual data point is tapped. */
+  onPointPress?: (point: StrengthTrendDataPoint) => void
+  /** Unit for display and labels. */
+  unit: 'lbs' | 'kg'
+  /** Animate the left-to-right line draw on mount (default true). */
+  animateOnMount?: boolean
+  className?: string
+}
+
+interface Coord {
+  x: number
+  y: number
+  point: StrengthTrendDataPoint
+  index: number
+}
+
+interface Geometry {
+  hasData: boolean
+  toX: (time: number) => number
+  toY: (value: number) => number
+  actual: Coord[]
+  projection: Coord[]
+  gridLines: Array<{ y: number; label: string }>
+  boundaries: Array<{ x: number; label: string }>
+}
+
+function timeOf(dateStr: string): number {
+  const t = Date.parse(dateStr)
+  return Number.isNaN(t) ? 0 : t
+}
+
+function formatValue(value: number): string {
+  return `${Math.round(value)}`
+}
+
+function buildGeometry(
+  data: StrengthTrendDataPoint[],
+  projection: StrengthTrendDataPoint[],
+  boundaries: StrengthTrendChartMesoBoundary[],
+  width: number,
+  height: number,
+): Geometry {
+  const values = [...data, ...projection].map((p) => p.e1rm)
+  if (values.length === 0) {
+    return {
+      hasData: false,
+      toX: () => 0,
+      toY: () => 0,
+      actual: [],
+      projection: [],
+      gridLines: [],
+      boundaries: [],
+    }
+  }
+
+  const times = [
+    ...data.map((p) => timeOf(p.date)),
+    ...projection.map((p) => timeOf(p.date)),
+    ...boundaries.map((b) => timeOf(b.date)),
+  ]
+  const tMin = Math.min(...times)
+  const tMaxRaw = Math.max(...times)
+  const tMax = tMaxRaw === tMin ? tMin + 1 : tMaxRaw
+
+  const yMin = Math.min(...values)
+  const yMax = Math.max(...values)
+  const range = yMax - yMin || Math.max(1, yMax * 0.1)
+  const padV = range * 0.15
+  const domainMin = yMin - padV
+  const domainMax = yMax + padV
+
+  const innerW = Math.max(1, width - PLOT_LEFT)
+  const toX = (time: number) =>
+    PLOT_LEFT + ((time - tMin) / (tMax - tMin)) * innerW
+  const toY = (value: number) =>
+    height - ((value - domainMin) / (domainMax - domainMin)) * height
+
+  const project = (points: StrengthTrendDataPoint[]): Coord[] =>
+    points.map((point, index) => ({
+      x: toX(timeOf(point.date)),
+      y: toY(point.e1rm),
+      point,
+      index,
+    }))
+
+  const tickValues = Array.from(
+    new Set([yMax, (yMin + yMax) / 2, yMin].map((v) => Math.round(v))),
+  )
+  const gridLines = tickValues.map((v) => ({ y: toY(v), label: formatValue(v) }))
+
+  return {
+    hasData: true,
+    toX,
+    toY,
+    actual: project(data),
+    projection: project(projection),
+    gridLines,
+    boundaries: boundaries.map((b) => ({
+      x: toX(timeOf(b.date)),
+      label: b.label,
+    })),
+  }
+}
+
+function computeTrend(
+  data: StrengthTrendDataPoint[],
+  boundaries: StrengthTrendChartMesoBoundary[],
+): { percent: number; positive: boolean } {
+  if (data.length < 2) return { percent: 0, positive: true }
+  let series = data
+  if (boundaries.length > 0) {
+    const lastBoundary = Math.max(...boundaries.map((b) => timeOf(b.date)))
+    const filtered = data.filter((p) => timeOf(p.date) >= lastBoundary)
+    if (filtered.length >= 2) series = filtered
+  }
+  const first = series[0].e1rm
+  const last = series[series.length - 1].e1rm
+  const percent = first ? ((last - first) / first) * 100 : 0
+  return { percent, positive: percent >= 0 }
+}
+
+function ChartLine({
+  coords,
+  color,
+  strokeWidth,
+  dashed,
+  testID,
+}: {
+  coords: Coord[]
+  color: string
+  strokeWidth: number
+  dashed?: boolean
+  testID: string
+}) {
+  return (
+    <>
+      {coords.map((c, i) => {
+        if (i === 0) return null
+        const prev = coords[i - 1]
+        const dx = c.x - prev.x
+        const dy = c.y - prev.y
+        const length = Math.sqrt(dx * dx + dy * dy)
+        const angle = Math.atan2(dy, dx) * (180 / Math.PI)
+        return (
+          <View
+            key={`${testID}-${i}`}
+            testID={testID}
+            accessibilityElementsHidden
+            style={[
+              {
+                position: 'absolute',
+                left: prev.x,
+                top: prev.y,
+                width: length,
+                transformOrigin: '0 0',
+                transform: [{ rotate: `${angle}deg` }],
+              },
+              dashed
+                ? {
+                    height: 0,
+                    borderTopWidth: strokeWidth,
+                    borderStyle: 'dashed',
+                    borderTopColor: color,
+                  }
+                : {
+                    height: strokeWidth,
+                    borderRadius: strokeWidth / 2,
+                    backgroundColor: color,
+                  },
+            ]}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+/**
+ * Estimated-1RM line chart over time with an optional dashed plan-projection
+ * line and PR star markers. Rendered entirely with absolutely-positioned
+ * Views (no SVG), following the Sparkline approach. Tapping an actual point
+ * opens a tooltip and fires `onPointPress`. A trend pill below the chart
+ * summarizes the percentage change for the current mesocycle.
+ *
+ * @example
+ * <StrengthTrendChart
+ *   data={[{ date: '2026-01-01', e1rm: 225 }, { date: '2026-02-01', e1rm: 245, isPR: true }]}
+ *   projection={[{ date: '2026-02-01', e1rm: 245 }, { date: '2026-03-01', e1rm: 260 }]}
+ *   width={320}
+ *   height={150}
+ *   unit="lbs"
+ * />
+ */
+export function StrengthTrendChart({
+  data,
+  projection = [],
+  width,
+  height,
+  mesoBoundaries = [],
+  onPointPress,
+  unit,
+  animateOnMount = true,
+  className,
+  ...props
+}: StrengthTrendChartProps) {
+  const geometry = useMemo(
+    () => buildGeometry(data, projection, mesoBoundaries, width, height),
+    [data, projection, mesoBoundaries, width, height],
+  )
+  const trend = useMemo(
+    () => computeTrend(data, mesoBoundaries),
+    [data, mesoBoundaries],
+  )
+
+  const [reveal] = useState(() => new Animated.Value(animateOnMount ? 0 : 1))
+  const [selected, setSelected] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!animateOnMount) return
+    const animation = Animated.timing(reveal, {
+      toValue: 1,
+      duration: 600,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: false,
+    })
+    animation.start()
+    return () => animation.stop()
+  }, [animateOnMount, reveal])
+
+  const current = data.length > 0 ? data[data.length - 1].e1rm : 0
+  const trendSign = trend.percent >= 0 ? '+' : '-'
+  const trendText = `${trendSign}${Math.abs(trend.percent).toFixed(1)}% this meso`
+  const ariaLabel = geometry.hasData
+    ? `Strength trend chart showing estimated one rep max over time. Current: ${formatValue(current)} ${unit}. Trend: ${trendSign}${Math.abs(trend.percent).toFixed(1)}%`
+    : 'Strength trend chart, no data'
+
+  if (!geometry.hasData) {
+    return (
+      <View
+        style={{ width }}
+        className={cn(className)}
+        accessibilityRole="image"
+        accessibilityLabel={ariaLabel}
+        testID="strength-trend-chart-empty"
+        {...props}
+      >
+        <View
+          style={{
+            width,
+            height,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_TERTIARY }}>
+            No strength data yet
+          </Text>
+        </View>
+      </View>
+    )
+  }
+
+  const revealWidth = reveal.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, width],
+  })
+
+  const selectedCoord =
+    selected != null ? geometry.actual[selected] : undefined
+
+  return (
+    <View
+      style={{ width }}
+      className={cn(className)}
+      testID="strength-trend-chart"
+      {...props}
+    >
+      <View style={{ width, height, position: 'relative' }}>
+        {/* Labelled, non-interactive chart canvas (grid + lines + markers). */}
+        <View
+          style={{ position: 'absolute', top: 0, left: 0, width, height }}
+          accessibilityRole="image"
+          accessibilityLabel={ariaLabel}
+          testID="strength-trend-chart-canvas"
+        >
+          {geometry.gridLines.map((line, i) => (
+            <View
+              key={`grid-${i}`}
+              accessibilityElementsHidden
+              testID="strength-trend-chart-gridline"
+              style={{
+                position: 'absolute',
+                left: PLOT_LEFT,
+                right: 0,
+                top: line.y,
+                height: 1,
+                backgroundColor: GRID_LINE,
+              }}
+            >
+              <Text
+                style={{
+                  position: 'absolute',
+                  left: -PLOT_LEFT,
+                  top: -6,
+                  width: PLOT_LEFT - 4,
+                  textAlign: 'right',
+                  fontSize: 9,
+                  fontFamily: 'Inter, sans-serif',
+                  color: TEXT_TERTIARY,
+                }}
+              >
+                {line.label}
+              </Text>
+            </View>
+          ))}
+
+          {geometry.boundaries.map((boundary, i) => (
+            <View
+              key={`boundary-${i}`}
+              accessibilityElementsHidden
+              testID="strength-trend-chart-meso-boundary"
+              style={{
+                position: 'absolute',
+                left: boundary.x,
+                top: 0,
+                width: 0,
+                height,
+                borderLeftWidth: 1,
+                borderStyle: 'dashed',
+                borderLeftColor: 'rgba(255,255,255,0.10)',
+              }}
+            />
+          ))}
+
+          <Animated.View
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: revealWidth,
+              height,
+              overflow: 'hidden',
+            }}
+            testID="strength-trend-chart-reveal"
+          >
+            <View style={{ width, height, position: 'absolute', top: 0, left: 0 }}>
+              <ChartLine
+                coords={geometry.projection}
+                color={TEXT_TERTIARY}
+                strokeWidth={2}
+                dashed
+                testID="strength-trend-chart-projection-segment"
+              />
+              <ChartLine
+                coords={geometry.actual}
+                color={BRAND_PRIMARY}
+                strokeWidth={2.5}
+                testID="strength-trend-chart-actual-segment"
+              />
+            </View>
+          </Animated.View>
+
+          {geometry.actual.map((c) =>
+            c.point.isPR ? (
+              <Text
+                key={`star-${c.index}`}
+                accessibilityElementsHidden
+                testID="strength-trend-chart-pr-star"
+                style={{
+                  position: 'absolute',
+                  left: c.x - 7,
+                  top: c.y - 20,
+                  fontSize: 12,
+                  color: STATUS_WARNING,
+                }}
+              >
+                ★
+              </Text>
+            ) : null,
+          )}
+        </View>
+
+        {/* Interactive point overlay (kept out of the image-role canvas). */}
+        <View
+          style={{ position: 'absolute', top: 0, left: 0, width, height }}
+          testID="strength-trend-chart-points"
+        >
+          {geometry.actual.map((c) => {
+            const label = c.point.sessionLabel ?? c.point.date
+            return (
+              <Pressable
+                key={`point-${c.index}`}
+                testID="strength-trend-chart-point"
+                accessibilityRole="button"
+                accessibilityLabel={`${label}: ${formatValue(c.point.e1rm)} ${unit}${c.point.isPR ? ', personal record' : ''}`}
+                onPress={() => {
+                  setSelected(c.index)
+                  onPointPress?.(c.point)
+                }}
+                style={{
+                  position: 'absolute',
+                  left: c.x - 4,
+                  top: c.y - 4,
+                  width: 8,
+                  height: 8,
+                  borderRadius: 1,
+                  backgroundColor: BRAND_PRIMARY,
+                }}
+              />
+            )
+          })}
+        </View>
+
+        {selectedCoord && (
+          <View
+            testID="strength-trend-chart-tooltip"
+            accessibilityElementsHidden
+            style={{
+              position: 'absolute',
+              left: Math.max(
+                0,
+                Math.min(width - TOOLTIP_WIDTH, selectedCoord.x - TOOLTIP_WIDTH / 2),
+              ),
+              top: Math.max(0, selectedCoord.y - 52),
+              maxWidth: TOOLTIP_WIDTH,
+              backgroundColor: TOOLTIP_BG,
+              borderWidth: 1,
+              borderColor: BORDER_STRONG,
+              borderRadius: 8,
+              paddingVertical: 8,
+              paddingHorizontal: 10,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 10,
+                fontFamily: 'Inter, sans-serif',
+                color: TEXT_TERTIARY,
+              }}
+            >
+              {selectedCoord.point.sessionLabel ?? selectedCoord.point.date}
+            </Text>
+            <Text
+              style={{
+                marginTop: 2,
+                fontSize: 13,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '700',
+                color: TEXT_PRIMARY,
+              }}
+            >
+              {`${formatValue(selectedCoord.point.e1rm)} ${unit}`}
+            </Text>
+            {selected != null && selected > 0 && (
+              <Text
+                style={{
+                  marginTop: 1,
+                  fontSize: 10,
+                  fontFamily: 'Inter, sans-serif',
+                  color:
+                    selectedCoord.point.e1rm - geometry.actual[selected - 1].point.e1rm >= 0
+                      ? STATUS_SUCCESS
+                      : STATUS_ERROR,
+                }}
+              >
+                {`${
+                  selectedCoord.point.e1rm - geometry.actual[selected - 1].point.e1rm >= 0
+                    ? '+'
+                    : '-'
+                }${Math.abs(
+                  selectedCoord.point.e1rm - geometry.actual[selected - 1].point.e1rm,
+                ).toFixed(1)} ${unit}`}
+              </Text>
+            )}
+          </View>
+        )}
+      </View>
+
+      {/* Meso boundary x-axis labels. */}
+      {geometry.boundaries.length > 0 && (
+        <View
+          style={{ width, height: 14, position: 'relative', marginTop: 2 }}
+          accessibilityElementsHidden
+          testID="strength-trend-chart-axis"
+        >
+          {geometry.boundaries.map((boundary, i) => (
+            <Text
+              key={`axis-${i}`}
+              testID="strength-trend-chart-axis-label"
+              style={{
+                position: 'absolute',
+                left: boundary.x - 24,
+                width: 48,
+                textAlign: 'center',
+                fontSize: 10,
+                fontFamily: 'Inter, sans-serif',
+                color: TEXT_TERTIARY,
+              }}
+            >
+              {boundary.label}
+            </Text>
+          ))}
+        </View>
+      )}
+
+      {/* Trend pill. */}
+      <View className="flex-row" style={{ marginTop: 8 }}>
+        <View
+          testID="strength-trend-chart-trend-pill"
+          accessibilityLabel={`Strength trend: ${trendText}`}
+          style={{
+            paddingVertical: 3,
+            paddingHorizontal: 8,
+            borderRadius: 4,
+            borderWidth: 1,
+            backgroundColor: trend.positive ? SUCCESS_PILL_BG : ERROR_PILL_BG,
+            borderColor: trend.positive ? SUCCESS_PILL_BORDER : ERROR_PILL_BORDER,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 11,
+              fontFamily: 'Inter, sans-serif',
+              fontWeight: '600',
+              color: trend.positive ? STATUS_SUCCESS : STATUS_ERROR,
+            }}
+          >
+            {trendText}
+          </Text>
+        </View>
+      </View>
+
+      {/* Legend. */}
+      <View
+        className="flex-row items-center"
+        style={{ marginTop: 8, gap: 14 }}
+        testID="strength-trend-chart-legend"
+      >
+        <View className="flex-row items-center" style={{ gap: 5 }}>
+          <View style={{ width: 14, height: 2.5, borderRadius: 1.5, backgroundColor: BRAND_PRIMARY }} />
+          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+            Actual
+          </Text>
+        </View>
+        <View className="flex-row items-center" style={{ gap: 5 }}>
+          <View
+            style={{
+              width: 14,
+              height: 0,
+              borderTopWidth: 2,
+              borderStyle: 'dashed',
+              borderTopColor: TEXT_TERTIARY,
+            }}
+          />
+          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+            Projected
+          </Text>
+        </View>
+        <View className="flex-row items-center" style={{ gap: 5 }}>
+          <Text style={{ fontSize: 12, color: STATUS_WARNING }}>★</Text>
+          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+            PR
+          </Text>
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -54,3 +54,9 @@ export {
   type MesoCardProps,
   type MesoVolumeHeatmapEntry,
 } from './MesoCard'
+export {
+  StrengthTrendChart,
+  type StrengthTrendChartProps,
+  type StrengthTrendDataPoint,
+  type StrengthTrendChartMesoBoundary,
+} from './StrengthTrendChart'


### PR DESCRIPTION
## StrengthTrendChart (TD-03.21, spec §24)

A new **organism**-tier chart for the workout component system: an estimated-1RM line chart over time, with a dashed plan-projection line and PR star markers. It is the Progress-tab hero chart for the exercise detail page.

Rendered entirely with absolutely-positioned `View`s (no SVG, no new deps), following the existing `Sparkline.tsx` approach — line segments are thin Views rotated via `transform`/`transformOrigin`, dashed segments use a dashed top-border View.

### Props
- `data: StrengthTrendDataPoint[]` (`{ date, e1rm, isPR?, sessionLabel? }`)
- `projection?` — dashed plan trajectory
- `width`, `height` (supports a compact 120-160px variant)
- `mesoBoundaries?`, `onPointPress?`, `unit: 'lbs' | 'kg'`, `animateOnMount?`

### Visuals / states
- Actual line 2.5px brand-primary (`#FF7900`); projection 2px dashed `text-tertiary`
- PR markers = ★ 12px `status-warning`; 8px square pressable point dots
- Tap tooltip (`rgba(28,28,28,0.95)`, radius 8) showing date + value + delta
- 2-3 subtle horizontal gridlines with left-edge value labels
- Meso boundary vertical guides + axis labels
- Trend pill below: `+X.X% this meso` (teal success bg / red decline variant)
- Legend: Actual / Projected / PR
- Left-to-right draw animation, 600ms ease-out (RN `Animated`, `useNativeDriver: false`)
- Empty state placeholder
- Stories: Default, Compact, WithoutProjection, Declining, SinglePoint, Empty, Interactive

### Accessibility
- Chart canvas is `role="image"` with an aria-label including current value + trend %
- Interactive points live in a sibling overlay (kept out of the image-role node) as labelled buttons
- Empty state has a descriptive label

### Verify
- `pnpm type-check` -> 0 errors
- `pnpm lint` (new files) -> 0 errors / 0 warnings
- `pnpm test -- --run StrengthTrendChart` -> 18 passed (incl. 2 jest-axe checks)
- `pnpm-lock.yaml` unchanged (no new dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
