### PR TITLE
Fix undefined border-default token classes (TD-05.06)

### DIFF
--- a/packages/ui/scripts/check-border-classes.sh
+++ b/packages/ui/scripts/check-border-classes.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Detect undefined "DEFAULT-suffix" token classes in source components.
+#
+# In tailwind.config.js the DEFAULT variant of a color token is emitted as a
+# *suffix-less* utility. e.g. `colors.border.DEFAULT` -> class `border-border`,
+# `colors.background.DEFAULT` -> `bg-background`. Writing `border-border-default`
+# (or `bg-border-default`, `divide-border-default`, ...) references a token that
+# Tailwind never generates: the class silently renders nothing and the element
+# falls back to the framework default border color (currentColor under
+# NativeWind), producing unintended black borders instead of the theme color.
+#
+# Use the suffix-less DEFAULT class instead:
+#   border-border-default -> border-border
+#   bg-border-default     -> bg-border
+#   divide-border-default -> divide-border
+#
+# Stories and tests are excluded — they may demonstrate patterns intentionally.
+
+SRC_DIR="$(dirname "$0")/../src/components"
+
+ISSUES=$(grep -rnE '(bg|text|border|divide|ring|fill|stroke|outline|caret|accent|placeholder|decoration|from|via|to)-[a-z]+(-[a-z]+)*-default\b' \
+  "$SRC_DIR" \
+  --include="*.tsx" \
+  --include="*.ts" \
+  | grep -v '\.test\.' \
+  | grep -v '\.stories\.' \
+  | grep -v '\.visual\.' \
+  | grep -v 'var(--')
+
+if [ -n "$ISSUES" ]; then
+  echo "undefined token class: found '*-default' color utilities in source components."
+  echo "The DEFAULT variant of a token is the suffix-less class (e.g. 'border-border', not 'border-border-default')."
+  echo ""
+  echo "$ISSUES"
+  exit 1
+fi
+
+echo "No undefined DEFAULT-suffix token classes found."

--- a/packages/ui/src/components/custom/DateTime/DateTime.stories.tsx
+++ b/packages/ui/src/components/custom/DateTime/DateTime.stories.tsx
@@ -169,7 +169,7 @@ export const UsageExample: Story = {
       <View className="gap-2 p-4 bg-surface-elevated rounded-lg max-w-md">
         <Text className="text-lg font-semibold text-text-primary mb-2">Upcoming Events</Text>
         {items.map((item, index) => (
-          <View key={index} className="flex-row justify-between items-center py-2 border-b border-border-default">
+          <View key={index} className="flex-row justify-between items-center py-2 border-b border-border">
             <Text className="text-text-primary">{item.title}</Text>
             <DateTime value={item.date} format="relative" color="secondary" className="text-sm" />
           </View>

--- a/packages/ui/src/components/custom/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/components/custom/Sidebar/Sidebar.tsx
@@ -64,7 +64,7 @@ export function Sidebar({
       <View
         style={{ width: currentWidth }}
         className={cn(
-          'h-full flex-col bg-surface-base border-r border-border-default transition-all duration-200',
+          'h-full flex-col bg-surface-base border-r border-border transition-all duration-200',
           className
         )}
         {...props}

--- a/packages/ui/src/components/custom/stepper/Stepper.stories.tsx
+++ b/packages/ui/src/components/custom/stepper/Stepper.stories.tsx
@@ -137,7 +137,7 @@ export const VerticalWithContent: Story = {
             <Text className="text-text-secondary text-sm">
               Fill in your profile details to continue.
             </Text>
-            <View className="bg-surface-inset border border-border-default rounded-md px-3 py-2">
+            <View className="bg-surface-inset border border-border rounded-md px-3 py-2">
               <Text className="text-text-secondary text-sm">Display Name</Text>
             </View>
           </View>

--- a/packages/ui/src/components/custom/stepper/Stepper.tsx
+++ b/packages/ui/src/components/custom/stepper/Stepper.tsx
@@ -91,7 +91,7 @@ function StepConnector({ index }: StepConnectorProps) {
       <View
         className={cn(
           'flex-1 h-0.5 mx-2',
-          isCompleted ? 'bg-brand-primary' : 'bg-border-default'
+          isCompleted ? 'bg-brand-primary' : 'bg-border'
         )}
       />
     )
@@ -101,7 +101,7 @@ function StepConnector({ index }: StepConnectorProps) {
     <View
       className={cn(
         'w-0.5 h-8 ml-4 my-1',
-        isCompleted ? 'bg-brand-primary' : 'bg-border-default'
+        isCompleted ? 'bg-brand-primary' : 'bg-border'
       )}
     />
   )

--- a/packages/ui/src/components/ui/autocomplete/Autocomplete.stories.tsx
+++ b/packages/ui/src/components/ui/autocomplete/Autocomplete.stories.tsx
@@ -287,7 +287,7 @@ export const FormExample: Story = {
           isRequired
         />
 
-        <View className="pt-2 border-t border-border-default">
+        <View className="pt-2 border-t border-border">
           <Text className="text-sm text-text-secondary">
             Selected: {country ? `${countryOptions.find(c => c.value === country)?.label}` : '-'}
             {city ? `, ${cityOptions[country!]?.find(c => c.value === city)?.label}` : ''}

--- a/packages/ui/src/components/ui/autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/ui/autocomplete/Autocomplete.tsx
@@ -238,7 +238,7 @@ export function Autocomplete<T extends string = string>({
           <View
             className={cn(
               'absolute z-50 top-full left-0 right-0 mt-1',
-              'bg-surface-elevated rounded-md shadow-lg border border-border-default',
+              'bg-surface-elevated rounded-md shadow-lg border border-border',
               'max-h-60 overflow-hidden'
             )}
           >

--- a/packages/ui/src/components/ui/card/Card.tsx
+++ b/packages/ui/src/components/ui/card/Card.tsx
@@ -47,7 +47,7 @@ const variantStyles: Record<CardVariant, string> = {
   elevated: '', // Will be set dynamically via elevation system
   outline: 'border-2 border-border-strong',  // Thicker border with stronger contrast
   filled: '', // Will be set dynamically via elevation system
-  accent: 'border border-border-default',
+  accent: 'border border-border',
   subtle: 'border border-border-subtle',
 }
 

--- a/packages/ui/src/components/ui/checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox/Checkbox.tsx
@@ -91,7 +91,7 @@ export const Checkbox = forwardRef<View, CheckboxProps>(function Checkbox(
           styles.box,
           isChecked || isIndeterminate
             ? 'bg-brand-primary border-brand-primary'
-            : 'bg-transparent border-border-default',
+            : 'bg-transparent border-border',
           isInvalid && 'border-status-error',
           !isDisabled && 'web:hover:border-brand-primary'
         )}

--- a/packages/ui/src/components/ui/collapse/Collapse.tsx
+++ b/packages/ui/src/components/ui/collapse/Collapse.tsx
@@ -180,7 +180,7 @@ export function Accordion({
 
   return (
     <AccordionContext.Provider value={{ openIndices, toggleIndex, allowMultiple }}>
-      <View className={cn('w-full divide-y divide-border-default', className)} {...props}>
+      <View className={cn('w-full divide-y divide-border', className)} {...props}>
         {React.Children.map(children, (child, index) => {
           if (React.isValidElement(child)) {
             return React.cloneElement(child as React.ReactElement<any>, { index })

--- a/packages/ui/src/components/ui/drawer/Drawer.tsx
+++ b/packages/ui/src/components/ui/drawer/Drawer.tsx
@@ -125,7 +125,7 @@ export function Drawer({
         >
           {/* Header */}
           {(title || showCloseButton) && (
-            <View className="flex-row items-center justify-between px-4 py-3 border-b border-border-default">
+            <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
               {title && (
                 <Text className="text-lg font-semibold text-text-primary">
                   {title}
@@ -165,7 +165,7 @@ export interface DrawerHeaderProps extends ViewProps {
 export function DrawerHeader({ className, children, ...props }: DrawerHeaderProps) {
   return (
     <View
-      className={cn('px-4 py-3 border-b border-border-default', className)}
+      className={cn('px-4 py-3 border-b border-border', className)}
       {...props}
     >
       {children}
@@ -217,7 +217,7 @@ export function DrawerFooter({ className, children, ...props }: DrawerFooterProp
     <View
       className={cn(
         'flex-row items-center justify-end gap-3',
-        'px-4 py-3 border-t border-border-default',
+        'px-4 py-3 border-t border-border',
         className
       )}
       {...props}

--- a/packages/ui/src/components/ui/form-field/FormField.tsx
+++ b/packages/ui/src/components/ui/form-field/FormField.tsx
@@ -253,7 +253,7 @@ export function FormActions({
     <View
       className={cn(
         'flex-row items-center gap-3 pt-4',
-        'border-t border-border-default mt-4',
+        'border-t border-border mt-4',
         alignStyles[align],
         className
       )}

--- a/packages/ui/src/components/ui/help-tip/HelpTip.tsx
+++ b/packages/ui/src/components/ui/help-tip/HelpTip.tsx
@@ -155,7 +155,7 @@ export function HelpTip({
           className={cn(
             'absolute z-50',
             'bg-surface-elevated rounded-lg shadow-lg',
-            'border border-border-default',
+            'border border-border',
             'px-3 py-2',
             placementStyles[placement],
             tooltipClassName

--- a/packages/ui/src/components/ui/menu/Menu.tsx
+++ b/packages/ui/src/components/ui/menu/Menu.tsx
@@ -116,7 +116,7 @@ export function MenuList({ children, className }: MenuListProps) {
       <View
         className={cn(
           'absolute z-50 top-full left-0 mt-1 min-w-[160px]',
-          'bg-surface-elevated rounded-lg shadow-lg border border-border-default',
+          'bg-surface-elevated rounded-lg shadow-lg border border-border',
           'py-1 overflow-hidden',
           className
         )}
@@ -195,7 +195,7 @@ export interface MenuDividerProps {
  * Divider between menu items.
  */
 export function MenuDivider({ className }: MenuDividerProps) {
-  return <View className={cn('h-px bg-border-default my-1', className)} />
+  return <View className={cn('h-px bg-border my-1', className)} />
 }
 
 export interface MenuGroupProps {

--- a/packages/ui/src/components/ui/pill/Pill.tsx
+++ b/packages/ui/src/components/ui/pill/Pill.tsx
@@ -36,7 +36,7 @@ const variantColorStyles: Record<PillVariant, Record<PillColor, string>> = {
     info: 'bg-status-info/10 border-status-info/25 text-status-info',
   },
   outline: {
-    default: 'border-border-default text-text-secondary',
+    default: 'border-border text-text-secondary',
     primary: 'border-brand-primary text-brand-primary',
     secondary: 'border-brand-secondary text-brand-secondary',
     success: 'border-status-success text-status-success',

--- a/packages/ui/src/components/ui/popover/Popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover/Popover.stories.tsx
@@ -152,12 +152,12 @@ export const WithFormContent: Story = {
           <Text className="text-text-secondary text-xs">
             Enter your new display name below.
           </Text>
-          <View className="bg-surface-inset border border-border-default rounded-md px-3 py-2">
+          <View className="bg-surface-inset border border-border rounded-md px-3 py-2">
             <Text className="text-text-secondary text-sm">John Doe</Text>
           </View>
           <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'flex-end' }}>
             <PopoverCloseButton>
-              <View className="px-3 py-1.5 rounded-md bg-surface-elevated border border-border-default">
+              <View className="px-3 py-1.5 rounded-md bg-surface-elevated border border-border">
                 <Text className="text-text-primary text-sm">Cancel</Text>
               </View>
             </PopoverCloseButton>

--- a/packages/ui/src/components/ui/popover/Popover.tsx
+++ b/packages/ui/src/components/ui/popover/Popover.tsx
@@ -188,7 +188,7 @@ export function PopoverContent({ children, className }: PopoverContentProps) {
       <View
         className={cn(
           'absolute z-50 min-w-[200px]',
-          'bg-surface-elevated rounded-lg shadow-lg border border-border-default',
+          'bg-surface-elevated rounded-lg shadow-lg border border-border',
           'p-4',
           placementStyles[placement],
           className

--- a/packages/ui/src/components/ui/radio/Radio.stories.tsx
+++ b/packages/ui/src/components/ui/radio/Radio.stories.tsx
@@ -188,7 +188,7 @@ export const FormExample: Story = {
           <Radio value="yearly">Yearly (save 20%)</Radio>
         </RadioGroup>
         
-        <View className="pt-4 border-t border-border-default">
+        <View className="pt-4 border-t border-border">
           <Text className="text-sm text-text-secondary">
             Selected: {plan} plan, billed {billing}
           </Text>

--- a/packages/ui/src/components/ui/select/Select.tsx
+++ b/packages/ui/src/components/ui/select/Select.tsx
@@ -187,7 +187,7 @@ export function Select<T extends string = string>({
             <View
               className={cn(
                 'absolute z-50 top-full left-0 right-0 mt-1',
-                'bg-surface-elevated rounded-md shadow-lg border border-border-default',
+                'bg-surface-elevated rounded-md shadow-lg border border-border',
                 'max-h-60 overflow-hidden'
               )}
             >

--- a/packages/ui/src/components/ui/tabs/Tabs.tsx
+++ b/packages/ui/src/components/ui/tabs/Tabs.tsx
@@ -100,8 +100,8 @@ export function TabList({ children, className }: TabListProps) {
 
   const variantStyles = {
     line: orientation === 'horizontal'
-      ? 'border-b border-border-default'
-      : 'border-r border-border-default',
+      ? 'border-b border-border'
+      : 'border-r border-border',
     enclosed: 'bg-surface-raised rounded-lg p-1',
     'soft-rounded': 'bg-surface-raised rounded-full p-1',
   }

--- a/packages/ui/src/components/ui/toolbar-button/ToolbarButton.stories.tsx
+++ b/packages/ui/src/components/ui/toolbar-button/ToolbarButton.stories.tsx
@@ -319,7 +319,7 @@ export const CompactMode: Story = {
             onPress={() => setIsCompact(!isCompact)}
           />
         </View>
-        <View className="h-px bg-border-default" />
+        <View className="h-px bg-border" />
         <ToolbarButtonGroup gap="sm">
           <ToolbarButton
             label="Filter"

--- a/packages/ui/src/components/ui/toolbar-button/ToolbarButton.tsx
+++ b/packages/ui/src/components/ui/toolbar-button/ToolbarButton.tsx
@@ -231,7 +231,7 @@ export function ToolbarButton({
             <View
               className={cn(
                 'absolute z-50 top-full left-0 mt-1',
-                'rounded-lg shadow-lg border border-border-default',
+                'rounded-lg shadow-lg border border-border',
                 'min-w-[150px] overflow-hidden',
                 `bg-[${MENU_BG}]`
               )}

--- a/packages/ui/src/stories/PresetShowcase.stories.tsx
+++ b/packages/ui/src/stories/PresetShowcase.stories.tsx
@@ -24,7 +24,7 @@ function PresetSwitcher({
   onSwitch: (name: string) => void
 }) {
   return (
-    <View className="flex-row items-center gap-3 p-4 bg-surface-elevated rounded-lg border border-border-default">
+    <View className="flex-row items-center gap-3 p-4 bg-surface-elevated rounded-lg border border-border">
       <Text className="text-text-secondary text-sm font-medium">Active Preset:</Text>
       {Object.keys(presets).map((name) => (
         <Pressable
@@ -33,7 +33,7 @@ function PresetSwitcher({
           className={`px-4 py-2 rounded-md border ${
             activePreset === name
               ? 'bg-brand-primary border-brand-primary'
-              : 'bg-surface-base border-border-default web:hover:bg-interactive-hover'
+              : 'bg-surface-base border-border web:hover:bg-interactive-hover'
           }`}
         >
           <Text
@@ -272,7 +272,7 @@ function TypographyShowcase() {
       </Section>
 
       <Section title="Monospace Font (font-mono)">
-        <View className="bg-surface-elevated rounded-lg p-4 border border-border-default">
+        <View className="bg-surface-elevated rounded-lg p-4 border border-border">
           <Text className="text-sm text-text-primary font-mono">
             {'const theme = applyThemePreset(audiobookPreset)'}
           </Text>
@@ -368,13 +368,13 @@ function ColorPaletteShowcase() {
 
       <Section title="Text Colors">
         <View className="flex-row gap-3 flex-wrap">
-          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border-default">
+          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border">
             <Text className="text-xs font-mono font-medium text-text-primary">text-primary</Text>
           </View>
-          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border-default">
+          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border">
             <Text className="text-xs font-mono font-medium text-text-secondary">text-secondary</Text>
           </View>
-          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border-default">
+          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-elevated border border-border">
             <Text className="text-xs font-mono font-medium text-text-tertiary">text-tertiary</Text>
           </View>
         </View>
@@ -382,25 +382,25 @@ function ColorPaletteShowcase() {
 
       <Section title="Surface Colors">
         <View className="flex-row gap-3 flex-wrap">
-          <ColorSwatch label="surface-base" className="bg-surface-base border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="surface-elevated" className="bg-surface-elevated border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="surface-raised" className="bg-surface-raised border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="surface-overlay" className="bg-surface-overlay border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="surface-input" className="bg-surface-input border border-border-default" textClass="text-text-primary" />
+          <ColorSwatch label="surface-base" className="bg-surface-base border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="surface-elevated" className="bg-surface-elevated border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="surface-raised" className="bg-surface-raised border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="surface-overlay" className="bg-surface-overlay border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="surface-input" className="bg-surface-input border border-border" textClass="text-text-primary" />
         </View>
       </Section>
 
       <Section title="Background Colors">
         <View className="flex-row gap-3 flex-wrap">
-          <ColorSwatch label="background-base" className="bg-background-base border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="background-default" className="bg-background-default border border-border-default" textClass="text-text-primary" />
-          <ColorSwatch label="background-subtle" className="bg-background-subtle border border-border-default" textClass="text-text-primary" />
+          <ColorSwatch label="background-base" className="bg-background-base border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="background-default" className="bg-background-default border border-border" textClass="text-text-primary" />
+          <ColorSwatch label="background-subtle" className="bg-background-subtle border border-border" textClass="text-text-primary" />
         </View>
       </Section>
 
       <Section title="Border Colors">
         <View className="flex-row gap-3 flex-wrap">
-          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-base border-2 border-border-default">
+          <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-base border-2 border-border">
             <Text className="text-xs font-mono font-medium text-text-primary">border-default</Text>
           </View>
           <View className="rounded-lg p-3 min-w-[120px] min-h-[60px] justify-end bg-surface-base border-2 border-border-subtle">


### PR DESCRIPTION
## TD-05.06 — Audit all components for token misuse

Audited **every** titan-design component for the class-hygiene issues found earlier in the workout atoms, using `tailwind.config.js` + `src/theme/global.css` as the source of truth for what's defined.

### Audit results (what turned out NOT to be a bug)
- **`font-body` vs `font-sans`** — `font-body` **is** defined (`--font-family-body` → Nunito Sans, and `font-sans` → Inter). The two are distinct, intentional tokens (VelocityStrip even documents the convention). 34 `font-body` usages left untouched.
- **`rounded-sm` assumptions** — `rounded-sm` is defined (4px). Valid; no change.
- **`bg-vel-*` / undefined classes** — no `vel-*` classes appear in JSX. VelocityStrip's `'vel-*'` strings are internal enum keys mapped to hex values, not classNames.

### Fixes made (unambiguous correctness — 42 occurrences, 22 files)
The one systemic error: **`border-border-default` / `bg-border-default` / `divide-border-default` are undefined classes.** The config defines `colors.border.DEFAULT`, whose Tailwind utility is the **suffix-less** `border-border`. The `-default` suffix variant is never generated, so the class renders no color and the element falls back to the framework default border color (currentColor under NativeWind → unintended black borders). This is the exact "bare border" symptom from the workout-atoms audit, root-caused to a token typo.

Verified empirically by compiling the config with the Tailwind CLI: `.border-border` and `.border-border-subtle` generate; `.border-border-default` does not.

| From | To |
| --- | --- |
| `border-border-default` | `border-border` |
| `bg-border-default` | `bg-border` |
| `divide-border-default` | `divide-border` |

The correct token is unambiguous (same token, DEFAULT variant) — no color/shade choice involved, so this is a pure correctness fix, not a restyle. Applied in source components and their stories.

### Tooling
Restored the missing **`packages/ui/scripts/check-border-classes.sh`** — it is referenced by `pnpm lint:borders` in `package.json` but was absent on `main`, so the script errored. The check now flags any `*-default` color-utility class in source components. Confirmed it fails on an injected regression and passes on the fixed tree.

### Needs visual review
All are **undefined classes in `*.stories.tsx` demo files** (they render nothing today); the correct replacement requires a design decision, so they were deliberately left unchanged:

1. `bg-surface-secondary` — `src/components/ui/section/Section.stories.tsx:65,77,90,97`. `surface` has no `secondary` key (base/elevated/raised/overlay/input). Which surface token was intended?
2. `bg-primary-500` — `src/components/ui/stack/Stack.stories.tsx:37,88,91,94`. No top-level `primary` color / no numeric scale; likely `bg-brand-primary`, but which shade?
3. `bg-surface-inset` — `src/components/ui/popover/Popover.stories.tsx:155`, `src/components/custom/stepper/Stepper.stories.tsx:140`. No `inset` surface key — `surface-input` or `surface-raised`?
4. `border-border-primary` — `src/components/ui/data-row/DataRow.stories.tsx:76`. `border` has no `primary` key — `border-brand-primary` or `border-border-strong`?
5. Systemic pattern note (not changed): the whole `ui/` library uses `border` + a themed `border-<color>` class (e.g. `border border-border`). This is correct on web. If NativeWind rendering shows currentColor borders here, a library-wide migration to inline `borderColor` (as done for the workout atoms) would be needed — out of scope for this correctness pass.

### Verification
`lint` = pass (0 errors; 91 pre-existing `any` warnings, none in touched files) · `lint:borders` = pass · `type-check` = pass · `build` = pass · `test` = **1308 passed / 77 files**.

`format:check`: the touched `.tsx` files were already Prettier-dirty on `main` (the known ~188-file pre-existing issue; CI runs it `continue-on-error`). The single-token className swaps don't affect formatting, so they were left to avoid large unrelated reformatting diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
