### PR TITLE
Fix undefined Tailwind utility classes in demo stories (TD-05.07)

### DIFF
--- a/packages/ui/src/components/custom/stepper/Stepper.stories.tsx
+++ b/packages/ui/src/components/custom/stepper/Stepper.stories.tsx
@@ -137,7 +137,7 @@ export const VerticalWithContent: Story = {
             <Text className="text-text-secondary text-sm">
               Fill in your profile details to continue.
             </Text>
-            <View className="bg-surface-inset border border-border rounded-md px-3 py-2">
+            <View className="bg-surface-input border border-border rounded-md px-3 py-2">
               <Text className="text-text-secondary text-sm">Display Name</Text>
             </View>
           </View>

--- a/packages/ui/src/components/ui/data-row/DataRow.stories.tsx
+++ b/packages/ui/src/components/ui/data-row/DataRow.stories.tsx
@@ -73,6 +73,6 @@ export const CustomClassName: Story = {
   args: {
     label: 'Bordered Row',
     value: 'With custom styles',
-    className: 'border-b border-border-primary px-4',
+    className: 'border-b border-border px-4',
   },
 }

--- a/packages/ui/src/components/ui/popover/Popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover/Popover.stories.tsx
@@ -152,7 +152,7 @@ export const WithFormContent: Story = {
           <Text className="text-text-secondary text-xs">
             Enter your new display name below.
           </Text>
-          <View className="bg-surface-inset border border-border rounded-md px-3 py-2">
+          <View className="bg-surface-input border border-border rounded-md px-3 py-2">
             <Text className="text-text-secondary text-sm">John Doe</Text>
           </View>
           <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'flex-end' }}>

--- a/packages/ui/src/components/ui/section/Section.stories.tsx
+++ b/packages/ui/src/components/ui/section/Section.stories.tsx
@@ -62,7 +62,7 @@ export const FullExample: Story = {
           <Text style={{ color: '#6366f1', fontSize: 13 }}>Details</Text>
         }
       />
-      <SectionContent className="rounded-lg bg-surface-secondary p-4">
+      <SectionContent className="rounded-lg bg-surface-elevated p-4">
         <Text style={{ color: '#a0a0a0' }}>Chart or data visualization</Text>
       </SectionContent>
     </Section>
@@ -74,7 +74,7 @@ export const MultipleSections: Story = {
     <View>
       <Section>
         <SectionHeader title="Today" subtitle="3 exercises" />
-        <SectionContent className="rounded-lg bg-surface-secondary p-4">
+        <SectionContent className="rounded-lg bg-surface-elevated p-4">
           <Text style={{ color: '#a0a0a0' }}>Today&apos;s workout data</Text>
         </SectionContent>
       </Section>
@@ -87,14 +87,14 @@ export const MultipleSections: Story = {
             <Text style={{ color: '#6366f1', fontSize: 13 }}>See All</Text>
           }
         />
-        <SectionContent className="rounded-lg bg-surface-secondary p-4">
+        <SectionContent className="rounded-lg bg-surface-elevated p-4">
           <Text style={{ color: '#a0a0a0' }}>Weekly summary</Text>
         </SectionContent>
       </Section>
 
       <Section>
         <SectionHeader title="Personal Records" />
-        <SectionContent className="rounded-lg bg-surface-secondary p-4">
+        <SectionContent className="rounded-lg bg-surface-elevated p-4">
           <Text style={{ color: '#a0a0a0' }}>PR list</Text>
         </SectionContent>
       </Section>

--- a/packages/ui/src/components/ui/stack/Stack.stories.tsx
+++ b/packages/ui/src/components/ui/stack/Stack.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof Stack>
 
 function Box({ children }: { children: string }) {
   return (
-    <View className="rounded bg-primary-500 px-4 py-2">
+    <View className="rounded bg-brand-primary px-4 py-2">
       <Text className="text-sm text-white">{children}</Text>
     </View>
   )
@@ -85,13 +85,13 @@ export const WithAlignment: Story = {
 
       <Text className="text-sm font-medium text-neutral-400">align=&quot;center&quot;</Text>
       <HStack gap={2} align="center">
-        <View className="rounded bg-primary-500 px-4 py-1">
+        <View className="rounded bg-brand-primary px-4 py-1">
           <Text className="text-sm text-white">Short</Text>
         </View>
-        <View className="rounded bg-primary-500 px-4 py-4">
+        <View className="rounded bg-brand-primary px-4 py-4">
           <Text className="text-sm text-white">Tall</Text>
         </View>
-        <View className="rounded bg-primary-500 px-4 py-2">
+        <View className="rounded bg-brand-primary px-4 py-2">
           <Text className="text-sm text-white">Medium</Text>
         </View>
       </HStack>


### PR DESCRIPTION
## TD-05.07 — Fix undefined Tailwind utility classes in demo stories

Four utility classes used only in stories/demos referenced tokens that do **not** exist in `packages/ui/tailwind.config.js`. Tailwind never emitted CSS for them, so each rendered **no color**. Remapped to the real tokens per the config's scales.

### Fixes (config-justified)
| File | Before | After | Why |
|------|--------|-------|-----|
| `Section.stories.tsx` (x4) | `bg-surface-secondary` | `bg-surface-elevated` | surface scale = base/elevated/raised/overlay/input — no `secondary` |
| `Popover.stories.tsx`, `Stepper.stories.tsx` | `bg-surface-inset` | `bg-surface-input` | no `inset`; `input` is the nearest recessed surface (sibling `border-border` already used alongside) |
| `DataRow.stories.tsx` | `border-border-primary` | `border-border` | border scale = DEFAULT/subtle/strong/focus/input — no `primary`; DEFAULT ⇒ doubled `border-border` prefix |
| `Stack.stories.tsx` (x4) | `bg-primary-500` | `bg-brand-primary` | see note below |

### Note — corrected inference
The pre-research inferred `bg-primary-500 → bg-primary`, but **`bg-primary` is also undefined**: there is no top-level `primary` color in the config. `primary` lives under `brand` (`brand.primary.DEFAULT = var(--color-brand-primary)`). The correct DEFAULT utility is **`bg-brand-primary`**, which is what shipped components use (`Tabs`, `Chip`, `Progress`, `Pill`, `Indicator`, `Checkbox`, `Radio`) and what the sibling Save button in `Popover.stories` already uses.

Stories/demos only — no shipped components touched.

### Visual verification
Built storybook (`pnpm build-storybook`, fixed in #46), served `storybook-static/`, screenshotted each affected story via Playwright at `theme:light` and read computed styles:

- `bg-surface-elevated` → `rgb(250, 250, 250)` — **color renders**
- `bg-brand-primary` → `rgb(255, 121, 0)` — **color renders** (three orange boxes, confirmed in screenshot)
- `border-border` → `borderBottomColor rgb(232, 233, 235)` — **color renders** ("Bordered Row" underline visible)
- `bg-surface-input` → `rgb(250, 250, 250)` — **color renders** (Stepper)
- Popover uses the same `bg-surface-input` token; its portal did not open under generic click automation, so verified via CSS-rule presence (`.bg-surface-input{background-color:var(--color-surface-input)}`) + the identical token rendering live in the Stepper story.

All four target utilities are present in the built CSS; the four former tokens are absent from it.

### Gate
`lint` pass (0 errors) · `type-check` pass · `build` pass · `test` pass (1348/1348, `vitest run`) · `build-storybook` pass. Touched files introduce no new prettier issues (the 4 flagged files were already part of the pre-existing repo-wide format drift; not reformatted to avoid unrelated diff noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
