### PR TITLE
Add ProgramPlanningPage template (TD-03.30)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ProgramPlanningPage.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ProgramPlanningPage.stories.tsx
@@ -1,0 +1,257 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ProgramPlanningPage, type PlanMeso } from './ProgramPlanningPage'
+import type { ExerciseCardProps } from './ExerciseCard'
+import type { WorkoutMuscleGroup } from './WorkoutCard'
+
+const upperMuscles: WorkoutMuscleGroup[] = [
+  { group: 'chest', label: 'Chest', volumeStatus: 'productive' },
+  { group: 'front-delts', label: 'Front Delts', volumeStatus: 'maintenance' },
+  { group: 'triceps', label: 'Triceps', volumeStatus: 'productive' },
+]
+
+const lowerMuscles: WorkoutMuscleGroup[] = [
+  { group: 'quads', label: 'Quads', volumeStatus: 'over' },
+  { group: 'glutes', label: 'Glutes', volumeStatus: 'productive' },
+  { group: 'hamstrings', label: 'Hamstrings', volumeStatus: 'maintenance' },
+]
+
+const upperExercises: ExerciseCardProps[] = [
+  {
+    name: 'Barbell Bench Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 4, reps: 8, weight: 185, unit: 'lbs' },
+    e1rm: { value: 235, unit: 'lbs' },
+    isPR: true,
+    setVelocities: [
+      [1.05, 0.94, 0.82, 0.74],
+      [0.98, 0.9, 0.8, 0.71],
+    ],
+    totalPlannedSets: 4,
+  },
+  {
+    name: 'Incline Dumbbell Press',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 3, reps: 10, weight: 70, unit: 'lbs' },
+    e1rm: { value: 92, unit: 'lbs' },
+    totalPlannedSets: 3,
+  },
+  {
+    name: 'Cable Triceps Pushdown',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3×12-15 @ RPE 8',
+    previousBest: '50 lbs × 14',
+  },
+]
+
+const lowerExercises: ExerciseCardProps[] = [
+  {
+    name: 'Back Squat',
+    state: 'collapsed',
+    onToggle: () => {},
+    summary: { sets: 5, reps: 5, weight: 275, unit: 'lbs' },
+    e1rm: { value: 335, unit: 'lbs' },
+    totalPlannedSets: 5,
+  },
+  {
+    name: 'Romanian Deadlift',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3×8-10 @ RPE 8',
+    previousBest: '225 lbs × 9',
+  },
+  {
+    name: 'Leg Press',
+    state: 'upcoming',
+    onToggle: () => {},
+    prescription: '3×12 @ RPE 9',
+    previousBest: '450 lbs × 12',
+  },
+]
+
+function upperWorkout(
+  id: string,
+  date: string,
+  status: 'completed' | 'today' | 'upcoming'
+): PlanMeso['weeks'][number]['workouts'][number] {
+  return {
+    id,
+    name: 'Upper A',
+    date,
+    duration: '52 min',
+    status,
+    muscleGroups: upperMuscles,
+    totalSets: 18,
+    totalVolume: 21400,
+    unit: 'lbs',
+    exercises: upperExercises,
+  }
+}
+
+function lowerWorkout(
+  id: string,
+  date: string,
+  status: 'completed' | 'today' | 'upcoming'
+): PlanMeso['weeks'][number]['workouts'][number] {
+  return {
+    id,
+    name: 'Lower A',
+    date,
+    duration: '58 min',
+    status,
+    muscleGroups: lowerMuscles,
+    totalSets: 16,
+    totalVolume: 28800,
+    unit: 'lbs',
+    exercises: lowerExercises,
+  }
+}
+
+const accumulation: PlanMeso = {
+  id: 'm1',
+  name: 'Accumulation',
+  goal: 'Hypertrophy',
+  split: 'Upper/Lower',
+  weekRange: 'Weeks 1-4',
+  weekCount: 4,
+  currentWeek: 3,
+  status: 'current',
+  volumeHeatmap: [
+    { group: 'chest', percentage: 72 },
+    { group: 'back', percentage: 85 },
+    { group: 'legs', percentage: 90 },
+    { group: 'shoulders', percentage: 55 },
+    { group: 'arms', percentage: 60 },
+  ],
+  weeks: [
+    {
+      weekNumber: 1,
+      intensityLevel: 0.5,
+      intensityThreshold: 0.85,
+      workouts: [
+        upperWorkout('m1w1-u', 'Mon, Jun 2', 'completed'),
+        lowerWorkout('m1w1-l', 'Wed, Jun 4', 'completed'),
+      ],
+    },
+    {
+      weekNumber: 2,
+      intensityLevel: 0.62,
+      intensityThreshold: 0.85,
+      workouts: [
+        upperWorkout('m1w2-u', 'Mon, Jun 9', 'completed'),
+        lowerWorkout('m1w2-l', 'Wed, Jun 11', 'completed'),
+      ],
+    },
+    {
+      weekNumber: 3,
+      intensityLevel: 0.74,
+      intensityThreshold: 0.85,
+      isCurrent: true,
+      workouts: [
+        upperWorkout('m1w3-u', 'Mon, Jun 16', 'today'),
+        lowerWorkout('m1w3-l', 'Wed, Jun 18', 'upcoming'),
+      ],
+    },
+    {
+      weekNumber: 4,
+      intensityLevel: 0.35,
+      intensityThreshold: 0.85,
+      isDeload: true,
+      workouts: [
+        upperWorkout('m1w4-u', 'Mon, Jun 23', 'upcoming'),
+        lowerWorkout('m1w4-l', 'Wed, Jun 25', 'upcoming'),
+      ],
+    },
+  ],
+}
+
+const intensification: PlanMeso = {
+  id: 'm2',
+  name: 'Intensification',
+  goal: 'Strength',
+  split: 'Push/Pull/Legs',
+  weekRange: 'Weeks 5-7',
+  weekCount: 3,
+  status: 'upcoming',
+  volumeHeatmap: [
+    { group: 'chest', percentage: 60 },
+    { group: 'back', percentage: 70 },
+    { group: 'legs', percentage: 80 },
+    { group: 'shoulders', percentage: 50 },
+    { group: 'arms', percentage: 45 },
+  ],
+  weeks: [
+    {
+      weekNumber: 1,
+      intensityLevel: 0.78,
+      intensityThreshold: 0.9,
+      workouts: [upperWorkout('m2w1-u', 'Mon, Jun 30', 'upcoming')],
+    },
+    {
+      weekNumber: 2,
+      intensityLevel: 0.86,
+      intensityThreshold: 0.9,
+      workouts: [lowerWorkout('m2w2-l', 'Mon, Jul 7', 'upcoming')],
+    },
+    {
+      weekNumber: 3,
+      intensityLevel: 0.92,
+      intensityThreshold: 0.9,
+      workouts: [upperWorkout('m2w3-u', 'Mon, Jul 14', 'upcoming')],
+    },
+  ],
+}
+
+const peak: PlanMeso = {
+  id: 'm3',
+  name: 'Peak',
+  goal: 'Peaking',
+  split: 'Full Body',
+  weekRange: 'Weeks 8-9',
+  weekCount: 2,
+  status: 'upcoming',
+  weeks: [
+    {
+      weekNumber: 1,
+      intensityLevel: 0.95,
+      intensityThreshold: 0.95,
+      workouts: [upperWorkout('m3w1-u', 'Mon, Jul 21', 'upcoming')],
+    },
+    {
+      weekNumber: 2,
+      intensityLevel: 0.6,
+      intensityThreshold: 0.95,
+      isDeload: true,
+      workouts: [lowerWorkout('m3w2-l', 'Mon, Jul 28', 'upcoming')],
+    },
+  ],
+}
+
+const accumulationDone: PlanMeso = {
+  ...accumulation,
+  id: 'm0',
+  name: 'Base',
+  status: 'completed',
+  weekRange: 'Weeks -3-0',
+}
+
+const mesos: PlanMeso[] = [accumulationDone, accumulation, intensification, peak]
+
+const meta: Meta<typeof ProgramPlanningPage> = {
+  title: 'Custom/Workout/ProgramPlanningPage',
+  component: ProgramPlanningPage,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  args: { title: 'Program Plan', mesos },
+}
+
+export default meta
+type Story = StoryObj<typeof ProgramPlanningPage>
+
+export const Default: Story = {}
+
+export const SingleMeso: Story = {
+  args: { mesos: [accumulation] },
+}

--- a/packages/ui/src/components/custom/Workout/ProgramPlanningPage.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ProgramPlanningPage.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  ProgramPlanningPage,
+  deriveNavLevel,
+  toProgressBarMesos,
+  findMeso,
+  findWeek,
+  findWorkout,
+  buildBreadcrumbs,
+  type PlanMeso,
+} from './ProgramPlanningPage'
+
+const workout = (id: string, status: 'completed' | 'today' | 'upcoming') => ({
+  id,
+  name: `Workout ${id}`,
+  date: 'Mon, Jun 2',
+  status,
+  muscleGroups: [{ group: 'chest', label: 'Chest' as const }],
+  totalSets: 12,
+  unit: 'lbs' as const,
+  exercises: [
+    {
+      name: 'Bench Press',
+      state: 'collapsed' as const,
+      onToggle: () => {},
+      summary: { sets: 3, reps: 8, weight: 185, unit: 'lbs' as const },
+    },
+    { name: 'Row', state: 'upcoming' as const, onToggle: () => {}, prescription: '3×10' },
+  ],
+})
+
+const mesos: PlanMeso[] = [
+  {
+    id: 'm1',
+    name: 'Accumulation',
+    goal: 'Hypertrophy',
+    split: 'Upper/Lower',
+    weekRange: 'Weeks 1-4',
+    weekCount: 2,
+    currentWeek: 1,
+    status: 'current',
+    weeks: [
+      {
+        weekNumber: 1,
+        intensityLevel: 0.5,
+        isCurrent: true,
+        workouts: [workout('w1a', 'today'), workout('w1b', 'upcoming')],
+      },
+      { weekNumber: 2, intensityLevel: 0.7, workouts: [workout('w2a', 'upcoming')] },
+    ],
+  },
+  {
+    id: 'm2',
+    name: 'Peak',
+    goal: 'Peaking',
+    split: 'Full Body',
+    weekRange: 'Weeks 5-6',
+    weekCount: 1,
+    status: 'upcoming',
+    weeks: [{ weekNumber: 1, intensityLevel: 0.9, workouts: [workout('w3a', 'upcoming')] }],
+  },
+]
+
+describe('deriveNavLevel', () => {
+  it('returns the deepest level indicated by the selection cursor', () => {
+    expect(deriveNavLevel({ weekNumber: null, workoutId: null })).toBe('meso')
+    expect(deriveNavLevel({ weekNumber: 1, workoutId: null })).toBe('week')
+    expect(deriveNavLevel({ weekNumber: 1, workoutId: 'w1a' })).toBe('workout')
+  })
+})
+
+describe('toProgressBarMesos', () => {
+  it('projects only the fields MesoProgressBar needs', () => {
+    expect(toProgressBarMesos(mesos)).toEqual([
+      { id: 'm1', name: 'Accumulation', weekCount: 2, status: 'current', currentWeek: 1 },
+      { id: 'm2', name: 'Peak', weekCount: 1, status: 'upcoming', currentWeek: undefined },
+    ])
+  })
+})
+
+describe('find helpers', () => {
+  it('locates a meso, week, and workout down the tree', () => {
+    const meso = findMeso(mesos, 'm1')
+    expect(meso?.name).toBe('Accumulation')
+    const week = findWeek(meso, 1)
+    expect(week?.workouts).toHaveLength(2)
+    expect(findWorkout(week, 'w1b')?.name).toBe('Workout w1b')
+  })
+
+  it('returns null for missing ids or null inputs', () => {
+    expect(findMeso(mesos, 'nope')).toBeNull()
+    expect(findMeso(mesos, null)).toBeNull()
+    expect(findWeek(null, 1)).toBeNull()
+    expect(findWorkout(findWeek(findMeso(mesos, 'm1'), 1), 'nope')).toBeNull()
+  })
+})
+
+describe('buildBreadcrumbs', () => {
+  it('grows the trail with drill depth', () => {
+    const meso = mesos[0]
+    expect(buildBreadcrumbs(meso, null, null).map((c) => c.label)).toEqual(['Accumulation'])
+    expect(buildBreadcrumbs(meso, 1, null).map((c) => c.label)).toEqual(['Accumulation', 'Week 1'])
+    const wo = findWorkout(findWeek(meso, 1), 'w1a')
+    expect(buildBreadcrumbs(meso, 1, wo).map((c) => c.level)).toEqual(['meso', 'week', 'workout'])
+  })
+})
+
+describe('ProgramPlanningPage', () => {
+  it('renders the progress bar and starts at the meso level', () => {
+    render(<ProgramPlanningPage mesos={mesos} />)
+    expect(screen.getByTestId('program-planning-page')).toBeInTheDocument()
+    expect(screen.getByTestId('meso-progress-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('program-planning-page-meso-level')).toBeInTheDocument()
+    expect(screen.getByTestId('program-planning-page-crumb-meso')).toHaveTextContent('Accumulation')
+  })
+
+  it('drills meso -> week -> workout and rewinds via breadcrumbs', () => {
+    render(<ProgramPlanningPage mesos={mesos} />)
+
+    // Meso level: tapping a week's workout pill drills into that week.
+    fireEvent.click(screen.getAllByTestId('workout-pill-pressable')[0])
+    expect(screen.getByTestId('program-planning-page-week-level')).toBeInTheDocument()
+    expect(screen.getByTestId('program-planning-page-crumb-week')).toHaveTextContent('Week 1')
+
+    // Week level: the week's two workouts render as cards; open the first.
+    expect(screen.getAllByTestId('workout-card')).toHaveLength(2)
+    fireEvent.click(screen.getAllByTestId('workout-card-toggle')[0])
+    expect(screen.getByTestId('program-planning-page-workout-level')).toBeInTheDocument()
+    expect(screen.getByTestId('workout-card-exercises')).toBeInTheDocument()
+
+    // Breadcrumb rewinds back to the meso overview.
+    fireEvent.click(screen.getByTestId('program-planning-page-crumb-meso'))
+    expect(screen.getByTestId('program-planning-page-meso-level')).toBeInTheDocument()
+  })
+
+  it('switches the active meso when a progress-bar segment is pressed', () => {
+    render(<ProgramPlanningPage mesos={mesos} />)
+    fireEvent.click(screen.getByTestId('meso-segment-m2'))
+    expect(screen.getByTestId('program-planning-page-crumb-meso')).toHaveTextContent('Peak')
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
@@ -1,0 +1,423 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useMemo, useState } from 'react'
+import { View, Text, Pressable, type ViewProps } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { MesoProgressBar, type Meso, type MesoStatus } from './MesoProgressBar'
+import { MesoCard, type MesoVolumeHeatmapEntry } from './MesoCard'
+import { type WeekRowProps, type WeekRowWorkout } from './WeekRow'
+import { WorkoutCard, type WorkoutStatus, type WorkoutMuscleGroup } from './WorkoutCard'
+import { type WorkoutPillStatus } from './WorkoutPill'
+import { type ExerciseCardProps } from './ExerciseCard'
+
+const SURFACE_ELEVATED = WORKOUT_TOKENS.surface.elevated
+const BORDER_DEFAULT = WORKOUT_TOKENS.border.default
+const BRAND_PRIMARY = '#FF7900'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_TERTIARY = '#6B7280'
+const PAGE_BG = '#0E0E0E'
+
+/** A single workout within a planned week, plus its exercise breakdown. */
+export interface PlanWorkout {
+  /** Stable identifier used for drill-down selection. */
+  id: string
+  name: string
+  date: string
+  duration?: string
+  status: WorkoutStatus
+  muscleGroups: WorkoutMuscleGroup[]
+  totalSets: number
+  totalVolume?: number
+  unit: 'lbs' | 'kg'
+  /** Exercises revealed when the workout is opened. */
+  exercises: ExerciseCardProps[]
+}
+
+/** A training week inside a mesocycle. */
+export interface PlanWeek {
+  /** 1-based week index within the mesocycle. */
+  weekNumber: number
+  /** Planned intensity for the week, 0-1. */
+  intensityLevel: number
+  /** Optional MRV/overexertion threshold, 0-1. */
+  intensityThreshold?: number
+  isDeload?: boolean
+  isCurrent?: boolean
+  workouts: PlanWorkout[]
+}
+
+/** A mesocycle: the top level of the drill-down. */
+export interface PlanMeso {
+  id: string
+  name: string
+  goal: string
+  split: string
+  weekRange: string
+  weekCount: number
+  currentWeek?: number
+  status: MesoStatus
+  volumeHeatmap?: MesoVolumeHeatmapEntry[]
+  weeks: PlanWeek[]
+}
+
+/** Current depth of the meso -> week -> workout drill-down. */
+export type ProgramNavLevel = 'meso' | 'week' | 'workout'
+
+/** The navigation cursor within the active mesocycle. */
+export interface ProgramSelection {
+  weekNumber: number | null
+  workoutId: string | null
+}
+
+/** One tappable step in the breadcrumb trail. */
+export interface ProgramBreadcrumb {
+  key: string
+  label: string
+  level: ProgramNavLevel
+}
+
+export interface ProgramPlanningPageProps extends ViewProps {
+  /** Page heading. */
+  title?: string
+  /** Mesocycles that make up the program. */
+  mesos: PlanMeso[]
+  className?: string
+}
+
+/** Map a workout's lifecycle status onto a WorkoutPill status. */
+const WORKOUT_PILL_STATUS: Record<WorkoutStatus, WorkoutPillStatus> = {
+  completed: 'completed',
+  today: 'current',
+  upcoming: 'upcoming',
+}
+
+/** Derive the current drill-down level from the selection cursor (pure). */
+export function deriveNavLevel(selection: ProgramSelection): ProgramNavLevel {
+  if (selection.workoutId != null) return 'workout'
+  if (selection.weekNumber != null) return 'week'
+  return 'meso'
+}
+
+/** Project the mesocycles onto MesoProgressBar segment data (pure). */
+export function toProgressBarMesos(mesos: PlanMeso[]): Meso[] {
+  return mesos.map(({ id, name, weekCount, status, currentWeek }) => ({
+    id,
+    name,
+    weekCount,
+    status,
+    currentWeek,
+  }))
+}
+
+/** Look up a meso by id, or null. */
+export function findMeso(mesos: PlanMeso[], id: string | null): PlanMeso | null {
+  if (id == null) return null
+  return mesos.find((meso) => meso.id === id) ?? null
+}
+
+/** Look up a week within a meso, or null. */
+export function findWeek(meso: PlanMeso | null, weekNumber: number | null): PlanWeek | null {
+  if (meso == null || weekNumber == null) return null
+  return meso.weeks.find((week) => week.weekNumber === weekNumber) ?? null
+}
+
+/** Look up a workout within a week, or null. */
+export function findWorkout(week: PlanWeek | null, workoutId: string | null): PlanWorkout | null {
+  if (week == null || workoutId == null) return null
+  return week.workouts.find((workout) => workout.id === workoutId) ?? null
+}
+
+/** Build the breadcrumb trail for the active drill path (pure). */
+export function buildBreadcrumbs(
+  meso: PlanMeso,
+  weekNumber: number | null,
+  workout: PlanWorkout | null
+): ProgramBreadcrumb[] {
+  const crumbs: ProgramBreadcrumb[] = [{ key: 'meso', label: meso.name, level: 'meso' }]
+  if (weekNumber != null) {
+    crumbs.push({ key: 'week', label: `Week ${weekNumber}`, level: 'week' })
+  }
+  if (workout != null) {
+    crumbs.push({ key: 'workout', label: workout.name, level: 'workout' })
+  }
+  return crumbs
+}
+
+interface BreadcrumbsProps {
+  crumbs: ProgramBreadcrumb[]
+  onNavigate: (level: ProgramNavLevel) => void
+}
+
+function Breadcrumbs({ crumbs, onNavigate }: BreadcrumbsProps) {
+  return (
+    <View
+      className="flex-row items-center flex-wrap"
+      style={{ gap: 4 }}
+      testID="program-planning-page-breadcrumbs"
+    >
+      {crumbs.map((crumb, index) => {
+        const isLast = index === crumbs.length - 1
+        return (
+          <View key={crumb.key} className="flex-row items-center" style={{ gap: 4 }}>
+            {index > 0 && <Text style={{ fontSize: 12, color: TEXT_TERTIARY }}>{'›'}</Text>}
+            <Pressable
+              onPress={() => onNavigate(crumb.level)}
+              disabled={isLast}
+              accessibilityRole="button"
+              testID={`program-planning-page-crumb-${crumb.key}`}
+            >
+              <Text
+                style={{
+                  fontSize: 12,
+                  fontFamily: 'Inter, sans-serif',
+                  fontWeight: isLast ? '700' : '500',
+                  color: isLast ? TEXT_PRIMARY : BRAND_PRIMARY,
+                }}
+              >
+                {crumb.label}
+              </Text>
+            </Pressable>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+/** Project a plan week onto WeekRow props, wiring pill taps to week selection. */
+function toWeekRow(
+  week: PlanWeek,
+  meso: PlanMeso,
+  onSelectWeek: (weekNumber: number) => void
+): WeekRowProps {
+  const workouts: WeekRowWorkout[] = week.workouts.map((workout) => ({
+    name: workout.name,
+    status: WORKOUT_PILL_STATUS[workout.status],
+    onPress: () => onSelectWeek(week.weekNumber),
+  }))
+  return {
+    weekNumber: week.weekNumber,
+    totalWeeks: meso.weekCount,
+    workouts,
+    intensityLevel: week.intensityLevel,
+    intensityThreshold: week.intensityThreshold,
+    isCurrent: week.isCurrent ?? week.weekNumber === meso.currentWeek,
+    isDeload: week.isDeload,
+  }
+}
+
+interface MesoLevelProps {
+  mesos: PlanMeso[]
+  activeMesoId: string | null
+  onSelectMeso: (id: string) => void
+  onSelectWeek: (weekNumber: number) => void
+}
+
+function MesoLevel({ mesos, activeMesoId, onSelectMeso, onSelectWeek }: MesoLevelProps) {
+  return (
+    <View style={{ gap: 12 }} testID="program-planning-page-meso-level">
+      {mesos.map((meso) => {
+        const expanded = meso.id === activeMesoId
+        return (
+          <MesoCard
+            key={meso.id}
+            name={meso.name}
+            goal={meso.goal}
+            split={meso.split}
+            weekRange={meso.weekRange}
+            currentWeek={meso.currentWeek}
+            totalWeeks={meso.weekCount}
+            weeks={expanded ? meso.weeks.map((week) => toWeekRow(week, meso, onSelectWeek)) : []}
+            volumeHeatmap={meso.volumeHeatmap}
+            expanded={expanded}
+            onToggle={() => onSelectMeso(meso.id)}
+            highlighted={expanded}
+          />
+        )
+      })}
+    </View>
+  )
+}
+
+interface WeekLevelProps {
+  week: PlanWeek
+  onSelectWorkout: (id: string) => void
+}
+
+function WeekLevel({ week, onSelectWorkout }: WeekLevelProps) {
+  return (
+    <View style={{ gap: 10 }} testID="program-planning-page-week-level">
+      {week.workouts.map((workout) => (
+        <WorkoutCard
+          key={workout.id}
+          name={workout.name}
+          date={workout.date}
+          duration={workout.duration}
+          status={workout.status}
+          muscleGroups={workout.muscleGroups}
+          totalSets={workout.totalSets}
+          totalVolume={workout.totalVolume}
+          unit={workout.unit}
+          exercises={workout.exercises}
+          expanded={false}
+          onToggle={() => onSelectWorkout(workout.id)}
+        />
+      ))}
+    </View>
+  )
+}
+
+interface WorkoutLevelProps {
+  workout: PlanWorkout
+  expandedExercise: number | null
+  onToggleExercise: (index: number) => void
+}
+
+function WorkoutLevel({ workout, expandedExercise, onToggleExercise }: WorkoutLevelProps) {
+  const exercises = workout.exercises.map((exercise, index) => ({
+    ...exercise,
+    state:
+      exercise.state === 'upcoming'
+        ? exercise.state
+        : ((index === expandedExercise ? 'expanded' : 'collapsed') as ExerciseCardProps['state']),
+    onToggle: () => onToggleExercise(index),
+  }))
+  return (
+    <View testID="program-planning-page-workout-level">
+      <WorkoutCard
+        name={workout.name}
+        date={workout.date}
+        duration={workout.duration}
+        status={workout.status}
+        muscleGroups={workout.muscleGroups}
+        totalSets={workout.totalSets}
+        totalVolume={workout.totalVolume}
+        unit={workout.unit}
+        exercises={exercises}
+        expanded
+        onToggle={() => undefined}
+      />
+    </View>
+  )
+}
+
+/**
+ * ProgramPlanningPage — a meso -> week -> workout drill-down over an entire
+ * training program. A `MesoProgressBar` pins the mesocycle timeline to the top;
+ * the body swaps between three levels: expandable `MesoCard`s (with inline
+ * `WeekRow`s), a week's `WorkoutCard` list, and a single opened `WorkoutCard`
+ * with inline `ExerciseCard` expansion. A breadcrumb trail tracks and rewinds
+ * the drill path. Selection is page-level state; children keep their own styles.
+ *
+ * @example
+ * <ProgramPlanningPage mesos={mesos} />
+ */
+export function ProgramPlanningPage({
+  title = 'Program Plan',
+  mesos,
+  className,
+  ...props
+}: ProgramPlanningPageProps) {
+  const [activeMesoId, setActiveMesoId] = useState<string | null>(mesos[0]?.id ?? null)
+  const [selectedWeek, setSelectedWeek] = useState<number | null>(null)
+  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null)
+  const [expandedExercise, setExpandedExercise] = useState<number | null>(null)
+
+  const progressMesos = useMemo(() => toProgressBarMesos(mesos), [mesos])
+  const activeMeso = findMeso(mesos, activeMesoId)
+  const level = deriveNavLevel({ weekNumber: selectedWeek, workoutId: selectedWorkoutId })
+  const activeWeek = findWeek(activeMeso, selectedWeek)
+  const activeWorkout = findWorkout(activeWeek, selectedWorkoutId)
+
+  const selectMeso = (id: string) => {
+    setActiveMesoId(id)
+    setSelectedWeek(null)
+    setSelectedWorkoutId(null)
+  }
+  const selectWeek = (weekNumber: number) => {
+    setSelectedWeek(weekNumber)
+    setSelectedWorkoutId(null)
+    setExpandedExercise(null)
+  }
+  const selectWorkout = (id: string) => {
+    setSelectedWorkoutId(id)
+    setExpandedExercise(null)
+  }
+  const toggleExercise = (index: number) =>
+    setExpandedExercise((current) => (current === index ? null : index))
+
+  const navigateTo = (target: ProgramNavLevel) => {
+    if (target === 'meso') selectMeso(activeMesoId ?? mesos[0]?.id)
+    else if (target === 'week' && selectedWeek != null) selectWeek(selectedWeek)
+  }
+
+  return (
+    <View
+      className={className}
+      style={{ width: 390, backgroundColor: PAGE_BG }}
+      accessibilityRole={'main' as ViewProps['accessibilityRole']}
+      aria-label={title}
+      testID="program-planning-page"
+      {...props}
+    >
+      <View style={{ padding: 16, gap: 14 }} testID="program-planning-page-content">
+        <Text
+          accessibilityRole="header"
+          style={{
+            fontSize: 20,
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontWeight: '700',
+            color: TEXT_PRIMARY,
+          }}
+          testID="program-planning-page-title"
+        >
+          {title}
+        </Text>
+
+        <View style={{ marginHorizontal: -16 }}>
+          <MesoProgressBar
+            mesos={progressMesos}
+            activeMesoId={activeMesoId}
+            onMesoPress={selectMeso}
+          />
+        </View>
+
+        {activeMeso != null && (
+          <Breadcrumbs
+            crumbs={buildBreadcrumbs(activeMeso, selectedWeek, activeWorkout)}
+            onNavigate={navigateTo}
+          />
+        )}
+
+        <View
+          style={{
+            backgroundColor: SURFACE_ELEVATED,
+            borderWidth: 1,
+            borderColor: BORDER_DEFAULT,
+            borderRadius: 12,
+            padding: 12,
+          }}
+          testID="program-planning-page-body"
+        >
+          {level === 'meso' && (
+            <MesoLevel
+              mesos={mesos}
+              activeMesoId={activeMesoId}
+              onSelectMeso={selectMeso}
+              onSelectWeek={selectWeek}
+            />
+          )}
+          {level === 'week' && activeWeek != null && (
+            <WeekLevel week={activeWeek} onSelectWorkout={selectWorkout} />
+          )}
+          {level === 'workout' && activeWorkout != null && (
+            <WorkoutLevel
+              workout={activeWorkout}
+              expandedExercise={expandedExercise}
+              onToggleExercise={toggleExercise}
+            />
+          )}
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -95,6 +95,22 @@ export {
   type TrainingStatusSummary,
 } from './TrainingStatusPage'
 export {
+  ProgramPlanningPage,
+  deriveNavLevel,
+  toProgressBarMesos,
+  findMeso,
+  findWeek,
+  findWorkout,
+  buildBreadcrumbs,
+  type ProgramPlanningPageProps,
+  type PlanMeso,
+  type PlanWeek,
+  type PlanWorkout,
+  type ProgramNavLevel,
+  type ProgramSelection,
+  type ProgramBreadcrumb,
+} from './ProgramPlanningPage'
+export {
   MuscleGroup,
   SimpleMuscleGroup,
   SIMPLE_TO_DETAILED,


### PR DESCRIPTION
## TD-03.30 — ProgramPlanningPage template

A meso → week → workout drill-down over an entire training program, built as a **page-model** in the same style as `TrainingStatusPage` (TD-03.31): pure derive helpers + page-level selection state + story + vitest test. It **composes** the already-styled Workout components via their prop contracts — no child redesign.

### Composition
- **`MesoProgressBar`** pinned to the top (segment widths ∝ `weekCount`, active meso highlighted, tap to switch meso).
- **Breadcrumb trail** (page-local) tracks and rewinds the drill path; each crumb is tappable.
- **Meso level** — `MesoCard` list; the active card is expanded, rendering its inline `WeekRow`s. A `WeekRow` workout pill tap drills into that week.
- **Week level** — the selected week's `WorkoutCard` list; tapping a card opens it.
- **Workout level** — a single opened `WorkoutCard` with inline `ExerciseCard` expansion (one exercise open at a time).

Page orchestration is split into small (≤30-line) helpers/subcomponents. Pure, exported, unit-tested helpers: `deriveNavLevel`, `toProgressBarMesos`, `findMeso` / `findWeek` / `findWorkout`, `buildBreadcrumbs`.

### Drill-down / selection state
Cursor is `{ activeMesoId, selectedWeek, selectedWorkoutId, expandedExercise }`; the render level is derived (`workout > week > meso`). Selecting a level up-stream clears everything below it, and breadcrumbs rewind to any ancestor. No spec doc exists in-repo (§30 referenced but absent) — the layout was composed from the components' documented props; no design decision was required.

### Screenshot verification (Storybook **dev** server, `document.fonts.ready`, animations disabled, both themes, each level)
**Dark theme (design-system default) — fully coherent at every level:**
- *Meso:* title, progress bar (teal done / orange current w/ fill / gray upcoming), breadcrumb, expanded `Base` MesoCard with W1–W4 WeekRows (completed/current/deload pills, intensity bars, heatmap strip) and collapsed MesoCards below. No overlap/blank.
- *Week:* breadcrumb `Base › Week 1`, two WorkoutCards (Upper A / Lower A) with muscle chips + stats.
- *Workout:* breadcrumb `Base › Week 1 › Upper A`, WorkoutCard expanded with inline ExerciseCards — velocity strip, e1rm badge, PR star, upcoming prescriptions. Drill-down and inline expansion verified working.

**Light theme — page chrome correct; a known child limitation surfaces:**
- My page-level chrome (title, `MesoProgressBar`, breadcrumbs, body surface) renders with correct contrast in light theme.
- The child `Card`-based components (`MesoCard`, `WorkoutCard`, `ExerciseCard`) flip their surface to `#FAFAFA` in light theme (via `Card`'s `outline`/`accent` light-mode branch) while their **hardcoded** primary text (`#F3F4F6`) stays near-white → **white-on-white on the card interiors** (e.g. meso/workout/exercise names). This is **pre-existing and reproduced in `MesoCard`'s own `Expanded` story** in light theme, not introduced here. It cannot be fixed at the page level without redesigning those `done`/on-`main` children (`useTheme` reads the global `html` class, so a subtree can't be pinned dark), which is explicitly out of scope. The pattern page `TrainingStatusPage` avoids this only because its children (`MesoStatusCard`) hardcode a dark `bgColor`; the mandated children here do not expose that lever. Dark (the primary theme) is the coherent target.

### Gates
`lint` ✅ (0 warnings in touched files) · `type-check` ✅ · `build` ✅ · `test` ✅ (1363 passed) · `build-storybook` ✅ (compiles)

Touched `Workout/index.ts` by **adding** the export only (prettier-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
