### PR TITLE
Fix BodyMap render in Storybook via Vite dep optimizer (TD-03.37)

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-native-web-vite'
 import {
   reactNativeSvgWebResolver,
-  reactNativeBodyHighlighterEsm,
+  reactNativeSvgWebResolverEsbuild,
   svgWebAliases,
   webResolveExtensions,
 } from '../vite-rn-svg-plugins'
@@ -19,12 +19,19 @@ const config: StorybookConfig = {
   },
   // Mirror the test runner's react-native-svg web resolution so the real
   // <Body/> SVG renders under react-native-web in Storybook too.
+  //
+  // Unlike vitest, Storybook serves to a real browser, so the dependencies must
+  // resolve to plain ESM with no throwing dynamic `require()`. Instead of
+  // hand-bundling react-native-body-highlighter with a nested esbuild that
+  // externalizes react/react-native (which esbuild emits as a dynamic
+  // `require('react')` — fatal in the browser), let Vite's own dep optimizer
+  // pre-bundle it: the optimizer rewrites bare imports of the project's real
+  // react / react-native(-web) to the app's single copies (proper ESM, no
+  // dynamic require, no duplicate react / invalid-hook-call). The svg `.web.js`
+  // resolution that the Vite resolveId plugin provides for non-pre-bundled
+  // paths is replayed inside the optimizer via the esbuild-plugin form.
   viteFinal: async (cfg) => {
-    cfg.plugins = [
-      reactNativeSvgWebResolver(),
-      reactNativeBodyHighlighterEsm(),
-      ...(cfg.plugins ?? []),
-    ]
+    cfg.plugins = [reactNativeSvgWebResolver(), ...(cfg.plugins ?? [])]
     cfg.resolve = cfg.resolve ?? {}
     const existingAlias = cfg.resolve.alias
     const existingAliasArray = Array.isArray(existingAlias)
@@ -36,11 +43,21 @@ const config: StorybookConfig = {
     cfg.resolve.alias = [...svgWebAliases, ...existingAliasArray]
     cfg.resolve.extensions = [...webResolveExtensions, ...(cfg.resolve.extensions ?? [])]
     cfg.optimizeDeps = cfg.optimizeDeps ?? {}
-    cfg.optimizeDeps.exclude = [
-      ...(cfg.optimizeDeps.exclude ?? []),
+    cfg.optimizeDeps.include = [
+      ...(cfg.optimizeDeps.include ?? []),
       'react-native-svg',
       'react-native-body-highlighter',
     ]
+    cfg.optimizeDeps.esbuildOptions = {
+      ...(cfg.optimizeDeps.esbuildOptions ?? {}),
+      loader: { ...(cfg.optimizeDeps.esbuildOptions?.loader ?? {}), '.js': 'jsx' },
+      jsx: 'automatic',
+      resolveExtensions: webResolveExtensions,
+      plugins: [
+        ...(cfg.optimizeDeps.esbuildOptions?.plugins ?? []),
+        reactNativeSvgWebResolverEsbuild(),
+      ],
+    }
     return cfg
   },
 }

--- a/packages/ui/vite-rn-svg-plugins.ts
+++ b/packages/ui/vite-rn-svg-plugins.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module'
 import { dirname, resolve as resolvePath } from 'node:path'
 import { existsSync } from 'node:fs'
 import type { Alias, Plugin } from 'vite'
+import type { Plugin as EsbuildPlugin } from 'esbuild'
 
 const require = createRequire(import.meta.url)
 // esbuild ships nested under vite in the pnpm store; resolve it from there.
@@ -93,6 +94,33 @@ export function reactNativeBodyHighlighterEsm(): Plugin {
         logLevel: 'silent',
       })
       return { code: result.outputFiles[0].text, map: null }
+    },
+  }
+}
+
+/**
+ * esbuild-plugin equivalent of {@link reactNativeSvgWebResolver}, for use during
+ * Vite's dependency pre-bundling (`optimizeDeps.esbuildOptions.plugins`). The
+ * Vite `resolveId` plugin above never runs inside esbuild's optimizer pass, so
+ * when react-native-svg / react-native-body-highlighter are pre-bundled (rather
+ * than excluded) the same web resolution must be replayed here:
+ *   - bare `react-native-svg` -> its ESM ("module") build entry, and
+ *   - relative imports inside the package -> their `.web.js` siblings when one
+ *     exists (so the web implementations win over the native Flow sources).
+ */
+export function reactNativeSvgWebResolverEsbuild(): EsbuildPlugin {
+  return {
+    name: 'react-native-svg-web-resolver-esbuild',
+    setup(build) {
+      build.onResolve({ filter: /^react-native-svg$/ }, () => ({ path: svgModuleEntry }))
+      build.onResolve({ filter: /^\./ }, (args) => {
+        if (!args.importer.includes('/react-native-svg/')) return null
+        const base = resolvePath(dirname(args.importer), args.path)
+        for (const candidate of [`${base}.web.js`, `${base}/index.web.js`]) {
+          if (existsSync(candidate)) return { path: candidate }
+        }
+        return null
+      })
     },
   }
 }


### PR DESCRIPTION
## The bug (TD-03.37)
Loading the **BodyMap** story in the Storybook dev server threw `Error: Dynamic require of "react" is not supported`, so it failed to render — while the other 6 workout organisms rendered fine.

## Root cause
The story's `react-native-body-highlighter@3.2.0` dependency was hand-bundled by `reactNativeBodyHighlighterEsm()` in `vite-rn-svg-plugins.ts` — a Vite `transform` plugin that runs a nested `esbuild.build({ format: 'esm', external: ['react','react/jsx-runtime','react-native'], ... })`. esbuild emits a **throwing dynamic `require()`** for those externals. That is tolerated under vitest/jsdom and irrelevant to the tsup build (which externalizes the libs), but it is **fatal in the real browser** Storybook serves to. That's why CI (build + vitest) stayed green while the preview was broken.

## The fix
Stop hand-bundling body-highlighter for Storybook; let **Vite's own dep optimizer** consume it instead.
- `.storybook/main.ts` viteFinal: removed `reactNativeBodyHighlighterEsm()` from `plugins`; moved `react-native-svg` + `react-native-body-highlighter` from `optimizeDeps.exclude` to `optimizeDeps.include`, with `optimizeDeps.esbuildOptions` set to `loader: { '.js': 'jsx' }`, `jsx: 'automatic'`, `resolveExtensions: webResolveExtensions`, and a new esbuild plugin in `esbuildOptions.plugins`.
- Added `reactNativeSvgWebResolverEsbuild()` to `vite-rn-svg-plugins.ts` — the esbuild-plugin equivalent of the existing Vite `reactNativeSvgWebResolver` (which never runs during esbuild pre-bundling): `onResolve` bare `react-native-svg` -> its ESM entry, and relative imports inside the package -> their `.web.js` siblings.
- Kept `svgWebAliases` in `resolve.alias` and `reactNativeSvgWebResolver()` for non-pre-bundled paths.

The optimizer pre-bundles to plain ESM and rewrites bare `react` / `react-native(-web)` imports to the project's single copies — no dynamic require, no duplicate react / invalid-hook-call.

**The vitest path is left fully intact** — `reactNativeBodyHighlighterEsm()` and `vitest.config.ts` are unchanged.

## Verification
- `pnpm type-check` -> 0 errors
- `pnpm test -- --run` -> **1298 passed / 75 files** (incl. the 14 BodyMap tests)
- `pnpm build` -> success
- **Storybook preview**: launched `pnpm storybook --ci`, screenshotted the BodyMap story (`custom-workout-bodymap--front`) with Playwright. It now renders the full front-view **anatomical body SVG** with color-coded muscle regions (green delts/chest, blue biceps, yellow abs, orange quads), the Front/Back toggle, and the accessible muscle legend — no "Dynamic require" error page. Console shows only benign react-native-web event-prop warnings. Smoke-checked `custom-workout-mesostatuscard--default` (non-svg) still renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
