### PR TITLE
Fix workout organism review nits (TD-03.35)

### DIFF
--- a/packages/ui/src/components/custom/Workout/CapacityBandChart.test.tsx
+++ b/packages/ui/src/components/custom/Workout/CapacityBandChart.test.tsx
@@ -98,6 +98,16 @@ describe('CapacityBandChart', () => {
       expect(dots[2]).toHaveStyle({ backgroundColor: '#2196F3' }) // below
     })
 
+    it('renders dots at the spec 8px size with a visible outline', () => {
+      render(<CapacityBandChart {...baseProps} />)
+      const dots = screen.getAllByTestId('capacity-band-chart-dot')
+      expect(dots[0]).toHaveStyle({
+        width: '8px',
+        height: '8px',
+        borderTopColor: '#F3F4F6',
+      })
+    })
+
     it('does not render dots as buttons without onWorkoutPress', () => {
       render(<CapacityBandChart {...baseProps} />)
       expect(screen.queryByRole('button')).not.toBeInTheDocument()

--- a/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
+++ b/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
@@ -5,7 +5,9 @@ import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-n
 const STATUS_SUCCESS = '#14B8A6'
 const STATUS_WARNING = '#FFB020'
 const STATUS_INFO = '#2196F3'
-const SURFACE_ELEVATED = '#191919'
+/** Dot outline: near-white ring so load dots read on the band fill and any
+ *  surface (matches the MesoStatusCard gauge-marker convention). */
+const DOT_BORDER = '#F3F4F6'
 const TEXT_TERTIARY = '#6B7280'
 const BAND_FILL = 'rgba(20,184,166,0.1)'
 const BAND_EDGE = 'rgba(20,184,166,0.45)'
@@ -16,7 +18,7 @@ const PADDING_RIGHT = 10
 const PADDING_TOP = 8
 const PADDING_BOTTOM = 16
 const COLUMN_STEP = 4
-const DOT_SIZE = 12
+const DOT_SIZE = 8
 
 export type WorkoutDotStatus = 'within' | 'above' | 'below'
 
@@ -451,7 +453,7 @@ export function CapacityBandChart({
           borderRadius: DOT_SIZE / 2,
           backgroundColor: color,
           borderWidth: 2,
-          borderColor: SURFACE_ELEVATED,
+          borderColor: DOT_BORDER,
         }
         const label = `Workout on ${formatDate(workout.date)}, load ${workout.load}, ${
           STATUS_PHRASES[workout.status]

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.test.tsx
@@ -59,6 +59,19 @@ describe('MesoStatusCard', () => {
       expect(screen.getByText('3×8 @ 185 lbs')).toBeInTheDocument()
     })
 
+    it('renders every metric cell even when labels repeat (stable unique keys)', () => {
+      render(
+        <MesoStatusCard
+          {...baseProps}
+          metrics={[
+            { label: 'Set', value: '1' },
+            { label: 'Set', value: '2' },
+          ]}
+        />,
+      )
+      expect(screen.getAllByTestId('meso-status-card-metric')).toHaveLength(2)
+    })
+
     it('does not render the metrics grid when empty', () => {
       render(<MesoStatusCard {...baseProps} metrics={[]} />)
       expect(
@@ -102,6 +115,30 @@ describe('MesoStatusCard', () => {
         />,
       )
       expect(screen.getByLabelText('Volume: 100%')).toBeInTheDocument()
+    })
+
+    it('guards a non-finite level, rendering 0% instead of NaN%', () => {
+      render(
+        <MesoStatusCard
+          {...baseProps}
+          gauges={[{ label: 'Intensity', level: Number.NaN }]}
+        />,
+      )
+      expect(screen.getByLabelText('Intensity: 0%')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Intensity: NaN%')).not.toBeInTheDocument()
+    })
+
+    it('renders every gauge even when labels repeat (stable unique keys)', () => {
+      render(
+        <MesoStatusCard
+          {...baseProps}
+          gauges={[
+            { label: 'Load', level: 0.3 },
+            { label: 'Load', level: 0.6 },
+          ]}
+        />,
+      )
+      expect(screen.getAllByTestId('meso-status-card-gauge')).toHaveLength(2)
     })
   })
 

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
@@ -93,6 +93,7 @@ export interface MesoStatusCardProps extends ViewProps {
 }
 
 function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0
   if (value < 0) return 0
   if (value > 1) return 1
   return value
@@ -380,16 +381,16 @@ export function MesoStatusCard({
             style={{ gap: 8 }}
             testID="meso-status-card-metrics"
           >
-            {metrics.map((metric) => (
-              <MetricCell key={metric.label} metric={metric} />
+            {metrics.map((metric, index) => (
+              <MetricCell key={`${metric.label}-${index}`} metric={metric} />
             ))}
           </View>
         )}
 
         {gauges.length > 0 && (
           <View style={{ gap: 12 }} testID="meso-status-card-gauges">
-            {gauges.map((gauge) => (
-              <Gauge key={gauge.label} gauge={gauge} />
+            {gauges.map((gauge, index) => (
+              <Gauge key={`${gauge.label}-${index}`} gauge={gauge} />
             ))}
           </View>
         )}

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.test.tsx
@@ -104,6 +104,34 @@ describe('ReadinessCheck', () => {
       )
       expect(screen.getByTestId('readiness-check-warmup-badge')).toHaveTextContent('Caution')
     })
+
+    it('phrases a zero deficit as on-average rather than "below"', () => {
+      render(
+        <ReadinessCheck
+          {...baseProps}
+          factors={makeFactors()}
+          warmUpCompleted
+          warmUpValidation={{ velocityDeficit: 0, recommendation: 'Proceed.', status: 'good' }}
+        />,
+      )
+      expect(screen.getByTestId('readiness-check-warmup-deficit')).toHaveTextContent(
+        'Velocity on 14-day average',
+      )
+    })
+
+    it('phrases a negative deficit as above average', () => {
+      render(
+        <ReadinessCheck
+          {...baseProps}
+          factors={makeFactors()}
+          warmUpCompleted
+          warmUpValidation={{ velocityDeficit: -6, recommendation: 'Proceed.', status: 'good' }}
+        />,
+      )
+      expect(screen.getByTestId('readiness-check-warmup-deficit')).toHaveTextContent(
+        'Velocity 6% above 14-day average',
+      )
+    })
   })
 
   describe('accessibility', () => {

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
@@ -74,6 +74,14 @@ function emojiSet(factor: ReadinessFactor): readonly string[] {
   return EMOJI_SETS[factor.id.toLowerCase()] ?? EMOJI_SETS[factor.label.toLowerCase()] ?? DEFAULT_EMOJI_SET
 }
 
+/** Warm-up velocity phrasing. Deficit is % below the 14-day average, so a
+ *  non-positive deficit means velocity is on/above average — never "below". */
+function velocityDeficitText(deficit: number): string {
+  if (deficit > 0) return `Velocity ${deficit}% below 14-day average`
+  if (deficit < 0) return `Velocity ${Math.abs(deficit)}% above 14-day average`
+  return 'Velocity on 14-day average'
+}
+
 interface EmojiSliderProps {
   factor: ReadinessFactor
 }
@@ -177,7 +185,7 @@ function WarmUpCard({ validation }: { validation: WarmUpValidation }) {
           style={{ fontSize: 12, fontWeight: '600', fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
           testID="readiness-check-warmup-deficit"
         >
-          {`Velocity ${validation.velocityDeficit}% below 14-day average`}
+          {velocityDeficitText(validation.velocityDeficit)}
         </Text>
         <Badge variant="subtle" color={badge.color} size="sm" testID="readiness-check-warmup-badge">
           {badge.label}

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.test.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.test.tsx
@@ -117,6 +117,24 @@ describe('StrengthTrendChart', () => {
       const pill = screen.getByTestId('strength-trend-chart-trend-pill')
       expect(pill.textContent?.startsWith('-')).toBe(true)
     })
+
+    it('stays neutral instead of using the whole series when the current meso has <2 points', () => {
+      render(
+        <StrengthTrendChart
+          {...baseProps}
+          data={[
+            { date: '2026-01-06', e1rm: 200 },
+            { date: '2026-02-01', e1rm: 210 },
+            { date: '2026-03-20', e1rm: 250 },
+          ]}
+          mesoBoundaries={[{ date: '2026-03-01', label: 'Peak' }]}
+        />,
+      )
+      // Only one point falls in the current meso, so the pill must not report
+      // the whole-series jump (+25%) under the "this meso" label.
+      const pill = screen.getByTestId('strength-trend-chart-trend-pill')
+      expect(pill).toHaveTextContent('+0.0% this meso')
+    })
   })
 
   describe('interaction', () => {
@@ -143,6 +161,16 @@ describe('StrengthTrendChart', () => {
   describe('empty state', () => {
     it('renders an empty placeholder when there is no data', () => {
       render(<StrengthTrendChart {...baseProps} data={[]} />)
+      expect(
+        screen.getByTestId('strength-trend-chart-empty'),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('strength-trend-chart-canvas'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows the placeholder when data is empty even if a projection exists', () => {
+      render(<StrengthTrendChart {...baseProps} data={[]} projection={projection} />)
       expect(
         screen.getByTestId('strength-trend-chart-empty'),
       ).toBeInTheDocument()

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
@@ -95,7 +95,9 @@ function buildGeometry(
   height: number,
 ): Geometry {
   const values = [...data, ...projection].map((p) => p.e1rm)
-  if (values.length === 0) {
+  // Empty state keys off actual data only: a projection with no measured
+  // sessions still shows the placeholder rather than a "Current: 0" chart.
+  if (data.length === 0) {
     return {
       hasData: false,
       toX: () => 0,
@@ -165,7 +167,11 @@ function computeTrend(
   if (boundaries.length > 0) {
     const lastBoundary = Math.max(...boundaries.map((b) => timeOf(b.date)))
     const filtered = data.filter((p) => timeOf(p.date) >= lastBoundary)
-    if (filtered.length >= 2) series = filtered
+    // The pill is labelled "this meso"; if the current meso has <2 points
+    // there is no meso trend to show — stay neutral rather than silently
+    // reporting the whole-series change under a "this meso" label.
+    if (filtered.length < 2) return { percent: 0, positive: true }
+    series = filtered
   }
   const first = series[0].e1rm
   const last = series[series.length - 1].e1rm


### PR DESCRIPTION
## TD-03.35 — Polish pass: workout organism review nits

Correctness bugfixes from the organism-wave review (PRs #31–#35), plus two concrete spec-value visual corrections.

### Logic fixes (each covered by a new vitest test)
- **CapacityBandChart** — none logic (visual only, see below).
- **StrengthTrendChart**
  - Empty-state now keys off actual `data` only: a projection with no measured sessions renders the placeholder instead of a `Current: 0 lbs` chart.
  - Trend pill: when the current meso (last boundary) has `<2` points, stay neutral (`+0.0% this meso`) instead of silently reporting the whole-series change under a "this meso" label.
- **MesoStatusCard**
  - `clamp01` now guards non-finite input — a `NaN` gauge level renders `0%`, not `NaN%`.
  - Mapped metric/gauge lists use stable unique keys (`label+index`) so duplicate labels no longer collide.
- **ReadinessCheck**
  - Warm-up phrasing corrected: a non-positive velocity deficit reads "Velocity on 14-day average" / "N% above 14-day average" instead of the nonsensical "N% below".

### Visual changes — recommend screenshot confirmation
- **DOT_SIZE 12 → 8px** (spec §26) in CapacityBandChart.
- **CapacityBandChart dot border token `#191919` → `#F3F4F6`** — the hardcoded near-surface border was effectively invisible; the light ring matches the MesoStatusCard gauge-marker convention. Please verify visually.

No other subjective visual changes were made (e.g. the metrics-grid 48% flex-wrap was left as-is).

### Verification
- `pnpm lint` pass (0 errors; pre-existing warnings only, none in touched files)
- `pnpm type-check` pass
- `pnpm build` pass
- `pnpm test` pass — 1348 tests, 8 new
- Touched files kept consistent with their existing style. `format:check` fails on this repo's known ~186-file backlog on `main` (CI `continue-on-error`); these 4 files are part of that pre-existing set and were not reformatted to avoid unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)