### PR TITLE
Add build-time tokens.css generator (TD-05.02)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/generate-tokens-css.mjs",
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "lint:borders": "bash scripts/check-border-classes.sh",

--- a/packages/ui/scripts/generate-tokens-css.mjs
+++ b/packages/ui/scripts/generate-tokens-css.mjs
@@ -1,0 +1,20 @@
+/**
+ * Build-time codegen: write `dist/tokens.css` from the theme token maps.
+ *
+ * Runs after `tsup` (which cleans and populates `dist/`), consuming the built
+ * generator so the emitted CSS uses the exact same resolved token values as
+ * the published design system.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { generateTokensCss } from '../dist/theme/tokens-css.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const outputPath = path.resolve(__dirname, '../dist/tokens.css')
+
+await mkdir(path.dirname(outputPath), { recursive: true })
+await writeFile(outputPath, generateTokensCss(), 'utf8')
+
+console.log(`Generated ${path.relative(process.cwd(), outputPath)}`)

--- a/packages/ui/src/theme/tokens-css.test.ts
+++ b/packages/ui/src/theme/tokens-css.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { generateTokensCss } from './tokens-css'
+import { darkThemeCSSVars, lightThemeCSSVars } from './config'
+
+describe('generateTokensCss', () => {
+  const css = generateTokensCss()
+
+  it('emits a default :root block and a .light override block', () => {
+    expect(css).toContain(':root {')
+    expect(css).toContain('.light, :root.light {')
+  })
+
+  it('emits every dark token in :root with its exact value', () => {
+    for (const [name, value] of Object.entries(darkThemeCSSVars)) {
+      expect(css).toContain(`  ${name}: ${value};`)
+    }
+  })
+
+  it('emits every light token with its exact value', () => {
+    for (const [name, value] of Object.entries(lightThemeCSSVars)) {
+      expect(css).toContain(`  ${name}: ${value};`)
+    }
+  })
+
+  it('is deterministic across invocations', () => {
+    expect(generateTokensCss()).toBe(css)
+  })
+})

--- a/packages/ui/src/theme/tokens-css.ts
+++ b/packages/ui/src/theme/tokens-css.ts
@@ -1,0 +1,34 @@
+/**
+ * Token CSS Generator
+ *
+ * Emits a static `:root {}` CSS block from the canonical theme token maps
+ * (`darkThemeCSSVars` / `lightThemeCSSVars`). HTML prototypes import the
+ * generated stylesheet so they always resolve to the exact same values as
+ * the design system. Pure codegen: deterministic and diffable against source.
+ *
+ * Dark mode is the default (`:root`); light mode is activated with `.light`,
+ * matching the convention in `theme/global.css`.
+ */
+
+import { darkThemeCSSVars, lightThemeCSSVars } from './config'
+
+type CSSVarMap = Record<string, string>
+
+const GENERATED_HEADER = '/* Generated from theme token maps. Do not edit by hand. */'
+
+function formatBlock(selector: string, vars: CSSVarMap): string {
+  const declarations = Object.entries(vars)
+    .map(([name, value]) => `  ${name}: ${value};`)
+    .join('\n')
+  return `${selector} {\n${declarations}\n}`
+}
+
+/**
+ * Build the full `tokens.css` contents: a default (dark) `:root` block plus a
+ * `.light` override block, driven entirely by the exported token maps.
+ */
+export function generateTokensCss(): string {
+  const root = formatBlock(':root', darkThemeCSSVars)
+  const light = formatBlock('.light, :root.light', lightThemeCSSVars)
+  return `${GENERATED_HEADER}\n\n${root}\n\n${light}\n`
+}

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     'theme/index': 'src/theme/index.ts',
+    'theme/tokens-css': 'src/theme/tokens-css.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Adds a build-time codegen step that emits a static `:root {}` CSS block into `dist/tokens.css` from the canonical theme token maps. HTML prototypes can import this stylesheet and always resolve to the exact same values as the `@titan-design/react-ui` design system (TD-05.02).

## What changed

- **`src/theme/tokens-css.ts`** — pure `generateTokensCss()` that reads `darkThemeCSSVars` / `lightThemeCSSVars` from `theme/config` and emits a default (dark) `:root` block plus a `.light, :root.light` override, matching the convention already used in `theme/global.css` (dark = default).
- **`scripts/generate-tokens-css.mjs`** — writes `dist/tokens.css`, wired into `pnpm build` (`tsup && node scripts/generate-tokens-css.mjs`). It runs after `tsup` (which cleans `dist/`) and consumes the built generator, so emitted values match the published bundle. No new dependencies.
- **`tsup.config.ts`** — adds a dedicated `theme/tokens-css` entry so the generator is available as a plain-Node-importable `dist/theme/tokens-css.mjs`.
- **`tokens-css.test.ts`** — asserts every token appears with its exact value (value-equality against the maps) and that output is deterministic.

The `TOKEN_MAP` referenced by the ticket is realized by the existing canonical CSS-var maps in `theme/config.ts` (`darkThemeCSSVars` / `lightThemeCSSVars`), which already map token → CSS custom property → resolved value.

## Verification

- `pnpm lint` — pass (0 errors; pre-existing warnings only, none in touched files)
- `pnpm type-check` — pass
- `pnpm build` — pass; produces `dist/tokens.css` (80 declarations across `:root` + `.light`)
- `pnpm test` — pass (1308 tests, incl. 4 new)

### Known caveat
`pnpm format:check` fails on ~188 unrelated files already on `main` and runs non-blocking in CI (`continue-on-error: true`). This PR's touched files are Prettier-clean (`prettier --check` passes on them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)