### PR TITLE
Add specimen-page scaffold and restore comparison config (TD-04.02)

### DIFF
--- a/packages/ui/playwright.comparison.config.ts
+++ b/packages/ui/playwright.comparison.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './specimen',
+  testMatch: '**/*.visual.test.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:5200',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1200, height: 900 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm specimen --port 5200',
+    port: 5200,
+    reuseExistingServer: true,
+    timeout: 60000,
+  },
+})

--- a/packages/ui/specimen/comparison.html
+++ b/packages/ui/specimen/comparison.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Titan Design — HTML vs React Comparison</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #101010;
+        color: #f3f4f6;
+        font-family: Inter, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./comparison.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/specimen/index.html
+++ b/packages/ui/specimen/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Titan Design — Specimen</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #101010;
+        color: #f3f4f6;
+        font-family: Inter, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/specimen/index.tsx
+++ b/packages/ui/specimen/index.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import '../src/theme/global.css'
+
+import { StatusDot } from '../src/components/custom/Workout/StatusDot'
+import type { StatusDotVariant } from '../src/components/custom/Workout/StatusDot'
+import { WeightBadge } from '../src/components/custom/Workout/WeightBadge'
+
+import { CompareRow, MagnifiedStrip, Section, Variants, specimenTokens } from './scaffold'
+
+/* HTML ground-truth primitives — raw DOM matching the prototype exactly. */
+
+function HtmlDot({ size, color }: { size: number; color: string }) {
+  return (
+    <span
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: color,
+        display: 'inline-block',
+      }}
+    />
+  )
+}
+
+const STATUS_DOT_VARIANTS: StatusDotVariant[] = [
+  'success',
+  'warning',
+  'error',
+  'neutral',
+  'on-track',
+  'deviation',
+  'future',
+]
+
+const STATUS_DOT_HEX: Record<StatusDotVariant, string> = {
+  success: '#14B8A6',
+  warning: '#FFB020',
+  error: '#D14343',
+  neutral: '#6B7280',
+  'on-track': '#14B8A6',
+  deviation: '#FFB020',
+  future: '#2C2C2C',
+}
+
+/**
+ * Scaffold demo page. Proves the Section / CompareRow / Variants /
+ * MagnifiedStrip helpers render real react-native-web components beside their
+ * HTML ground truth. Downstream tickets (TD-04.03..08) extend this file with
+ * one <Section> per component family.
+ */
+function App() {
+  return (
+    <div style={{ padding: '24px 32px', maxWidth: 1200, margin: '0 auto' }}>
+      <h1
+        style={{
+          fontFamily: specimenTokens.fontHeading,
+          fontSize: 24,
+          fontWeight: 700,
+          color: specimenTokens.textPrimary,
+          margin: '0 0 4px',
+        }}
+      >
+        Titan Design — Specimen
+      </h1>
+      <p style={{ color: specimenTokens.textSecondary, fontSize: 12, margin: '0 0 28px' }}>
+        Layer 1 visual comparison scaffold. HTML ground truth (left) vs React (right).
+      </p>
+
+      <Section title="StatusDot" desc="Status indicator dot across every variant.">
+        <CompareRow
+          label="all variants"
+          html={
+            <Variants
+              items={STATUS_DOT_VARIANTS.map((v) => ({
+                label: v,
+                node: <HtmlDot size={8} color={STATUS_DOT_HEX[v]} />,
+              }))}
+            />
+          }
+          react={
+            <Variants
+              items={STATUS_DOT_VARIANTS.map((v) => ({
+                label: v,
+                node: <StatusDot variant={v} />,
+              }))}
+            />
+          }
+        />
+        <div style={{ marginTop: 12 }}>
+          <MagnifiedStrip
+            size={40}
+            items={STATUS_DOT_VARIANTS.map((v) => ({
+              label: v,
+              node: <StatusDot variant={v} size="md" />,
+            }))}
+          />
+        </div>
+      </Section>
+
+      <Section title="WeightBadge" desc="Estimated 1RM / N-rep-max load badge.">
+        <CompareRow
+          label="sizes"
+          html={
+            <Variants
+              items={(['sm', 'md', 'lg'] as const).map((size) => ({
+                label: size,
+                node: (
+                  <span
+                    style={{
+                      fontFamily: specimenTokens.fontHeading,
+                      fontSize: size === 'sm' ? 9 : size === 'md' ? 10 : 12,
+                      fontWeight: 600,
+                      color: specimenTokens.textSecondary,
+                      border: `1px solid ${specimenTokens.borderDefault}`,
+                      borderRadius: 2,
+                      padding: '2px 8px',
+                      background: specimenTokens.surfaceRaised,
+                    }}
+                  >
+                    217 lbs
+                  </span>
+                ),
+              }))}
+            />
+          }
+          react={
+            <Variants
+              items={(['sm', 'md', 'lg'] as const).map((size) => ({
+                label: size,
+                node: <WeightBadge value={217} size={size} />,
+              }))}
+            />
+          }
+        />
+      </Section>
+    </div>
+  )
+}
+
+const container = document.getElementById('root')
+if (container) {
+  createRoot(container).render(<App />)
+}

--- a/packages/ui/specimen/scaffold.tsx
+++ b/packages/ui/specimen/scaffold.tsx
@@ -1,0 +1,197 @@
+import React from 'react'
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Specimen scaffold — Layer 1 visual-comparison tooling (TD-04.02)
+
+   Reusable layout primitives for HTML-vs-React specimen pages. Downstream
+   specimen sections (TD-04.03..08) compose these helpers: wrap each component
+   family in a <Section>, place ground-truth HTML beside the React render with
+   <CompareRow>, fan out sizes/states with <Variants>, and blow up sub-pixel
+   atoms with <MagnifiedStrip>.
+
+   Adapted from the brain-dashboard SpecimenView.tsx pattern to the titan-design
+   DOM/react-native-web specimen convention (plain elements + inline styles,
+   matching specimen/comparison.tsx) so it can host any react-native-web
+   component without a StyleSheet dependency.
+
+   ── Canonical token mapping ────────────────────────────────────────────────
+   The specimen chrome hard-codes hex values so the page renders identically
+   whether or not theme CSS is loaded. Each value below is the frozen twin of a
+   canonical token in src/theme/global.css (:root, dark theme). Keep in sync.
+
+     Specimen hex        Canonical token (global.css)      Role
+     ----------------    ------------------------------    ------------------
+     #FF7900             --color-brand-primary             brand / active
+     #101010             --color-bg-base                   page background
+     #191919             --color-surface-elevated          card / cell surface
+     #1C1C1C             --color-surface-raised            raised surface
+     #F3F4F6             --color-text-primary              primary text
+     #9CA3AF             --color-text-secondary            secondary text
+     #6B7280             --color-text-tertiary             labels / captions
+     #1F1F1F             --color-border-default            hairline borders
+     #2C2C2C             --color-border-strong             divider / strong edge
+     'Space Grotesk'     --font-family-heading             headings / numerals
+     'Inter'             --font-family-sans                body
+     'Nunito Sans'       --font-family-body                UI labels
+   ──────────────────────────────────────────────────────────────────────── */
+
+export const specimenTokens = {
+  brand: '#FF7900',
+  bgBase: '#101010',
+  surfaceElevated: '#191919',
+  surfaceRaised: '#1C1C1C',
+  textPrimary: '#F3F4F6',
+  textSecondary: '#9CA3AF',
+  textTertiary: '#6B7280',
+  borderDefault: '#1F1F1F',
+  borderStrong: '#2C2C2C',
+  fontHeading: "'Space Grotesk', sans-serif",
+  fontBody: "'Inter', sans-serif",
+  fontUi: "'Nunito Sans', sans-serif",
+} as const
+
+const captionStyle: React.CSSProperties = {
+  fontSize: 9,
+  textTransform: 'uppercase',
+  letterSpacing: 0.8,
+  color: specimenTokens.textTertiary,
+  fontFamily: specimenTokens.fontUi,
+}
+
+/** Titled section wrapper grouping related component specimens. */
+export function Section({
+  title,
+  desc,
+  children,
+}: {
+  title: string
+  desc?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section style={{ marginBottom: 40, scrollMarginTop: 20 }}>
+      <h2
+        style={{
+          fontFamily: specimenTokens.fontHeading,
+          fontSize: 18,
+          fontWeight: 700,
+          color: specimenTokens.textPrimary,
+          margin: '0 0 4px',
+          paddingBottom: 8,
+          borderBottom: `1px solid ${specimenTokens.borderDefault}`,
+        }}
+      >
+        {title}
+      </h2>
+      {desc ? (
+        <p style={{ color: specimenTokens.textSecondary, fontSize: 12, margin: '0 0 16px' }}>
+          {desc}
+        </p>
+      ) : null}
+      <div style={{ marginTop: 12 }}>{children}</div>
+    </section>
+  )
+}
+
+/** Side-by-side row: HTML ground truth (left) vs React render (right). */
+export function CompareRow({
+  label,
+  html,
+  react,
+}: {
+  label: string
+  html: React.ReactNode
+  react: React.ReactNode
+}) {
+  return (
+    <div
+      data-testid={`compare-${label.replace(/\s+/g, '-').toLowerCase()}`}
+      style={{
+        display: 'flex',
+        gap: 32,
+        alignItems: 'flex-start',
+        padding: '12px 16px',
+        background: specimenTokens.surfaceElevated,
+        border: `1px solid ${specimenTokens.borderDefault}`,
+        borderRadius: 8,
+        marginBottom: 8,
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div style={{ ...captionStyle, marginBottom: 6 }}>HTML — {label}</div>
+        <div className="html-version" style={{ display: 'flex', alignItems: 'flex-start' }}>
+          {html}
+        </div>
+      </div>
+      <div style={{ width: 1, alignSelf: 'stretch', background: specimenTokens.borderStrong }} />
+      <div style={{ flex: 1 }}>
+        <div style={{ ...captionStyle, marginBottom: 6 }}>React — {label}</div>
+        <div className="react-version" style={{ display: 'flex', alignItems: 'flex-start' }}>
+          {react}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Horizontal strip of variants, each captioned with a small label beneath. */
+export function Variants({ items }: { items: Array<{ label: string; node: React.ReactNode }> }) {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, alignItems: 'flex-end' }}>
+      {items.map((item, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', minHeight: 24 }}>{item.node}</div>
+          <span style={captionStyle}>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Blows up sub-pixel atoms (dots, hairlines) to an explicit size for review. */
+export function MagnifiedStrip({
+  size,
+  items,
+}: {
+  size: number
+  items: Array<{ label: string; node: React.ReactNode }>
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 20,
+        alignItems: 'flex-end',
+        padding: '12px 16px',
+        background: specimenTokens.surfaceRaised,
+        border: `1px dashed ${specimenTokens.borderStrong}`,
+        borderRadius: 8,
+      }}
+    >
+      <span style={{ ...captionStyle, alignSelf: 'center' }}>magnified {size}px</span>
+      {items.map((item, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: size,
+              height: size,
+            }}
+          >
+            {item.node}
+          </div>
+          <span style={captionStyle}>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/specimen/vite.config.ts
+++ b/packages/ui/specimen/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react({ jsxImportSource: 'nativewind' })],
+  root: __dirname,
+  resolve: {
+    alias: {
+      'react-native': 'react-native-web',
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [
+        tailwindcss({ config: path.resolve(__dirname, '../tailwind.config.js') }),
+        autoprefixer(),
+      ],
+    },
+  },
+})


### PR DESCRIPTION
## TD-04.02 — specimen-page scaffold (keystone for TD-04.03..08)

Builds the Layer 1 HTML-vs-React visual-comparison scaffold and restores the specimen dev-server + comparison tooling that had been deleted from HEAD.

### Scaffold helpers (`specimen/scaffold.tsx`)
Canonical, reusable layout primitives modeled on the brain `SpecimenView.tsx` pattern, adapted to the titan-design DOM / react-native-web specimen convention:
- `Section` — titled group wrapper
- `CompareRow` — HTML ground truth (left) vs React render (right)
- `Variants` — captioned horizontal variant strip
- `MagnifiedStrip` — blows up sub-pixel atoms (dots/hairlines) to a review size
- `specimenTokens` + a **canonical token-mapping comment block** tying each frozen specimen hex back to its `src/theme/global.css` token.

### Entry + fonts
`specimen/index.tsx` + `index.html` self-mount a demo composing the helpers with real components (`StatusDot`, `WeightBadge`) beside HTML ground truth. **Google Fonts** (Space Grotesk, Inter, Nunito Sans) wired in the page head. Components are imported directly (not via the Workout barrel) so the production vite build stays clean of the `react-native-body-highlighter` JSX-in-.js landmine.

### Restored infrastructure (deleted from HEAD, recovered from `9083a9b`)
- `packages/ui/playwright.comparison.config.ts`
- `specimen/vite.config.ts`
- `specimen/comparison.html` (Google Fonts wired)

so `pnpm specimen`, `specimen:compare`, and `test:visual:compare` resolve again.

### Verification
| Gate | Result |
|------|--------|
| `pnpm lint` | pass (0 errors; 92 pre-existing warnings, none in touched files) |
| `pnpm type-check` | pass |
| `pnpm build` | pass |
| `pnpm test` (vitest run) | pass — 1355 tests |
| `pnpm build-storybook` | pass |
| `vite build` (scaffold) | pass — 1904 modules |
| `test:visual:compare` | config loads + specimen dev server boots; comparison run itself blocked by pre-existing stale `comparison.tsx` (see below) |

### Out of scope / note
The tracked `specimen/comparison.tsx` is stale against the current component API — it imports the removed `E1rmBadge` export (now `BaseBadge`/`WeightBadge`), so its App crashes at runtime and renders no test IDs. This is pre-existing breakage at HEAD, unrelated to the scaffold; it is left untouched here (no existing specimens deleted). Fixing/porting `comparison.tsx` to the current API is a follow-up.

No shared files modified — changes are confined to `specimen/` + the restored config, disjoint from concurrent TD-03.30 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)