### PR TITLE
Fix build-storybook by pre-bundling body-highlighter for production

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,5 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-native-web-vite'
 import {
+  reactNativeBodyHighlighterEsm,
   reactNativeSvgWebResolver,
   reactNativeSvgWebResolverEsbuild,
   svgWebAliases,
@@ -30,8 +31,19 @@ const config: StorybookConfig = {
   // dynamic require, no duplicate react / invalid-hook-call). The svg `.web.js`
   // resolution that the Vite resolveId plugin provides for non-pre-bundled
   // paths is replayed inside the optimizer via the esbuild-plugin form.
-  viteFinal: async (cfg) => {
-    cfg.plugins = [reactNativeSvgWebResolver(), ...(cfg.plugins ?? [])]
+  //
+  // The dep optimizer only runs on the dev server. `build-storybook` (a Rollup
+  // production build) never pre-bundles, so it would hand the package's raw CJS
+  // dist — untranspiled JSX plus `exports.default` with no static ESM default —
+  // straight to Rollup, which fails with "default is not exported by dist/index.js".
+  // For the build only, pre-transform the entry to self-contained ESM via
+  // esbuild (reactNativeBodyHighlighterEsm) so Rollup sees a real default export.
+  // It is scoped to PRODUCTION because its esbuild-externalized react/react-native
+  // imports would break the dev server's ESM serving (hence the optimizer there).
+  viteFinal: async (cfg, options) => {
+    const buildOnlyPlugins =
+      options.configType === 'PRODUCTION' ? [reactNativeBodyHighlighterEsm()] : []
+    cfg.plugins = [reactNativeSvgWebResolver(), ...buildOnlyPlugins, ...(cfg.plugins ?? [])]
     cfg.resolve = cfg.resolve ?? {}
     const existingAlias = cfg.resolve.alias
     const existingAliasArray = Array.isArray(existingAlias)


### PR DESCRIPTION
## Problem

`pnpm build-storybook` (in `packages/ui`) failed with a Rollup error, producing no usable `storybook-static/`:

```
src/components/custom/Workout/BodyMap.tsx (4:7): "default" is not exported by
".../react-native-body-highlighter/dist/index.js"
```

The package's own `pnpm build` (tsup), `type-check`, `lint`, and `vitest` all passed — only the Storybook Vite/Rollup production build broke.

## Root cause

`react-native-body-highlighter@3.2.0` ships an **untranspiled-JSX CommonJS** dist whose only default is a runtime `exports.default` (with `__esModule: true`) — no statically-analyzable ESM default export. `BodyMap.tsx` does `import BodyHighlighter from 'react-native-body-highlighter'`, and Rollup rejects that default import.

The prior dev fix (#38) makes this work on the **dev server** via Vite's dependency optimizer (`optimizeDeps.include`). But the optimizer only runs in dev. `build-storybook` is a Rollup production build that never pre-bundles, so it fed the raw CJS dist straight to Rollup and failed.

## Fix

Wire the already-present-but-unused `reactNativeBodyHighlighterEsm` transform plugin (in `vite-rn-svg-plugins.ts`) into `viteFinal` for **PRODUCTION builds only**. It esbuild-bundles the package entry into a self-contained ESM module with a real default export, which Rollup resolves cleanly. It stays scoped to `PRODUCTION` so the dev server keeps using the optimizer path (its esbuild-externalized react/react-native imports would otherwise break dev's raw-ESM serving — the exact reason #38 moved dev off this plugin).

**No stories or components were deleted.** The plugin was purpose-built for this scenario and was sitting unused; this simply activates it for the build.

## Verification

- `pnpm lint` — pass (0 errors)
- `pnpm type-check` — pass
- `pnpm build` — pass
- `pnpm test` (vitest run) — pass (81 files, 1348 tests)
- `pnpm build-storybook` — **pass**; emits complete `storybook-static/` with `index.json` listing 660 story entries (including all 18 BodyMap / BodyMapDetailPanel stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
