### PR TITLE
Add BodyMap organism (TD-03.23, spec §22)

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,12 +1,14 @@
 import type { StorybookConfig } from '@storybook/react-native-web-vite'
+import {
+  reactNativeSvgWebResolver,
+  reactNativeBodyHighlighterEsm,
+  svgWebAliases,
+  webResolveExtensions,
+} from '../vite-rn-svg-plugins'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-a11y',
-    '@storybook/addon-docs',
-    '@storybook/addon-themes',
-  ],
+  addons: ['@storybook/addon-a11y', '@storybook/addon-docs', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/react-native-web-vite',
     options: {
@@ -14,6 +16,32 @@ const config: StorybookConfig = {
         jsxImportSource: 'nativewind',
       },
     },
+  },
+  // Mirror the test runner's react-native-svg web resolution so the real
+  // <Body/> SVG renders under react-native-web in Storybook too.
+  viteFinal: async (cfg) => {
+    cfg.plugins = [
+      reactNativeSvgWebResolver(),
+      reactNativeBodyHighlighterEsm(),
+      ...(cfg.plugins ?? []),
+    ]
+    cfg.resolve = cfg.resolve ?? {}
+    const existingAlias = cfg.resolve.alias
+    const existingAliasArray = Array.isArray(existingAlias)
+      ? existingAlias
+      : Object.entries(existingAlias ?? {}).map(([find, replacement]) => ({
+          find,
+          replacement: replacement as string,
+        }))
+    cfg.resolve.alias = [...svgWebAliases, ...existingAliasArray]
+    cfg.resolve.extensions = [...webResolveExtensions, ...(cfg.resolve.extensions ?? [])]
+    cfg.optimizeDeps = cfg.optimizeDeps ?? {}
+    cfg.optimizeDeps.exclude = [
+      ...(cfg.optimizeDeps.exclude ?? []),
+      'react-native-svg',
+      'react-native-body-highlighter',
+    ]
+    return cfg
   },
 }
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,10 +82,11 @@
     "@gluestack-style/react": "^1.0.0",
     "@gluestack-ui/themed": "^1.1.0",
     "clsx": "^2.1.0",
+    "react-native-body-highlighter": "^3.2.0",
+    "react-native-svg": "^15.15.5",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
-    "nativewind": "^4.2.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.2.0",
@@ -108,6 +109,7 @@
     "jest-axe": "^9.0.0",
     "jsdom": "^25.0.0",
     "lucide-react": "^0.469.0",
+    "nativewind": "^4.2.1",
     "prettier": "^3.8.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,19 +62,27 @@
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-native": ">=0.72.0",
+    "react-native-body-highlighter": ">=3.0.0",
+    "react-native-svg": ">=15.0.0",
     "react-native-web": ">=0.19.0"
   },
   "peerDependenciesMeta": {
+    "lucide-react-native": {
+      "optional": true
+    },
     "nativewind": {
       "optional": true
     },
     "react-native": {
       "optional": true
     },
-    "react-native-web": {
+    "react-native-body-highlighter": {
       "optional": true
     },
-    "lucide-react-native": {
+    "react-native-svg": {
+      "optional": true
+    },
+    "react-native-web": {
       "optional": true
     }
   },
@@ -82,8 +90,6 @@
     "@gluestack-style/react": "^1.0.0",
     "@gluestack-ui/themed": "^1.1.0",
     "clsx": "^2.1.0",
-    "react-native-body-highlighter": "^3.2.0",
-    "react-native-svg": "^15.15.5",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
@@ -113,6 +119,8 @@
     "prettier": "^3.8.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-native-body-highlighter": "^3.2.0",
+    "react-native-svg": "^15.15.5",
     "react-native-web": "^0.19.0",
     "storybook": "^10.2.0",
     "tailwindcss": "^3.4.0",

--- a/packages/ui/src/components/custom/Workout/BodyMap.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMap.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { View } from 'react-native'
+import { BodyMap, type BodyMapData } from './BodyMap'
+import { MuscleGroup } from './muscleTaxonomy'
+
+const sampleData: BodyMapData[] = [
+  { muscleGroup: MuscleGroup.CHEST, intensity: 0.7, volumeStatus: 'productive', weeklySets: 12 },
+  {
+    muscleGroup: MuscleGroup.FRONT_DELTS,
+    intensity: 0.5,
+    volumeStatus: 'maintenance',
+    weeklySets: 5,
+  },
+  {
+    muscleGroup: MuscleGroup.SIDE_DELTS,
+    intensity: 0.6,
+    volumeStatus: 'productive',
+    weeklySets: 10,
+  },
+  { muscleGroup: MuscleGroup.BICEPS, intensity: 0.3, volumeStatus: 'under', weeklySets: 3 },
+  { muscleGroup: MuscleGroup.TRICEPS, intensity: 0.65, volumeStatus: 'productive', weeklySets: 8 },
+  { muscleGroup: MuscleGroup.ABS, intensity: 0.4, volumeStatus: 'maintenance', weeklySets: 6 },
+  {
+    muscleGroup: MuscleGroup.OBLIQUES,
+    intensity: 0.35,
+    volumeStatus: 'maintenance',
+    weeklySets: 4,
+  },
+  { muscleGroup: MuscleGroup.QUADS, intensity: 0.95, volumeStatus: 'over', weeklySets: 20 },
+]
+
+const backData: BodyMapData[] = [
+  { muscleGroup: MuscleGroup.LATS, intensity: 0.6, volumeStatus: 'productive', weeklySets: 11 },
+  {
+    muscleGroup: MuscleGroup.UPPER_BACK,
+    intensity: 0.5,
+    volumeStatus: 'maintenance',
+    weeklySets: 8,
+  },
+  { muscleGroup: MuscleGroup.REAR_DELTS, intensity: 0.3, volumeStatus: 'under', weeklySets: 4 },
+  { muscleGroup: MuscleGroup.TRICEPS, intensity: 0.65, volumeStatus: 'productive', weeklySets: 8 },
+  { muscleGroup: MuscleGroup.GLUTES, intensity: 0.7, volumeStatus: 'productive', weeklySets: 10 },
+  {
+    muscleGroup: MuscleGroup.HAMSTRINGS,
+    intensity: 0.55,
+    volumeStatus: 'productive',
+    weeklySets: 9,
+  },
+  { muscleGroup: MuscleGroup.CALVES, intensity: 0.2, volumeStatus: 'under', weeklySets: 3 },
+]
+
+const meta: Meta<typeof BodyMap> = {
+  title: 'Custom/Workout/BodyMap',
+  component: BodyMap,
+  tags: ['autodocs'],
+  argTypes: {
+    view: { control: 'inline-radio', options: ['front', 'back'] },
+    mode: { control: 'inline-radio', options: ['simple', 'detailed'] },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ padding: 16, maxWidth: 320 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof BodyMap>
+
+export const Front: Story = {
+  args: { data: sampleData, view: 'front', mode: 'detailed' },
+}
+
+export const Back: Story = {
+  args: { data: backData, view: 'back', mode: 'detailed' },
+}
+
+export const Simple: Story = {
+  args: { data: sampleData, view: 'front', mode: 'simple' },
+}
+
+export const Detailed: Story = {
+  args: { data: sampleData, view: 'front', mode: 'detailed' },
+}
+
+export const Highlighted: Story = {
+  args: {
+    data: sampleData,
+    view: 'front',
+    mode: 'detailed',
+    highlightedMuscle: MuscleGroup.QUADS,
+  },
+}
+
+export const Empty: Story = {
+  args: { data: [], view: 'front' },
+}
+
+function InteractiveBodyMap() {
+  const [view, setView] = useState<'front' | 'back'>('front')
+  const [selected, setSelected] = useState<MuscleGroup | null>(null)
+  return (
+    <View style={{ maxWidth: 320 }}>
+      <BodyMap
+        data={view === 'front' ? sampleData : backData}
+        view={view}
+        onViewChange={setView}
+        onMusclePress={(m) => setSelected((cur) => (cur === m ? null : m))}
+        highlightedMuscle={selected}
+        mode="detailed"
+      />
+    </View>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveBodyMap />,
+}

--- a/packages/ui/src/components/custom/Workout/BodyMap.test.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMap.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { BodyMap, type BodyMapData } from './BodyMap'
+import { MuscleGroup } from './muscleTaxonomy'
+
+const data: BodyMapData[] = [
+  { muscleGroup: MuscleGroup.CHEST, intensity: 0.7, volumeStatus: 'productive', weeklySets: 12 },
+  { muscleGroup: MuscleGroup.LATS, intensity: 0.4, volumeStatus: 'under', weeklySets: 6 },
+  { muscleGroup: MuscleGroup.QUADS, intensity: 0.9, volumeStatus: 'over', weeklySets: 20 },
+]
+
+describe('BodyMap', () => {
+  describe('rendering', () => {
+    it('renders the container, SVG, and view toggle', () => {
+      render(<BodyMap data={data} view="front" />)
+      expect(screen.getByTestId('body-map')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-svg')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-view-toggle')).toBeInTheDocument()
+    })
+
+    it('renders the SVG body for both front and back views', () => {
+      const { rerender, container } = render(<BodyMap data={data} view="front" />)
+      expect(container.querySelector('svg')).toBeInTheDocument()
+      rerender(<BodyMap data={data} view="back" />)
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('renders one legend button per muscle in detailed mode', () => {
+      render(<BodyMap data={data} view="front" mode="detailed" />)
+      expect(screen.getByTestId('body-map-muscle-chest')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-muscle-lats')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-muscle-quads')).toBeInTheDocument()
+    })
+
+    it('aggregates muscles into simple groups in simple mode', () => {
+      render(<BodyMap data={data} view="front" mode="simple" />)
+      // chest -> chest, lats -> back, quads -> legs
+      expect(screen.getByTestId('body-map-muscle-chest')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-muscle-back')).toBeInTheDocument()
+      expect(screen.getByTestId('body-map-muscle-legs')).toBeInTheDocument()
+      expect(screen.queryByTestId('body-map-muscle-lats')).not.toBeInTheDocument()
+    })
+
+    it('renders an empty hint when there is no data', () => {
+      render(<BodyMap data={[]} view="front" />)
+      expect(screen.getByTestId('body-map-empty')).toBeInTheDocument()
+      expect(screen.queryByTestId('body-map-legend')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('interaction', () => {
+    it('calls onMusclePress with the tapped muscle group', () => {
+      const onMusclePress = vi.fn()
+      render(<BodyMap data={data} view="front" onMusclePress={onMusclePress} />)
+      fireEvent.click(screen.getByTestId('body-map-muscle-chest'))
+      expect(onMusclePress).toHaveBeenCalledWith(MuscleGroup.CHEST)
+    })
+
+    it('reports a representative detailed muscle from a simple group tap', () => {
+      const onMusclePress = vi.fn()
+      render(<BodyMap data={data} view="front" mode="simple" onMusclePress={onMusclePress} />)
+      fireEvent.click(screen.getByTestId('body-map-muscle-back'))
+      expect(onMusclePress).toHaveBeenCalledWith(MuscleGroup.LATS)
+    })
+
+    it('calls onViewChange from the front/back toggle', () => {
+      const onViewChange = vi.fn()
+      render(<BodyMap data={data} view="front" onViewChange={onViewChange} />)
+      fireEvent.click(screen.getByTestId('body-map-toggle-back'))
+      expect(onViewChange).toHaveBeenCalledWith('back')
+      fireEvent.click(screen.getByTestId('body-map-toggle-front'))
+      expect(onViewChange).toHaveBeenCalledWith('front')
+    })
+  })
+
+  describe('highlighted muscle', () => {
+    it('marks the highlighted muscle button as pressed', () => {
+      render(<BodyMap data={data} view="front" highlightedMuscle={MuscleGroup.CHEST} />)
+      expect(screen.getByTestId('body-map-muscle-chest')).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByTestId('body-map-muscle-lats')).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('applies an edge glow when a muscle is highlighted', () => {
+      render(<BodyMap data={data} view="front" highlightedMuscle={MuscleGroup.QUADS} />)
+      const svg = screen.getByTestId('body-map-svg')
+      expect(svg.getAttribute('style') ?? '').toContain('box-shadow')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('labels each muscle button with name, status, and weekly sets', () => {
+      render(<BodyMap data={data} view="front" />)
+      expect(screen.getByLabelText('Chest, productive, 12 sets this week')).toBeInTheDocument()
+      expect(screen.getByLabelText('Lats, under-trained, 6 sets this week')).toBeInTheDocument()
+    })
+
+    it('labels the view toggle buttons', () => {
+      render(<BodyMap data={data} view="front" onViewChange={vi.fn()} />)
+      expect(screen.getByLabelText('Show front view')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show back view')).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations with data', async () => {
+      const { container } = render(
+        <BodyMap
+          data={data}
+          view="front"
+          onViewChange={vi.fn()}
+          onMusclePress={vi.fn()}
+          highlightedMuscle={MuscleGroup.CHEST}
+        />
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('has no accessibility violations when empty', async () => {
+      const { container } = render(<BodyMap data={[]} view="back" />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/BodyMap.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMap.tsx
@@ -1,0 +1,348 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useEffect, useMemo, useState } from 'react'
+import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import BodyHighlighter, { type ExtendedBodyPart, type Slug } from 'react-native-body-highlighter'
+import { cn } from '../../../utils/cn'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import {
+  MuscleGroup,
+  SimpleMuscleGroup,
+  MUSCLE_TO_SVG_SLUGS,
+  MUSCLE_DISPLAY_NAMES,
+  SIMPLE_DISPLAY_NAMES,
+  DETAILED_TO_SIMPLE,
+  SLUG_TO_PRIMARY_MUSCLE,
+  VOLUME_STATUS_LABELS,
+  getHeatmapColor,
+  isMoreSevere,
+  type VolumeStatus,
+} from './muscleTaxonomy'
+
+/**
+ * react-native-body-highlighter is published as a CommonJS default export; the
+ * interop keeps it working whether the bundler unwraps the default or not.
+ */
+const Body = ((BodyHighlighter as unknown as { default?: typeof BodyHighlighter }).default ??
+  BodyHighlighter) as typeof BodyHighlighter
+
+const OUTLINE_FILL = 'rgba(255,255,255,0.08)'
+const OUTLINE_BORDER = 'rgba(255,255,255,0.12)'
+const BODY_SCALE = 0.8 // 200x400 intrinsic -> ~160x320 px
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+
+export interface BodyMapData {
+  muscleGroup: MuscleGroup
+  /** Intensity 0-1 for heatmap color. */
+  intensity: number
+  /** Volume status for tooltip / heatmap token. */
+  volumeStatus: VolumeStatus
+  /** Weekly effective sets. */
+  weeklySets: number
+}
+
+export interface BodyMapProps extends ViewProps {
+  /** Muscle group intensity data. */
+  data: BodyMapData[]
+  /** Which view to show. */
+  view: 'front' | 'back'
+  /** Toggle between front/back. */
+  onViewChange?: (view: 'front' | 'back') => void
+  /** Called when a muscle group is tapped. */
+  onMusclePress?: (muscleGroup: MuscleGroup) => void
+  /** Currently highlighted muscle (from external selection). */
+  highlightedMuscle?: MuscleGroup | null
+  /** Show simplified (8 groups) or detailed (15 groups). */
+  mode?: 'simple' | 'detailed'
+  className?: string
+}
+
+interface LegendEntry {
+  key: string
+  name: string
+  status: VolumeStatus
+  intensity: number
+  sets: number
+  /** Detailed group reported to onMusclePress. */
+  muscle: MuscleGroup
+}
+
+/** Build the per-slug heatmap fill list, combining groups that share a slug. */
+function buildSlugParts(data: BodyMapData[]): ExtendedBodyPart[] {
+  const bySlug = new Map<string, { status: VolumeStatus; intensity: number }>()
+  for (const d of data) {
+    for (const slug of MUSCLE_TO_SVG_SLUGS[d.muscleGroup] ?? []) {
+      const existing = bySlug.get(slug)
+      if (!existing || isMoreSevere(d.volumeStatus, existing.status)) {
+        bySlug.set(slug, { status: d.volumeStatus, intensity: d.intensity })
+      }
+    }
+  }
+  return Array.from(bySlug.entries()).map(([slug, v]) => ({
+    slug: slug as Slug,
+    color: getHeatmapColor(v.status, v.intensity),
+  }))
+}
+
+/** Collapse data into per-simple-group legend entries (summed sets). */
+function buildSimpleLegend(data: BodyMapData[]): LegendEntry[] {
+  const bySimple = new Map<SimpleMuscleGroup, LegendEntry>()
+  for (const d of data) {
+    const simple = DETAILED_TO_SIMPLE[d.muscleGroup]
+    const existing = bySimple.get(simple)
+    if (!existing) {
+      bySimple.set(simple, {
+        key: simple,
+        name: SIMPLE_DISPLAY_NAMES[simple],
+        status: d.volumeStatus,
+        intensity: d.intensity,
+        sets: d.weeklySets,
+        muscle: d.muscleGroup,
+      })
+      continue
+    }
+    existing.sets += d.weeklySets
+    existing.intensity = Math.max(existing.intensity, d.intensity)
+    if (isMoreSevere(d.volumeStatus, existing.status)) {
+      existing.status = d.volumeStatus
+      existing.muscle = d.muscleGroup
+    }
+  }
+  return Array.from(bySimple.values())
+}
+
+/** One legend entry per data row, named by detailed group. */
+function buildDetailedLegend(data: BodyMapData[]): LegendEntry[] {
+  return data.map((d) => ({
+    key: d.muscleGroup,
+    name: MUSCLE_DISPLAY_NAMES[d.muscleGroup],
+    status: d.volumeStatus,
+    intensity: d.intensity,
+    sets: d.weeklySets,
+    muscle: d.muscleGroup,
+  }))
+}
+
+/**
+ * Interactive SVG body map with tappable muscle groups and a volume heatmap.
+ * Renders the front or back view (toggle via onViewChange), colors each muscle
+ * by its weekly-volume status, and exposes an accessible muscle legend wired to
+ * onMusclePress. Phase 1 uses react-native-body-highlighter's combined slugs
+ * (deltoids as one path, lats/upper-back shared); swipe between views and the
+ * delt/lat SVG split are follow-ups.
+ *
+ * @example
+ * <BodyMap
+ *   data={[{ muscleGroup: MuscleGroup.CHEST, intensity: 0.7, volumeStatus: 'productive', weeklySets: 12 }]}
+ *   view="front"
+ *   onViewChange={setView}
+ *   onMusclePress={setSelected}
+ *   highlightedMuscle={selected}
+ * />
+ */
+export function BodyMap({
+  data,
+  view,
+  onViewChange,
+  onMusclePress,
+  highlightedMuscle,
+  mode = 'detailed',
+  className,
+  ...props
+}: BodyMapProps) {
+  const slugParts = useMemo(() => buildSlugParts(data), [data])
+  const legend = useMemo(
+    () => (mode === 'simple' ? buildSimpleLegend(data) : buildDetailedLegend(data)),
+    [data, mode]
+  )
+
+  const [highlight] = useState(() => new Animated.Value(highlightedMuscle ? 1 : 0))
+  useEffect(() => {
+    const animation = Animated.timing(highlight, {
+      toValue: highlightedMuscle ? 1 : 0,
+      duration: 250,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: false,
+    })
+    animation.start()
+    return () => animation.stop()
+  }, [highlightedMuscle, highlight])
+
+  const scale = highlight.interpolate({ inputRange: [0, 1], outputRange: [1, 1.02] })
+  const glowColor = highlightedMuscle
+    ? getHeatmapColor(
+        data.find((d) => d.muscleGroup === highlightedMuscle)?.volumeStatus,
+        data.find((d) => d.muscleGroup === highlightedMuscle)?.intensity ?? 0
+      )
+    : null
+
+  const handleBodyPress = (part: ExtendedBodyPart) => {
+    if (!onMusclePress || !part.slug) return
+    const fromData = data.find((d) =>
+      (MUSCLE_TO_SVG_SLUGS[d.muscleGroup] ?? []).includes(part.slug as string)
+    )
+    const muscle = fromData?.muscleGroup ?? SLUG_TO_PRIMARY_MUSCLE[part.slug]
+    if (muscle) onMusclePress(muscle)
+  }
+
+  return (
+    <View className={cn(className)} testID="body-map" {...props}>
+      <ViewToggle view={view} onViewChange={onViewChange} />
+
+      <Animated.View
+        style={[
+          {
+            width: 200 * BODY_SCALE,
+            alignSelf: 'center',
+            transform: [{ scale }],
+          },
+          glowColor ? { boxShadow: `0 0 14px 2px ${glowColor}` } : undefined,
+        ]}
+        // The SVG is decorative; the accessible muscle legend below is the
+        // screen-reader / keyboard interface.
+        aria-hidden
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        testID="body-map-svg"
+      >
+        <Body
+          side={view}
+          data={slugParts}
+          scale={BODY_SCALE}
+          gender="male"
+          defaultFill={OUTLINE_FILL}
+          border={OUTLINE_BORDER}
+          onBodyPartPress={handleBodyPress}
+        />
+      </Animated.View>
+
+      {legend.length === 0 ? (
+        <Text
+          style={{
+            marginTop: 8,
+            fontSize: 12,
+            color: TEXT_SECONDARY,
+            textAlign: 'center',
+            fontFamily: 'Inter, sans-serif',
+          }}
+          testID="body-map-empty"
+        >
+          No training data
+        </Text>
+      ) : (
+        <View
+          className="flex-row flex-wrap"
+          style={{ marginTop: 10, gap: 6, justifyContent: 'center' }}
+          testID="body-map-legend"
+        >
+          {legend.map((entry) => (
+            <MuscleButton
+              key={entry.key}
+              entry={entry}
+              highlighted={highlightedMuscle === entry.muscle}
+              onMusclePress={onMusclePress}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}
+
+interface ViewToggleProps {
+  view: 'front' | 'back'
+  onViewChange?: (view: 'front' | 'back') => void
+}
+
+function ViewToggle({ view, onViewChange }: ViewToggleProps) {
+  return (
+    <View
+      className="flex-row self-center"
+      style={{ gap: 4, marginBottom: 8 }}
+      testID="body-map-view-toggle"
+    >
+      {(['front', 'back'] as const).map((side) => {
+        const active = view === side
+        return (
+          <Pressable
+            key={side}
+            onPress={() => onViewChange?.(side)}
+            accessibilityRole="button"
+            accessibilityLabel={`Show ${side} view`}
+            aria-pressed={active}
+            disabled={!onViewChange}
+            style={{
+              paddingHorizontal: 12,
+              paddingVertical: 4,
+              borderRadius: 9999,
+              backgroundColor: active ? 'rgba(255,121,0,0.16)' : 'transparent',
+              borderWidth: 1,
+              borderColor: active ? '#FF7900' : WORKOUT_TOKENS.border.strong,
+            }}
+            testID={`body-map-toggle-${side}`}
+          >
+            <Text
+              style={{
+                fontSize: 12,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: active ? '700' : '500',
+                color: active ? '#FF7900' : TEXT_SECONDARY,
+                textTransform: 'capitalize',
+              }}
+            >
+              {side}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+interface MuscleButtonProps {
+  entry: LegendEntry
+  highlighted: boolean
+  onMusclePress?: (muscleGroup: MuscleGroup) => void
+}
+
+function MuscleButton({ entry, highlighted, onMusclePress }: MuscleButtonProps) {
+  const dotColor = getHeatmapColor(entry.status, entry.intensity)
+  const label = `${entry.name}, ${VOLUME_STATUS_LABELS[entry.status]}, ${entry.sets} sets this week`
+  return (
+    <Pressable
+      onPress={() => onMusclePress?.(entry.muscle)}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      aria-pressed={highlighted}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 5,
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+        borderRadius: 9999,
+        borderWidth: 1,
+        borderColor: highlighted ? '#FF7900' : WORKOUT_TOKENS.border.default,
+        backgroundColor: WORKOUT_TOKENS.surface.raised,
+      }}
+      testID={`body-map-muscle-${entry.key}`}
+    >
+      <View
+        style={{ width: 7, height: 7, borderRadius: 9999, backgroundColor: dotColor }}
+        accessibilityElementsHidden
+        testID={`body-map-muscle-dot-${entry.key}`}
+      />
+      <Text
+        style={{
+          fontSize: 11,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: '500',
+          color: TEXT_PRIMARY,
+        }}
+        accessibilityElementsHidden
+      >
+        {entry.name}
+      </Text>
+    </Pressable>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -91,3 +91,19 @@ export {
   type WorkoutDot,
   type WorkoutDotStatus,
 } from './CapacityBandChart'
+export { BodyMap, type BodyMapProps, type BodyMapData } from './BodyMap'
+export {
+  MuscleGroup,
+  SimpleMuscleGroup,
+  SIMPLE_TO_DETAILED,
+  DETAILED_TO_SIMPLE,
+  MUSCLE_TO_SVG_SLUGS,
+  MUSCLE_TO_CATEGORY,
+  MUSCLE_DISPLAY_NAMES,
+  SIMPLE_DISPLAY_NAMES,
+  DEFAULT_VOLUME_LANDMARKS,
+  VOLUME_STATUS_LABELS,
+  getHeatmapColor,
+  type MovementCategory,
+  type VolumeLandmarks,
+} from './muscleTaxonomy'

--- a/packages/ui/src/components/custom/Workout/muscleTaxonomy.ts
+++ b/packages/ui/src/components/custom/Workout/muscleTaxonomy.ts
@@ -1,0 +1,252 @@
+/**
+ * Muscle grouping taxonomy for volume tracking, exercise mapping, and the
+ * BodyMap visualization. Ported from the Voltras muscle-taxonomy design doc.
+ *
+ * Level 2 (15 groups) is the primary volume-tracking unit; SimpleMuscleGroup
+ * (8 groups) is the beginner-facing aggregation. MUSCLE_TO_SVG_SLUGS maps each
+ * group to react-native-body-highlighter slugs using the closest-slug approach
+ * (Phase 1: combined colors, no sub-region splitting — deltoids is a single
+ * slug, lats and upper back share `upper-back`).
+ */
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+/**
+ * Full muscle group taxonomy for volume tracking and exercise mapping.
+ * 15 groups — the primary unit for volume accounting.
+ */
+export enum MuscleGroup {
+  // Push
+  CHEST = 'chest',
+  FRONT_DELTS = 'front_delts',
+  SIDE_DELTS = 'side_delts',
+  TRICEPS = 'triceps',
+
+  // Pull
+  LATS = 'lats',
+  UPPER_BACK = 'upper_back',
+  REAR_DELTS = 'rear_delts',
+  BICEPS = 'biceps',
+  FOREARMS = 'forearms',
+
+  // Legs
+  QUADS = 'quads',
+  HAMSTRINGS = 'hamstrings',
+  GLUTES = 'glutes',
+  CALVES = 'calves',
+
+  // Core
+  ABS = 'abs',
+  OBLIQUES = 'obliques',
+}
+
+/**
+ * Simplified muscle group view for beginners. Maps to one or more MuscleGroup.
+ */
+export enum SimpleMuscleGroup {
+  CHEST = 'chest',
+  BACK = 'back',
+  SHOULDERS = 'shoulders',
+  BICEPS = 'biceps',
+  TRICEPS = 'triceps',
+  LEGS = 'legs',
+  CORE = 'core',
+  FOREARMS = 'forearms',
+}
+
+/** Mapping from simplified groups to the full taxonomy. */
+export const SIMPLE_TO_DETAILED: Record<SimpleMuscleGroup, MuscleGroup[]> = {
+  [SimpleMuscleGroup.CHEST]: [MuscleGroup.CHEST],
+  [SimpleMuscleGroup.BACK]: [MuscleGroup.LATS, MuscleGroup.UPPER_BACK],
+  [SimpleMuscleGroup.SHOULDERS]: [
+    MuscleGroup.FRONT_DELTS,
+    MuscleGroup.SIDE_DELTS,
+    MuscleGroup.REAR_DELTS,
+  ],
+  [SimpleMuscleGroup.BICEPS]: [MuscleGroup.BICEPS],
+  [SimpleMuscleGroup.TRICEPS]: [MuscleGroup.TRICEPS],
+  [SimpleMuscleGroup.LEGS]: [
+    MuscleGroup.QUADS,
+    MuscleGroup.HAMSTRINGS,
+    MuscleGroup.GLUTES,
+    MuscleGroup.CALVES,
+  ],
+  [SimpleMuscleGroup.CORE]: [MuscleGroup.ABS, MuscleGroup.OBLIQUES],
+  [SimpleMuscleGroup.FOREARMS]: [MuscleGroup.FOREARMS],
+}
+
+/** Reverse map: detailed MuscleGroup -> its SimpleMuscleGroup. */
+export const DETAILED_TO_SIMPLE: Record<MuscleGroup, SimpleMuscleGroup> = Object.entries(
+  SIMPLE_TO_DETAILED
+).reduce(
+  (acc, [simple, groups]) => {
+    for (const group of groups) {
+      acc[group] = simple as SimpleMuscleGroup
+    }
+    return acc
+  },
+  {} as Record<MuscleGroup, SimpleMuscleGroup>
+)
+
+/** Movement category for training split organization. */
+export type MovementCategory = 'push' | 'pull' | 'legs' | 'core'
+
+export const MUSCLE_TO_CATEGORY: Record<MuscleGroup, MovementCategory> = {
+  [MuscleGroup.CHEST]: 'push',
+  [MuscleGroup.FRONT_DELTS]: 'push',
+  [MuscleGroup.SIDE_DELTS]: 'push',
+  [MuscleGroup.TRICEPS]: 'push',
+  [MuscleGroup.LATS]: 'pull',
+  [MuscleGroup.UPPER_BACK]: 'pull',
+  [MuscleGroup.REAR_DELTS]: 'pull',
+  [MuscleGroup.BICEPS]: 'pull',
+  [MuscleGroup.FOREARMS]: 'pull',
+  [MuscleGroup.QUADS]: 'legs',
+  [MuscleGroup.HAMSTRINGS]: 'legs',
+  [MuscleGroup.GLUTES]: 'legs',
+  [MuscleGroup.CALVES]: 'legs',
+  [MuscleGroup.ABS]: 'core',
+  [MuscleGroup.OBLIQUES]: 'core',
+}
+
+/**
+ * react-native-body-highlighter slug(s) per muscle group. Phase 1 uses the
+ * closest available slug; deltoids share one path and lats/upper-back share
+ * `upper-back` (see doc Level 4 "Recommended approach").
+ */
+export const MUSCLE_TO_SVG_SLUGS: Record<MuscleGroup, string[]> = {
+  [MuscleGroup.CHEST]: ['chest'],
+  [MuscleGroup.FRONT_DELTS]: ['deltoids'],
+  [MuscleGroup.SIDE_DELTS]: ['deltoids'],
+  [MuscleGroup.REAR_DELTS]: ['deltoids'],
+  [MuscleGroup.TRICEPS]: ['triceps'],
+  [MuscleGroup.LATS]: ['upper-back'],
+  [MuscleGroup.UPPER_BACK]: ['upper-back', 'trapezius'],
+  [MuscleGroup.BICEPS]: ['biceps'],
+  [MuscleGroup.FOREARMS]: ['forearm'],
+  [MuscleGroup.QUADS]: ['quadriceps'],
+  [MuscleGroup.HAMSTRINGS]: ['hamstring'],
+  [MuscleGroup.GLUTES]: ['gluteal'],
+  [MuscleGroup.CALVES]: ['calves'],
+  [MuscleGroup.ABS]: ['abs'],
+  [MuscleGroup.OBLIQUES]: ['obliques'],
+}
+
+/** Human-readable name per muscle group (used in a11y labels). */
+export const MUSCLE_DISPLAY_NAMES: Record<MuscleGroup, string> = {
+  [MuscleGroup.CHEST]: 'Chest',
+  [MuscleGroup.FRONT_DELTS]: 'Front Delts',
+  [MuscleGroup.SIDE_DELTS]: 'Side Delts',
+  [MuscleGroup.REAR_DELTS]: 'Rear Delts',
+  [MuscleGroup.TRICEPS]: 'Triceps',
+  [MuscleGroup.LATS]: 'Lats',
+  [MuscleGroup.UPPER_BACK]: 'Upper Back',
+  [MuscleGroup.BICEPS]: 'Biceps',
+  [MuscleGroup.FOREARMS]: 'Forearms',
+  [MuscleGroup.QUADS]: 'Quads',
+  [MuscleGroup.HAMSTRINGS]: 'Hamstrings',
+  [MuscleGroup.GLUTES]: 'Glutes',
+  [MuscleGroup.CALVES]: 'Calves',
+  [MuscleGroup.ABS]: 'Abs',
+  [MuscleGroup.OBLIQUES]: 'Obliques',
+}
+
+/** Human-readable name per simple group. */
+export const SIMPLE_DISPLAY_NAMES: Record<SimpleMuscleGroup, string> = {
+  [SimpleMuscleGroup.CHEST]: 'Chest',
+  [SimpleMuscleGroup.BACK]: 'Back',
+  [SimpleMuscleGroup.SHOULDERS]: 'Shoulders',
+  [SimpleMuscleGroup.BICEPS]: 'Biceps',
+  [SimpleMuscleGroup.TRICEPS]: 'Triceps',
+  [SimpleMuscleGroup.LEGS]: 'Legs',
+  [SimpleMuscleGroup.CORE]: 'Core',
+  [SimpleMuscleGroup.FOREARMS]: 'Forearms',
+}
+
+/** Volume landmarks per muscle group (weekly working sets). */
+export interface VolumeLandmarks {
+  mev: number // Minimum Effective Volume
+  mav: number // Maximum Adaptive Volume
+  mrv: number // Maximum Recoverable Volume
+}
+
+export const DEFAULT_VOLUME_LANDMARKS: Record<MuscleGroup, VolumeLandmarks> = {
+  [MuscleGroup.CHEST]: { mev: 8, mav: 14, mrv: 20 },
+  [MuscleGroup.LATS]: { mev: 8, mav: 14, mrv: 20 },
+  [MuscleGroup.UPPER_BACK]: { mev: 6, mav: 12, mrv: 18 },
+  [MuscleGroup.FRONT_DELTS]: { mev: 2, mav: 6, mrv: 10 },
+  [MuscleGroup.SIDE_DELTS]: { mev: 6, mav: 14, mrv: 22 },
+  [MuscleGroup.REAR_DELTS]: { mev: 6, mav: 12, mrv: 18 },
+  [MuscleGroup.BICEPS]: { mev: 4, mav: 10, mrv: 18 },
+  [MuscleGroup.TRICEPS]: { mev: 4, mav: 8, mrv: 14 },
+  [MuscleGroup.FOREARMS]: { mev: 2, mav: 6, mrv: 12 },
+  [MuscleGroup.QUADS]: { mev: 6, mav: 12, mrv: 18 },
+  [MuscleGroup.HAMSTRINGS]: { mev: 4, mav: 10, mrv: 16 },
+  [MuscleGroup.GLUTES]: { mev: 4, mav: 10, mrv: 16 },
+  [MuscleGroup.CALVES]: { mev: 6, mav: 10, mrv: 16 },
+  [MuscleGroup.ABS]: { mev: 0, mav: 8, mrv: 16 },
+  [MuscleGroup.OBLIQUES]: { mev: 0, mav: 6, mrv: 12 },
+}
+
+/** Weekly-volume status relative to MEV/MAV/MRV landmarks. */
+export type VolumeStatus = 'under' | 'maintenance' | 'productive' | 'over'
+
+/** Readable label per status for a11y descriptions. */
+export const VOLUME_STATUS_LABELS: Record<VolumeStatus, string> = {
+  under: 'under-trained',
+  maintenance: 'maintenance',
+  productive: 'productive',
+  over: 'over-reaching',
+}
+
+/** Severity ranking — higher wins when several groups share an SVG slug. */
+const STATUS_SEVERITY: Record<VolumeStatus, number> = {
+  under: 1,
+  maintenance: 2,
+  productive: 3,
+  over: 4,
+}
+
+/**
+ * Maps a volume status (and intensity, 0-1) to a heatmap fill color. The
+ * `approaching` token is used when a productive muscle nears its MRV.
+ */
+export function getHeatmapColor(status: VolumeStatus | null | undefined, intensity = 0): string {
+  const heatmap = WORKOUT_TOKENS.heatmap
+  switch (status) {
+    case 'under':
+      return heatmap.under
+    case 'maintenance':
+      return heatmap.maintenance
+    case 'productive':
+      return intensity >= 0.85 ? heatmap.approaching : heatmap.productive
+    case 'over':
+      return heatmap.over
+    default:
+      return heatmap.none
+  }
+}
+
+/** True when one status is at least as severe as another. */
+export function isMoreSevere(a: VolumeStatus, b: VolumeStatus): boolean {
+  return STATUS_SEVERITY[a] >= STATUS_SEVERITY[b]
+}
+
+/**
+ * Representative MuscleGroup for each SVG slug, used to resolve taps on shared
+ * paths (e.g. `deltoids`, `upper-back`) back to a single group.
+ */
+export const SLUG_TO_PRIMARY_MUSCLE: Record<string, MuscleGroup> = {
+  chest: MuscleGroup.CHEST,
+  deltoids: MuscleGroup.SIDE_DELTS,
+  triceps: MuscleGroup.TRICEPS,
+  'upper-back': MuscleGroup.LATS,
+  trapezius: MuscleGroup.UPPER_BACK,
+  biceps: MuscleGroup.BICEPS,
+  forearm: MuscleGroup.FOREARMS,
+  quadriceps: MuscleGroup.QUADS,
+  hamstring: MuscleGroup.HAMSTRINGS,
+  gluteal: MuscleGroup.GLUTES,
+  calves: MuscleGroup.CALVES,
+  abs: MuscleGroup.ABS,
+  obliques: MuscleGroup.OBLIQUES,
+}

--- a/packages/ui/src/theme/workout-tokens.ts
+++ b/packages/ui/src/theme/workout-tokens.ts
@@ -11,6 +11,17 @@ export const WORKOUT_TOKENS = {
     red: '#ff4757',
   },
 
+  // BodyMap volume heatmap scale (drive dynamic SVG fills, so inline values).
+  // Maps weekly-volume status against MEV/MAV/MRV landmarks to a fill color.
+  heatmap: {
+    none: '#E0E0E0', // gray — no training data
+    under: '#4A90D9', // cool blue — below MEV
+    maintenance: '#F5C842', // warm yellow — MEV to MAV
+    productive: '#4CAF50', // green — MAV to MRV
+    approaching: '#FFA502', // orange — near MRV
+    over: '#FF6B35', // red-orange — over MRV
+  },
+
   // Badge border-radius (rounded-sm is 4px, we need 2px)
   badgeRadius: 2,
 

--- a/packages/ui/vite-rn-svg-plugins.ts
+++ b/packages/ui/vite-rn-svg-plugins.ts
@@ -1,0 +1,111 @@
+import { createRequire } from 'node:module'
+import { dirname, resolve as resolvePath } from 'node:path'
+import { existsSync } from 'node:fs'
+import type { Alias, Plugin } from 'vite'
+
+const require = createRequire(import.meta.url)
+// esbuild ships nested under vite in the pnpm store; resolve it from there.
+const esbuild = createRequire(require.resolve('vite'))('esbuild') as typeof import('esbuild')
+
+/** Absolute path to react-native-svg's ESM ("module") build entry. */
+export const svgModuleEntry = (() => {
+  try {
+    return resolvePath(
+      dirname(require.resolve('react-native-svg/package.json')),
+      'lib/module/index.js'
+    )
+  } catch {
+    return 'react-native-svg'
+  }
+})()
+
+/**
+ * react-native-svg ships web implementations as `.web.js` siblings of its
+ * native (Flow) Fabric sources and relies on a bundler's React Native
+ * platform-extension resolution to pick them. Node-based resolvers never honor
+ * `.web.js`, so its relative imports would load the native Flow files
+ * (`Unexpected token 'typeof'`). The bare specifier is aliased to the ESM build
+ * (see svgWebAliases); this plugin rewrites each relative import inside the
+ * package to its `.web.js` sibling when one exists.
+ */
+export function reactNativeSvgWebResolver(): Plugin {
+  return {
+    name: 'react-native-svg-web-resolver',
+    enforce: 'pre',
+    resolveId(source, importer) {
+      if (!importer || !importer.includes('react-native-svg') || !source.startsWith('.')) {
+        return null
+      }
+      const base = resolvePath(dirname(importer), source)
+      for (const candidate of [`${base}.web.js`, `${base}/index.web.js`]) {
+        if (existsSync(candidate)) return candidate
+      }
+      return null
+    },
+  }
+}
+
+/**
+ * react-native-body-highlighter@3.2.0 ships untranspiled JSX inside a CommonJS
+ * dist whose `require('react-native-svg')` would, under a Node resolver, load
+ * react-native-svg's native Flow sources. Bundle the package entry to a single
+ * self-contained ESM module with esbuild — JSX compiled via the automatic
+ * runtime, react-native-svg's WEB build inlined, react/react-native external.
+ */
+export function reactNativeBodyHighlighterEsm(): Plugin {
+  let entry: string | null = null
+  try {
+    entry = require.resolve('react-native-body-highlighter')
+  } catch {
+    entry = null
+  }
+  return {
+    name: 'react-native-body-highlighter-esm',
+    enforce: 'pre',
+    async transform(_code, id) {
+      if (!entry || id.split('?')[0] !== entry) return null
+      const result = await esbuild.build({
+        entryPoints: [entry],
+        bundle: true,
+        format: 'esm',
+        platform: 'browser',
+        jsx: 'automatic',
+        loader: { '.js': 'jsx' },
+        alias: { 'react-native-svg': svgModuleEntry },
+        resolveExtensions: [
+          '.web.js',
+          '.web.ts',
+          '.web.tsx',
+          '.web.jsx',
+          '.js',
+          '.ts',
+          '.tsx',
+          '.jsx',
+          '.json',
+        ],
+        mainFields: ['module', 'main'],
+        external: ['react', 'react/jsx-runtime', 'react-native'],
+        write: false,
+        logLevel: 'silent',
+      })
+      return { code: result.outputFiles[0].text, map: null }
+    },
+  }
+}
+
+/** Alias entries that point react-native(-svg) at their web builds. */
+export const svgWebAliases: Alias[] = [{ find: /^react-native-svg$/, replacement: svgModuleEntry }]
+
+/** `.web.*`-first extension order so web platform files win over native. */
+export const webResolveExtensions = [
+  '.web.tsx',
+  '.web.ts',
+  '.web.jsx',
+  '.web.js',
+  '.tsx',
+  '.ts',
+  '.jsx',
+  '.js',
+  '.mjs',
+  '.json',
+]

--- a/packages/ui/vite-rn-svg-plugins.ts
+++ b/packages/ui/vite-rn-svg-plugins.ts
@@ -33,7 +33,11 @@ export function reactNativeSvgWebResolver(): Plugin {
     name: 'react-native-svg-web-resolver',
     enforce: 'pre',
     resolveId(source, importer) {
-      if (!importer || !importer.includes('react-native-svg') || !source.startsWith('.')) {
+      // Path-bounded match: only the real package dir (.../node_modules/react-native-svg/...)
+      // contains '/react-native-svg/'. pnpm peer-hash dirs encode it as
+      // 'react-native-svg@<version>' (e.g. lucide-react-native's hash), so a bare
+      // substring would over-match and rewrite their relative imports too.
+      if (!importer || !importer.includes('/react-native-svg/') || !source.startsWith('.')) {
         return null
       }
       const base = resolvePath(dirname(importer), source)
@@ -96,16 +100,22 @@ export function reactNativeBodyHighlighterEsm(): Plugin {
 /** Alias entries that point react-native(-svg) at their web builds. */
 export const svgWebAliases: Alias[] = [{ find: /^react-native-svg$/, replacement: svgModuleEntry }]
 
-/** `.web.*`-first extension order so web platform files win over native. */
+/**
+ * `.web.*`-first extension order so web platform files win over native. The
+ * remainder mirrors Vite's default extension order, so using this as a full
+ * replacement stays equivalent to "web-prepended defaults" — preserving `.mjs`
+ * priority and `.mts`, which a hand-trimmed list would otherwise drop.
+ */
 export const webResolveExtensions = [
   '.web.tsx',
   '.web.ts',
   '.web.jsx',
   '.web.js',
-  '.tsx',
+  '.mjs',
+  '.js',
+  '.mts',
   '.ts',
   '.jsx',
-  '.js',
-  '.mjs',
+  '.tsx',
   '.json',
 ]

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,23 +1,33 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import {
+  reactNativeSvgWebResolver,
+  reactNativeBodyHighlighterEsm,
+  svgWebAliases,
+  webResolveExtensions,
+} from './vite-rn-svg-plugins'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [reactNativeSvgWebResolver(), reactNativeBodyHighlighterEsm(), react()],
   test: {
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['src/**/*.visual.test.{ts,tsx}', 'node_modules'],
+    // Inline react-native-svg so its relative imports run through the resolver
+    // plugin above and resolve to the `.web.js` implementations instead of
+    // being externalized to Node (which would load the native Flow sources).
+    server: {
+      deps: {
+        inline: ['react-native-svg', 'react-native-body-highlighter'],
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       include: ['src/components/**/*.{ts,tsx}'],
-      exclude: [
-        'src/**/*.stories.tsx',
-        'src/**/*.test.tsx',
-        'src/**/index.ts',
-      ],
+      exclude: ['src/**/*.stories.tsx', 'src/**/*.test.tsx', 'src/**/index.ts'],
       thresholds: {
         statements: 80,
         branches: 80,
@@ -27,9 +37,11 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      'react-native': 'react-native-web',
-      '@': './src',
-    },
+    alias: [
+      ...svgWebAliases,
+      { find: /^react-native$/, replacement: 'react-native-web' },
+      { find: '@', replacement: './src' },
+    ],
+    extensions: webResolveExtensions,
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,16 +25,10 @@ importers:
         version: 2.1.1
       lucide-react-native:
         specifier: '>=0.400.0'
-        version: 0.563.0(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+        version: 0.563.0(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       react-native:
         specifier: '>=0.72.0'
         version: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
-      react-native-body-highlighter:
-        specifier: ^3.2.0
-        version: 3.2.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
-      react-native-svg:
-        specifier: ^15.15.5
-        version: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -117,6 +111,12 @@ importers:
       react-dom:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
+      react-native-body-highlighter:
+        specifier: ^3.2.0
+        version: 3.2.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      react-native-svg:
+        specifier: ^15.15.5
+        version: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       react-native-web:
         specifier: ^0.19.0
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4286,12 +4286,6 @@ packages:
       react-native: '*'
       react-native-worklets: '>=0.7.0'
 
-  react-native-svg@15.15.1:
-    resolution: {integrity: sha512-ZUD1xwc3Hwo4cOmOLumjJVoc7lEf9oQFlHnLmgccLC19fNm6LVEdtB+Cnip6gEi0PG3wfvVzskViEtrySQP8Fw==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
   react-native-svg@15.15.5:
     resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
     peerDependencies:
@@ -5103,9 +5097,6 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-
-  warn-once@0.1.1:
-    resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -9513,11 +9504,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react-native@0.563.0(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
+  lucide-react-native@0.563.0(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
-      react-native-svg: 15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
 
   lucide-react@0.469.0(react@18.3.1):
     dependencies:
@@ -10141,14 +10132,6 @@ snapshots:
       react-native-is-edge-to-edge: 1.2.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       react-native-worklets: 0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       semver: 7.7.3
-
-  react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      css-select: 5.2.2
-      css-tree: 1.1.3
-      react: 18.3.1
-      react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
-      warn-once: 0.1.1
 
   react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -11131,8 +11114,6 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
-
-  warn-once@0.1.1: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.0.57
       '@gluestack-ui/themed':
         specifier: ^1.1.0
-        version: 1.1.73(@gluestack-style/react@1.0.57)(@types/react-native@0.73.0(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+        version: 1.1.73(@gluestack-style/react@1.0.57)(@types/react-native@0.73.0(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -29,6 +29,12 @@ importers:
       react-native:
         specifier: '>=0.72.0'
         version: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
+      react-native-body-highlighter:
+        specifier: ^3.2.0
+        version: 3.2.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      react-native-svg:
+        specifier: ^15.15.5
+        version: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -101,7 +107,7 @@ importers:
         version: 0.469.0(react@18.3.1)
       nativewind:
         specifier: ^4.2.1
-        version: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
+        version: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -991,8 +997,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@expo/html-elements@55.0.3':
-    resolution: {integrity: sha512-/adnZVHXZ9NaaR7z5bz9lIFmIvMX8ghEfWucAjwuUwcq4jFfgun6VYjhs/9s0j93EC1FQl9HXWnl8oGCxp0YZg==}
+  '@expo/html-elements@56.0.1':
+    resolution: {integrity: sha512-cy9LTItlr+7kkC5289kW4un6qW4JZ3THu348ExXiTJcDXQufR+N+OvYS/Bxgm/gChMhvT673bphp8FwfSgARBA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -4245,6 +4251,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-native-body-highlighter@3.2.0:
+    resolution: {integrity: sha512-BxWwcX8PtbKr3X0bW0n4OyPT6b+2R9IUqDyMgq8PP6IhJouSt9ik10a3c7PRYOlA2DdrBjLFiwamqhsMS2BfeQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-css-interop@0.2.1:
     resolution: {integrity: sha512-B88f5rIymJXmy1sNC/MhTkb3xxBej1KkuAt7TiT9iM7oXz3RM8Bn+7GUrfR02TvSgKm4cg2XiSuLEKYfKwNsjA==}
     engines: {node: '>=18'}
@@ -4276,6 +4288,12 @@ packages:
 
   react-native-svg@15.15.1:
     resolution: {integrity: sha512-ZUD1xwc3Hwo4cOmOLumjJVoc7lEf9oQFlHnLmgccLC19fNm6LVEdtB+Cnip6gEi0PG3wfvVzskViEtrySQP8Fw==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-svg@15.15.5:
+    resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -5927,7 +5945,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/html-elements@55.0.3(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
+  '@expo/html-elements@56.0.1(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
@@ -5964,10 +5982,10 @@ snapshots:
     dependencies:
       '@gluestack-style/react': 1.0.57
 
-  '@gluestack-style/legend-motion-animation-driver@1.0.3(@gluestack-style/react@1.0.57)(@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))':
+  '@gluestack-style/legend-motion-animation-driver@1.0.3(@gluestack-style/react@1.0.57)(@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@gluestack-style/react': 1.0.57
-      '@legendapp/motion': 2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      '@legendapp/motion': 2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
 
   '@gluestack-style/react@1.0.57':
     dependencies:
@@ -6289,11 +6307,11 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@gluestack-ui/themed@1.1.73(@gluestack-style/react@1.0.57)(@types/react-native@0.73.0(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
+  '@gluestack-ui/themed@1.1.73(@gluestack-style/react@1.0.57)(@types/react-native@0.73.0(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@expo/html-elements': 55.0.3(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      '@expo/html-elements': 56.0.1(react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       '@gluestack-style/animation-resolver': 1.0.4(@gluestack-style/react@1.0.57)
-      '@gluestack-style/legend-motion-animation-driver': 1.0.3(@gluestack-style/react@1.0.57)(@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))
+      '@gluestack-style/legend-motion-animation-driver': 1.0.3(@gluestack-style/react@1.0.57)(@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))
       '@gluestack-style/react': 1.0.57
       '@gluestack-ui/accordion': 1.0.14(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       '@gluestack-ui/actionsheet': 0.2.53(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
@@ -6325,12 +6343,12 @@ snapshots:
       '@gluestack-ui/textarea': 0.1.25(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       '@gluestack-ui/toast': 1.0.9(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       '@gluestack-ui/tooltip': 0.1.44(react-dom@18.3.1(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
-      '@legendapp/motion': 2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      '@legendapp/motion': 2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       '@types/react-native': 0.73.0(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
-      react-native-svg: 15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       react-native-web: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - nativewind
@@ -6519,10 +6537,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
+  '@legendapp/motion@2.5.3(nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@legendapp/tools': 2.0.1(react@18.3.1)
-      nativewind: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
+      nativewind: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
       react: 18.3.1
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
 
@@ -9766,11 +9784,11 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)):
+  nativewind@4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)):
     dependencies:
       comment-json: 4.5.1
       debug: 4.4.3
-      react-native-css-interop: 0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
+      react-native-css-interop: 0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
       tailwindcss: 3.4.19(yaml@2.8.2)
     transitivePeerDependencies:
       - react
@@ -10088,7 +10106,13 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-css-interop@0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)):
+  react-native-body-highlighter@3.2.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
+      react-native-svg: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+
+  react-native-css-interop@0.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2)):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.28.6
@@ -10101,7 +10125,7 @@ snapshots:
       semver: 7.7.3
       tailwindcss: 3.4.19(yaml@2.8.2)
     optionalDependencies:
-      react-native-svg: 15.15.1(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10125,6 +10149,13 @@ snapshots:
       react: 18.3.1
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
       warn-once: 0.1.1
+
+  react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 18.3.1
+      react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
 
   react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## BodyMap organism (TD-03.23, spec §22)

Interactive SVG body map with tappable muscle groups and a weekly-volume heatmap. Renders the front or back view, colors each muscle by its volume status, edge-glows the highlighted muscle, and exposes an accessible muscle legend wired to `onMusclePress`.

### ⚠️ New runtime dependencies on the published package
This adds two **runtime** deps to `@titan-design/react-ui` (both in `dependencies`, externalized in the dist bundle):
- **`react-native-svg@15.15.5`** — peer of react-native (already present).
- **`react-native-body-highlighter@3.2.0`** — the SVG body component.

These are the first SVG-rendering deps in the package; please review the dependency surface.

### Making react-native-svg render under vitest (jsdom) + Storybook
react-native-svg ships native (Flow) Fabric sources alongside `.web.js` web implementations and relies on the bundler's React Native platform-extension resolution. vitest's Node resolver and esbuild ignore `.web.js`, and `react-native-body-highlighter` ships **untranspiled JSX inside a CommonJS dist**. Settled in a new shared module **`packages/ui/vite-rn-svg-plugins.ts`**, consumed by both `vitest.config.ts` and `.storybook/main.ts`:
- Alias `react-native-svg` → its ESM web build + a `resolveId` plugin that rewrites its relative imports to `.web.js` siblings; `.web.*`-first `resolve.extensions`.
- An esbuild transform that **bundles `react-native-body-highlighter`'s entry to ESM** (automatic JSX runtime, react-native-svg's web build inlined, react/react-native external) so its CJS `require('react-native-svg')` never loads the native Flow sources.

The real `<Body/>` SVG renders for real in tests (no mocking) — confirmed by a smoke test before building.

### Config files changed
- `vitest.config.ts` — import shared plugins; inline svg libs.
- `.storybook/main.ts` — `viteFinal` mirrors the same resolution.
- `packages/ui/vite-rn-svg-plugins.ts` — new shared plugin module.
- `package.json` / `pnpm-lock.yaml` — the two deps.

### Taxonomy module (`muscleTaxonomy.ts`)
Ported from the Voltras muscle-taxonomy doc: `MuscleGroup` (15), `SimpleMuscleGroup` (8), `SIMPLE_TO_DETAILED`, `MUSCLE_TO_SVG_SLUGS` (Phase 1 closest-slug), `MUSCLE_TO_CATEGORY`, `DEFAULT_VOLUME_LANDMARKS`, display-name maps, and a `volumeStatus`/intensity → heatmap-color helper.

### 6 new heatmap tokens (in `WORKOUT_TOKENS.heatmap`)
`none #E0E0E0`, `under #4A90D9`, `maintenance #F5C842`, `productive #4CAF50`, `approaching #FFA502`, `over #FF6B35` — inline values since they drive dynamic SVG fills.

### Phase 1 simplifications vs spec
- Deltoids share one SVG slug; lats + upper-back share the `upper-back` path (no sub-region split — Phase 2 forks the SVG).
- Front/back are toggled via `onViewChange`; swipe is a follow-up.
- Glow is `box-shadow` + a 250 ms scale animation; the SVG itself is `aria-hidden` and the accessible muscle legend (role=button, `"{name}, {status}, {sets} sets this week"`) is the screen-reader/keyboard interface.

### Verify (packages/ui)
- `pnpm type-check` → 0 errors
- `pnpm lint` → 0 errors (0 warnings in new files)
- `pnpm test --run` → **74 files / 1275 tests pass**, incl. 14 BodyMap tests with 2 jest-axe checks
- `pnpm build` → success incl. DTS; svg libs stay external imports in dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
