### PR TITLE
Add CSS property extraction script (TD-06.02)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,6 +50,7 @@
     "build-storybook": "storybook build",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
+    "extract-css": "node scripts/extract-css-properties.mjs",
     "specimen": "vite --config specimen/vite.config.ts",
     "specimen:compare": "vite --config specimen/vite.config.ts --open /comparison.html",
     "test:visual:compare": "playwright test --config playwright.comparison.config.ts",

--- a/packages/ui/scripts/extract-css-properties.mjs
+++ b/packages/ui/scripts/extract-css-properties.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Extract a CSS property manifest from a rendered HTML source.
+ *
+ * Given an HTML file and a CSS selector, this loads the file in a headless
+ * Chromium page (via Playwright), reads window.getComputedStyle for the matched
+ * element, and emits a manifest conforming to css-property-manifest.schema.json.
+ * Measuring the *rendered* computed styles removes the hand-transcription errors
+ * that come from reading values out of an HTML prototype by eye.
+ *
+ * Extracted properties carry `token: null`: getComputedStyle yields literal
+ * resolved values, not the semantic token they were sourced from, so tokens are
+ * annotated in a later step. The schema explicitly permits null tokens for
+ * literal (non-tokenized) values.
+ *
+ * Usage:
+ *   node scripts/extract-css-properties.mjs <html> <selector> <component> \
+ *     [--out <file>] [--variant <axis>=<value> ...]
+ */
+
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Visual CSS properties captured for each component. camelCase and letters-only
+ * so every emitted property name satisfies the schema's `^[a-zA-Z]+$` pattern.
+ */
+export const DEFAULT_VISUAL_PROPERTIES = [
+  'backgroundColor',
+  'color',
+  'borderColor',
+  'borderStyle',
+  'borderWidth',
+  'borderRadius',
+  'boxShadow',
+  'opacity',
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+  'letterSpacing',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+]
+
+/** Convert a camelCase CSS property name to its kebab-case getPropertyValue key. */
+export const toKebabCase = (property) =>
+  property.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+
+/**
+ * Read computed values for `properties` off `element` using `getComputed`, keyed
+ * by the original camelCase property name. Shared by the jsdom tests; mirrored
+ * in-page by extractStyleMapFromHtml (which cannot cross the browser boundary).
+ */
+export function readComputedStyleMap(element, properties, getComputed) {
+  const style = getComputed(element)
+  const styleMap = {}
+  for (const property of properties) {
+    styleMap[property] = style.getPropertyValue(toKebabCase(property))
+  }
+  return styleMap
+}
+
+/**
+ * Turn a camelCase-keyed computed-style map into manifest property entries,
+ * dropping properties whose computed value is empty so that every entry meets
+ * the schema's non-empty resolvedValue requirement.
+ */
+export function styleMapToProperties(styleMap) {
+  return Object.entries(styleMap)
+    .filter(([, value]) => typeof value === 'string' && value.trim().length > 0)
+    .map(([property, value]) => ({ property, token: null, resolvedValue: value.trim() }))
+}
+
+/** Assemble a CssPropertyManifest from a component name and a computed-style map. */
+export function buildCssPropertyManifest({ component, styleMap, baseVariant, description }) {
+  const properties = styleMapToProperties(styleMap)
+  if (properties.length === 0) {
+    throw new Error('No non-empty computed CSS properties were extracted for the selector')
+  }
+  const manifest = { component, properties }
+  if (description) manifest.description = description
+  if (baseVariant && Object.keys(baseVariant).length > 0) manifest.baseVariant = baseVariant
+  return manifest
+}
+
+/**
+ * Launch headless Chromium, load `htmlPath`, and read computed styles for the
+ * first element matching `selector`. Returns a camelCase-keyed style map.
+ */
+export async function extractStyleMapFromHtml(
+  htmlPath,
+  selector,
+  properties = DEFAULT_VISUAL_PROPERTIES
+) {
+  const { chromium } = await import('@playwright/test')
+  const browser = await chromium.launch()
+  try {
+    const page = await browser.newPage()
+    await page.goto(pathToFileURL(path.resolve(htmlPath)).href, { waitUntil: 'networkidle' })
+    await page.waitForSelector(selector)
+    return await page.evaluate(
+      ({ selector: sel, properties: props }) => {
+        const element = document.querySelector(sel)
+        if (!element) throw new Error(`No element matched selector: ${sel}`)
+        const style = getComputedStyle(element)
+        const styleMap = {}
+        for (const property of props) {
+          const kebab = property.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+          styleMap[property] = style.getPropertyValue(kebab)
+        }
+        return styleMap
+      },
+      { selector, properties }
+    )
+  } finally {
+    await browser.close()
+  }
+}
+
+/** High-level driver: extract a schema-shaped manifest from an HTML file + selector. */
+export async function extractCssPropertyManifest({
+  htmlPath,
+  selector,
+  component,
+  baseVariant,
+  description,
+}) {
+  const styleMap = await extractStyleMapFromHtml(htmlPath, selector)
+  return buildCssPropertyManifest({ component, styleMap, baseVariant, description })
+}
+
+/** Parse CLI argv into positional args and flags (--out, repeatable --variant k=v). */
+export function parseArgs(argv) {
+  const positional = []
+  const baseVariant = {}
+  let out
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--out') {
+      i += 1
+      out = argv[i]
+    } else if (arg === '--variant') {
+      i += 1
+      const [axis, value] = (argv[i] ?? '').split('=')
+      if (axis && value) baseVariant[axis] = value
+    } else {
+      positional.push(arg)
+    }
+  }
+  const [htmlPath, selector, component] = positional
+  return { htmlPath, selector, component, out, baseVariant }
+}
+
+async function main() {
+  const { htmlPath, selector, component, out, baseVariant } = parseArgs(process.argv.slice(2))
+  if (!htmlPath || !selector || !component) {
+    console.error(
+      'Usage: node scripts/extract-css-properties.mjs <html> <selector> <component> ' +
+        '[--out <file>] [--variant <axis>=<value> ...]'
+    )
+    process.exitCode = 1
+    return
+  }
+  const manifest = await extractCssPropertyManifest({ htmlPath, selector, component, baseVariant })
+  const json = JSON.stringify(manifest, null, 2)
+  if (out) {
+    const outPath = path.resolve(out)
+    await writeFile(outPath, `${json}\n`, 'utf8')
+    console.log(
+      `Wrote ${path.relative(process.cwd(), outPath)} (${manifest.properties.length} properties)`
+    )
+  } else {
+    console.log(json)
+  }
+}
+
+const invokedDirectly = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/packages/ui/src/theme/manifest/extract-css-properties.fixture.html
+++ b/packages/ui/src/theme/manifest/extract-css-properties.fixture.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>CSS extraction fixture — button specimen</title>
+  </head>
+  <body>
+    <button
+      data-testid="button"
+      style="
+        background-color: rgb(255, 121, 0);
+        color: rgb(255, 255, 255);
+        border-color: rgba(0, 0, 0, 0);
+        border-style: solid;
+        border-width: 0px;
+        border-radius: 6px;
+        font-family: Inter, sans-serif;
+        font-size: 16px;
+        font-weight: 600;
+        padding-top: 10px;
+        padding-right: 20px;
+        padding-bottom: 10px;
+        padding-left: 20px;
+      "
+    >
+      Start workout
+    </button>
+  </body>
+</html>

--- a/packages/ui/src/theme/manifest/extract-css-properties.test.ts
+++ b/packages/ui/src/theme/manifest/extract-css-properties.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  DEFAULT_VISUAL_PROPERTIES,
+  buildCssPropertyManifest,
+  readComputedStyleMap,
+  styleMapToProperties,
+  toKebabCase,
+  parseArgs,
+} from '../../../scripts/extract-css-properties.mjs'
+import { validateCssPropertyManifest } from './css-property-manifest.validate'
+
+const loadFixtureBody = (fileName: string): string => {
+  const html = readFileSync(join(__dirname, fileName), 'utf-8')
+  return new DOMParser().parseFromString(html, 'text/html').body.innerHTML
+}
+
+describe('toKebabCase', () => {
+  it('converts camelCase CSS property names to kebab-case', () => {
+    expect(toKebabCase('backgroundColor')).toBe('background-color')
+    expect(toKebabCase('paddingLeft')).toBe('padding-left')
+    expect(toKebabCase('color')).toBe('color')
+  })
+})
+
+describe('styleMapToProperties', () => {
+  it('drops empty computed values and tags each entry with a null token', () => {
+    const properties = styleMapToProperties({
+      backgroundColor: 'rgb(255, 121, 0)',
+      borderRadius: '  6px  ',
+      letterSpacing: '',
+      lineHeight: '   ',
+    })
+
+    expect(properties).toEqual([
+      { property: 'backgroundColor', token: null, resolvedValue: 'rgb(255, 121, 0)' },
+      { property: 'borderRadius', token: null, resolvedValue: '6px' },
+    ])
+  })
+})
+
+describe('buildCssPropertyManifest', () => {
+  it('throws when no property has a non-empty computed value', () => {
+    expect(() =>
+      buildCssPropertyManifest({ component: 'button', styleMap: { color: '' } })
+    ).toThrow(/No non-empty computed CSS properties/)
+  })
+
+  it('includes baseVariant and description only when provided', () => {
+    const manifest = buildCssPropertyManifest({
+      component: 'button',
+      styleMap: { color: 'rgb(255, 255, 255)' },
+      baseVariant: { variant: 'solid' },
+      description: 'from fixture',
+    })
+
+    expect(manifest).toMatchObject({
+      component: 'button',
+      description: 'from fixture',
+      baseVariant: { variant: 'solid' },
+    })
+  })
+})
+
+describe('parseArgs', () => {
+  it('parses positional args, --out, and repeated --variant flags', () => {
+    const result = parseArgs([
+      'specimen/index.html',
+      '.btn',
+      'button',
+      '--out',
+      'out.json',
+      '--variant',
+      'variant=solid',
+      '--variant',
+      'size=md',
+    ])
+
+    expect(result).toEqual({
+      htmlPath: 'specimen/index.html',
+      selector: '.btn',
+      component: 'button',
+      out: 'out.json',
+      baseVariant: { variant: 'solid', size: 'md' },
+    })
+  })
+})
+
+describe('extraction pipeline against a fixture specimen', () => {
+  it('produces a manifest that validates against the css-property-manifest schema', () => {
+    document.body.innerHTML = loadFixtureBody('extract-css-properties.fixture.html')
+    const element = document.querySelector('[data-testid="button"]')
+    expect(element).not.toBeNull()
+
+    const styleMap = readComputedStyleMap(element as Element, DEFAULT_VISUAL_PROPERTIES, (el) =>
+      getComputedStyle(el as Element)
+    )
+    const manifest = buildCssPropertyManifest({
+      component: 'button',
+      styleMap,
+      baseVariant: { variant: 'solid' },
+      description: 'Extracted from extract-css-properties.fixture.html',
+    })
+
+    expect(validateCssPropertyManifest(manifest)).toEqual({ valid: true, errors: [] })
+    const properties = manifest.properties.map((entry) => entry.property)
+    expect(properties).toContain('backgroundColor')
+    expect(properties).toContain('paddingLeft')
+    expect(manifest.properties.every((entry) => entry.token === null)).toBe(true)
+  })
+})


### PR DESCRIPTION
## TD-06.02 — Build CSS property extraction script

Adds `packages/ui/scripts/extract-css-properties.mjs`: given an HTML file and a CSS selector, it loads the file in headless Chromium (Playwright), reads `window.getComputedStyle` for the matched element, and emits a per-component manifest conforming to the TD-06.01 schema (`css-property-manifest.schema.json`). Measuring the *rendered* computed styles removes the hand-transcription errors of reading values off an HTML prototype by eye.

### What it extracts
- A curated set of visual CSS properties (colors, border, radius, box-shadow, opacity, typography, padding) as camelCase, letters-only names that satisfy the schema's `^[a-zA-Z]+$` property pattern.
- Each property is emitted with `token: null` — `getComputedStyle` yields literal resolved values, not the semantic token they came from; tokens are annotated in a later step (the schema explicitly permits null tokens for literal values).
- Empty computed values are dropped so every entry meets the non-empty `resolvedValue` requirement; the builder throws if nothing remains.
- CLI: `node scripts/extract-css-properties.mjs <html> <selector> <component> [--out <file>] [--variant <axis>=<value> ...]`, also wired as the additive `pnpm extract-css` script.

### How it's validated
`extract-css-properties.test.ts` drives the extraction pipeline over a fixture specimen (`extract-css-properties.fixture.html`) using jsdom `getComputedStyle`, builds a manifest, and asserts it passes the 06.01 `validateCssPropertyManifest`. Additional unit tests cover the kebab-case conversion, style-map filtering/`token: null` tagging, manifest-builder base-variant/description handling and empty-input error, and CLI arg parsing.

### Gate
lint (0 new warnings) · type-check · build · vitest run (84 files, 1369 tests) · build-storybook — all pass. Prettier-clean touched files.

Depends on TD-04.01 + TD-06.01 (both on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)