### PR TITLE
Add JSON schema for the per-component CSS property manifest (TD-06.01)

### DIFF
--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -3,11 +3,12 @@ export * from './tokens'
 export * from './config'
 export * from './shadows'
 export * from './elevation'
+export * from './manifest'
 
 // Re-export commonly used items
 export { getSemanticColors, type ThemeMode } from './tokens/semantic'
 export { getThemeCSSVars, gluestackConfig } from './config'
-export { 
+export {
   neumorphicShadows,
   // Color math utilities (HSV-based)
   lighten,

--- a/packages/ui/src/theme/manifest/css-property-manifest.example.json
+++ b/packages/ui/src/theme/manifest/css-property-manifest.example.json
@@ -1,0 +1,79 @@
+{
+  "component": "button",
+  "description": "Illustrative example conforming to css-property-manifest.schema.json. Values are derived from Button.tsx's variant/color/size style maps and the semantic token definitions they reference, not measured via getComputedStyle — a follow-up ticket generates verified manifests from the rendered Storybook DOM.",
+  "baseVariant": { "variant": "solid", "color": "primary", "size": "md" },
+  "properties": [
+    {
+      "property": "backgroundColor",
+      "token": "brand-primary",
+      "cssVariable": "--color-brand-primary",
+      "resolvedValue": "rgb(255, 121, 0)",
+      "variantOverrides": [
+        {
+          "variant": { "variant": "outline" },
+          "token": null,
+          "cssVariable": null,
+          "resolvedValue": "rgba(0, 0, 0, 0)"
+        },
+        {
+          "variant": { "variant": "solid", "color": "error" },
+          "token": "status-error",
+          "cssVariable": "--color-status-error",
+          "resolvedValue": "rgb(209, 67, 67)"
+        }
+      ]
+    },
+    {
+      "property": "color",
+      "token": null,
+      "resolvedValue": "rgb(255, 255, 255)",
+      "variantOverrides": [
+        {
+          "variant": { "variant": "outline" },
+          "token": "brand-primary",
+          "cssVariable": "--color-brand-primary",
+          "resolvedValue": "rgb(255, 121, 0)"
+        }
+      ]
+    },
+    {
+      "property": "borderColor",
+      "token": null,
+      "resolvedValue": "rgba(0, 0, 0, 0)",
+      "variantOverrides": [
+        {
+          "variant": { "variant": "outline" },
+          "token": "brand-primary",
+          "cssVariable": "--color-brand-primary",
+          "resolvedValue": "rgb(255, 121, 0)"
+        }
+      ]
+    },
+    {
+      "property": "borderWidth",
+      "token": null,
+      "resolvedValue": "0px",
+      "variantOverrides": [
+        {
+          "variant": { "variant": "outline" },
+          "token": null,
+          "resolvedValue": "2px"
+        }
+      ]
+    },
+    {
+      "property": "borderRadius",
+      "token": null,
+      "resolvedValue": "6px"
+    },
+    {
+      "property": "paddingLeft",
+      "token": null,
+      "resolvedValue": "20px",
+      "variantOverrides": [
+        { "variant": { "size": "sm" }, "token": null, "resolvedValue": "16px" },
+        { "variant": { "size": "lg" }, "token": null, "resolvedValue": "24px" }
+      ]
+    }
+  ]
+}

--- a/packages/ui/src/theme/manifest/css-property-manifest.schema.json
+++ b/packages/ui/src/theme/manifest/css-property-manifest.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://titan-design.dev/schemas/css-property-manifest.schema.json",
+  "title": "Component CSS Property Manifest",
+  "description": "Per-component record of visual CSS properties, the design token each one resolves from, the expected computed style value, and any per-variant overrides. Generated manifests serve as fixtures for Playwright computed-style assertions (see packages/ui/tests/visual).",
+  "type": "object",
+  "required": ["component", "properties"],
+  "additionalProperties": false,
+  "properties": {
+    "component": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Component identifier matching its src/components/ui/{component} directory and Storybook id (e.g. \"button\")."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional human-readable note about what this manifest covers."
+    },
+    "baseVariant": {
+      "$ref": "#/$defs/variantAxes",
+      "description": "The variant axis values (e.g. { \"variant\": \"solid\", \"color\": \"primary\", \"size\": \"md\" }) that each property's top-level resolvedValue was captured against. Axis names must match the component's own prop names."
+    },
+    "properties": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/cssPropertyEntry" },
+      "description": "One entry per visual CSS property tracked for this component."
+    }
+  },
+  "$defs": {
+    "variantAxes": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "type": "string" },
+      "description": "A set of variant axis name/value pairs (e.g. variant, color, size, state) as accepted by the component's props."
+    },
+    "cssPropertyEntry": {
+      "type": "object",
+      "required": ["property", "token", "resolvedValue"],
+      "additionalProperties": false,
+      "properties": {
+        "property": {
+          "type": "string",
+          "pattern": "^[a-zA-Z]+$",
+          "description": "CSS property name in camelCase as returned by window.getComputedStyle (e.g. backgroundColor, borderColor, fontSize)."
+        },
+        "token": {
+          "type": ["string", "null"],
+          "description": "Semantic design token key this property is sourced from (e.g. \"brand-primary\"), matching a key in packages/ui/src/theme/tokens/semantic.ts. Use null when the value is a literal not backed by a token."
+        },
+        "cssVariable": {
+          "type": ["string", "null"],
+          "description": "CSS custom property backing the token (e.g. \"--color-brand-primary\"), as declared in packages/ui/src/theme/global.css. Omit or null when no CSS variable is involved."
+        },
+        "resolvedValue": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Expected computed style value for baseVariant, in the format getComputedStyle returns it (e.g. \"rgb(255, 121, 0)\", \"8px\")."
+        },
+        "variantOverrides": {
+          "type": "array",
+          "default": [],
+          "items": { "$ref": "#/$defs/variantOverride" },
+          "description": "Overrides of token/resolvedValue for specific variant axis combinations, merged onto baseVariant."
+        }
+      }
+    },
+    "variantOverride": {
+      "type": "object",
+      "required": ["variant", "resolvedValue"],
+      "additionalProperties": false,
+      "properties": {
+        "variant": {
+          "$ref": "#/$defs/variantAxes",
+          "description": "Partial variant axis values that trigger this override (e.g. { \"variant\": \"outline\" } or { \"color\": \"error\", \"state\": \"hover\" })."
+        },
+        "token": {
+          "type": ["string", "null"],
+          "description": "Semantic token key for this override, or null for a literal value."
+        },
+        "cssVariable": {
+          "type": ["string", "null"],
+          "description": "CSS custom property backing the token for this override."
+        },
+        "resolvedValue": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Expected computed style value when the variant axes match."
+        }
+      }
+    }
+  }
+}

--- a/packages/ui/src/theme/manifest/css-property-manifest.test.ts
+++ b/packages/ui/src/theme/manifest/css-property-manifest.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import {
+  isCssPropertyManifest,
+  validateCssPropertyManifest,
+} from './css-property-manifest.validate'
+
+const readJson = (fileName: string): unknown =>
+  JSON.parse(readFileSync(join(__dirname, fileName), 'utf-8'))
+
+describe('css-property-manifest.schema.json', () => {
+  it('is well-formed JSON Schema with the documented top-level shape', () => {
+    const schema = readJson('css-property-manifest.schema.json') as Record<string, unknown>
+
+    expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema')
+    expect(schema.required).toEqual(['component', 'properties'])
+    expect(schema.$defs).toHaveProperty('cssPropertyEntry')
+    expect(schema.$defs).toHaveProperty('variantOverride')
+  })
+})
+
+describe('validateCssPropertyManifest', () => {
+  it('accepts the button example manifest', () => {
+    const example = readJson('css-property-manifest.example.json')
+
+    const result = validateCssPropertyManifest(example)
+
+    expect(result).toEqual({ valid: true, errors: [] })
+    expect(isCssPropertyManifest(example)).toBe(true)
+  })
+
+  it('rejects a manifest missing required top-level fields', () => {
+    const result = validateCssPropertyManifest({ component: 'button' })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('properties must be a non-empty array')
+  })
+
+  it('rejects a property entry missing a resolvedValue', () => {
+    const candidate = {
+      component: 'button',
+      properties: [{ property: 'backgroundColor', token: 'brand-primary' }],
+    }
+
+    const result = validateCssPropertyManifest(candidate)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('properties[0].resolvedValue must be a non-empty string')
+  })
+
+  it('rejects a variantOverride missing variant axes', () => {
+    const candidate = {
+      component: 'button',
+      properties: [
+        {
+          property: 'backgroundColor',
+          token: 'brand-primary',
+          resolvedValue: 'rgb(255, 121, 0)',
+          variantOverrides: [{ resolvedValue: 'rgba(0, 0, 0, 0)' }],
+        },
+      ],
+    }
+
+    const result = validateCssPropertyManifest(candidate)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'properties[0].variantOverrides[0].variant must be a non-empty string-keyed object'
+    )
+  })
+
+  it('allows token to be null for literal (non-tokenized) values', () => {
+    const candidate = {
+      component: 'button',
+      properties: [{ property: 'borderRadius', token: null, resolvedValue: '6px' }],
+    }
+
+    expect(validateCssPropertyManifest(candidate)).toEqual({ valid: true, errors: [] })
+  })
+})

--- a/packages/ui/src/theme/manifest/css-property-manifest.types.ts
+++ b/packages/ui/src/theme/manifest/css-property-manifest.types.ts
@@ -1,0 +1,49 @@
+/**
+ * TypeScript mirror of css-property-manifest.schema.json.
+ *
+ * A manifest records, per component, which visual CSS properties are tracked,
+ * which design token each one resolves from, the expected computed style
+ * value, and any per-variant overrides. Manifests are the fixtures consumed
+ * by Playwright computed-style assertions (see packages/ui/tests/visual).
+ */
+
+/** Variant axis name/value pairs, e.g. { variant: 'solid', color: 'primary', size: 'md' }. */
+export type VariantAxes = Record<string, string>
+
+/** A resolvedValue/token override that applies when the given variant axes match. */
+export interface VariantOverride {
+  /** Partial variant axis values that trigger this override, merged onto baseVariant. */
+  variant: VariantAxes
+  /** Semantic token key for this override, or null for a literal (non-tokenized) value. */
+  token?: string | null
+  /** CSS custom property backing the token for this override, if any. */
+  cssVariable?: string | null
+  /** Expected getComputedStyle value when the variant axes match. */
+  resolvedValue: string
+}
+
+/** A single tracked CSS property for a component. */
+export interface CssPropertyEntry {
+  /** CSS property name in camelCase, as returned by window.getComputedStyle (e.g. "backgroundColor"). */
+  property: string
+  /** Semantic token key this property is sourced from, or null if not backed by a token. */
+  token: string | null
+  /** CSS custom property backing the token (e.g. "--color-brand-primary"), if any. */
+  cssVariable?: string | null
+  /** Expected computed style value for baseVariant. */
+  resolvedValue: string
+  /** Overrides of token/resolvedValue for specific variant axis combinations. */
+  variantOverrides?: VariantOverride[]
+}
+
+/** The full per-component CSS property manifest. */
+export interface CssPropertyManifest {
+  /** Component identifier matching its src/components/ui/{component} directory and Storybook id. */
+  component: string
+  /** Optional human-readable note about what this manifest covers. */
+  description?: string
+  /** Variant axis values each property's top-level resolvedValue was captured against. */
+  baseVariant?: VariantAxes
+  /** Tracked CSS properties for this component. */
+  properties: CssPropertyEntry[]
+}

--- a/packages/ui/src/theme/manifest/css-property-manifest.validate.ts
+++ b/packages/ui/src/theme/manifest/css-property-manifest.validate.ts
@@ -1,0 +1,84 @@
+import type { CssPropertyManifest, VariantAxes } from './css-property-manifest.types'
+
+/** Result of validating a candidate manifest: valid iff errors is empty. */
+export interface ManifestValidationResult {
+  valid: boolean
+  errors: string[]
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isVariantAxes = (value: unknown): value is VariantAxes =>
+  isPlainObject(value) &&
+  Object.keys(value).length > 0 &&
+  Object.values(value).every((axisValue) => typeof axisValue === 'string')
+
+function collectVariantOverrideErrors(override: unknown, path: string): string[] {
+  if (!isPlainObject(override)) return [`${path} must be an object`]
+  const errors: string[] = []
+  if (!isVariantAxes(override.variant))
+    errors.push(`${path}.variant must be a non-empty string-keyed object`)
+  if (
+    override.token !== undefined &&
+    override.token !== null &&
+    typeof override.token !== 'string'
+  ) {
+    errors.push(`${path}.token must be a string or null`)
+  }
+  if (typeof override.resolvedValue !== 'string' || override.resolvedValue.length === 0) {
+    errors.push(`${path}.resolvedValue must be a non-empty string`)
+  }
+  return errors
+}
+
+function collectPropertyErrors(entry: unknown, path: string): string[] {
+  if (!isPlainObject(entry)) return [`${path} must be an object`]
+  const errors: string[] = []
+  if (typeof entry.property !== 'string' || entry.property.length === 0) {
+    errors.push(`${path}.property must be a non-empty string`)
+  }
+  if (entry.token !== null && typeof entry.token !== 'string') {
+    errors.push(`${path}.token must be a string or null`)
+  }
+  if (typeof entry.resolvedValue !== 'string' || entry.resolvedValue.length === 0) {
+    errors.push(`${path}.resolvedValue must be a non-empty string`)
+  }
+  if (entry.variantOverrides !== undefined) {
+    if (!Array.isArray(entry.variantOverrides)) {
+      errors.push(`${path}.variantOverrides must be an array`)
+    } else {
+      entry.variantOverrides.forEach((override, i) =>
+        errors.push(...collectVariantOverrideErrors(override, `${path}.variantOverrides[${i}]`))
+      )
+    }
+  }
+  return errors
+}
+
+/** Structurally validates a candidate value against the CssPropertyManifest shape. */
+export function validateCssPropertyManifest(candidate: unknown): ManifestValidationResult {
+  if (!isPlainObject(candidate)) return { valid: false, errors: ['manifest must be an object'] }
+
+  const errors: string[] = []
+  if (typeof candidate.component !== 'string' || candidate.component.length === 0) {
+    errors.push('component must be a non-empty string')
+  }
+  if (candidate.baseVariant !== undefined && !isVariantAxes(candidate.baseVariant)) {
+    errors.push('baseVariant must be a non-empty string-keyed object')
+  }
+  if (!Array.isArray(candidate.properties) || candidate.properties.length === 0) {
+    errors.push('properties must be a non-empty array')
+  } else {
+    candidate.properties.forEach((entry, i) =>
+      errors.push(...collectPropertyErrors(entry, `properties[${i}]`))
+    )
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+/** Type guard variant of validateCssPropertyManifest for use in narrowing contexts. */
+export function isCssPropertyManifest(candidate: unknown): candidate is CssPropertyManifest {
+  return validateCssPropertyManifest(candidate).valid
+}

--- a/packages/ui/src/theme/manifest/index.ts
+++ b/packages/ui/src/theme/manifest/index.ts
@@ -1,0 +1,11 @@
+export type {
+  CssPropertyEntry,
+  CssPropertyManifest,
+  VariantAxes,
+  VariantOverride,
+} from './css-property-manifest.types'
+export {
+  isCssPropertyManifest,
+  validateCssPropertyManifest,
+  type ManifestValidationResult,
+} from './css-property-manifest.validate'


### PR DESCRIPTION
## Summary
- Defines `packages/ui/src/theme/manifest/css-property-manifest.schema.json`, a JSON Schema (2020-12) capturing, per component: the tracked CSS property, the semantic design token it resolves from, the CSS custom property backing that token, the expected `getComputedStyle` value, and per-variant-axis overrides — shaped to match how components like `Button` already model `variant`/`color`/`size` style maps against `theme/tokens/semantic.ts`.
- Adds a hand-written TS mirror (`css-property-manifest.types.ts`) and a dependency-free structural validator (`css-property-manifest.validate.ts`, `validateCssPropertyManifest`/`isCssPropertyManifest`) — this repo has no zod/ajv, so validation stays plain TS rather than adding a new dependency.
- Adds a worked example manifest for Button (`css-property-manifest.example.json`) plus a vitest suite validating it against the schema/validator, doubling as usage documentation.
- Manifests conforming to this schema become the fixtures a follow-up ticket uses for Playwright computed-style assertions (`packages/ui/tests/visual`). This PR is schema authoring only — no components, stories, or visual assertions were touched.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint` (0 errors; 91 pre-existing warnings in unrelated files, unchanged)
- [x] `pnpm build`
- [x] `pnpm test` (full vitest suite: 76 files / 1304 tests passed, including 6 new manifest tests)
- [ ] `pnpm format:check` — fails, but pre-existing on `main` across 188 unrelated files (verified before this change); the 7 files touched here are Prettier-clean (`npx prettier --check` passes for all of them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)