### PR TITLE
Add ExerciseDetailPage template (TD-03.29)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.stories.tsx
@@ -1,0 +1,225 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import {
+  ExerciseDetailPage,
+  type ExerciseDetailEntry,
+  type ExerciseTrend,
+  type ExerciseVbt,
+} from './ExerciseDetailPage'
+import type { MesoStatusCardProps } from './MesoStatusCard'
+import type { SetRowProps } from './SetRow'
+
+const meso: MesoStatusCardProps = {
+  mesoName: 'Hypertrophy Block',
+  mesoSubtitle: 'Week 6 of 8 · Push/Pull/Legs',
+  statusBadge: { label: 'On Track', variant: 'success' },
+  metrics: [
+    { label: 'Prescribed', value: '4×8 @ RPE 8' },
+    { label: 'Actual', value: '4×8 @ 195 lbs' },
+    { label: 'Best e1RM', value: '248 lbs' },
+    { label: 'Sessions', value: '11' },
+  ],
+  gauges: [
+    { label: 'Intensity', level: 0.72, sublabel: 'Actual' },
+    { label: 'Volume', level: 0.6, sublabel: 'Weekly' },
+  ],
+  coaching: {
+    text: 'Bar speed is holding — add 5 lbs next session before the deload.',
+    highlights: ['add 5 lbs'],
+  },
+  nextTarget: { icon: '🎯', text: '200 lbs × 8 @ RPE 8' },
+}
+
+function historySets(weight: number, topRpe: number): SetRowProps[] {
+  return [1, 2, 3, 4].map((setNumber) => ({
+    mode: 'history' as const,
+    setNumber,
+    previous: { reps: 8, weight: weight - 5 },
+    reps: 8,
+    weight,
+    rpe: topRpe - (4 - setNumber) * 0.5,
+    unit: 'lbs' as const,
+  }))
+}
+
+const progression: ExerciseDetailEntry[] = [
+  {
+    id: 'w1',
+    title: 'Week 1',
+    summary: { sets: 4, reps: 8, weight: 175, unit: 'lbs' },
+    e1rm: { value: 222, unit: 'lbs' },
+    tempo: [3, 1, 1, 0],
+    sets: historySets(175, 7.5),
+  },
+  {
+    id: 'w2',
+    title: 'Week 2',
+    summary: { sets: 4, reps: 8, weight: 180, unit: 'lbs' },
+    e1rm: { value: 228, unit: 'lbs' },
+    tempo: [3, 1, 1, 0],
+    sets: historySets(180, 8),
+  },
+  {
+    id: 'w3',
+    title: 'Week 3',
+    summary: { sets: 4, reps: 8, weight: 185, unit: 'lbs' },
+    e1rm: { value: 235, unit: 'lbs' },
+    tempo: [3, 1, 1, 0],
+    sets: historySets(185, 8.5),
+  },
+  {
+    id: 'w4',
+    title: 'Week 4 · Deload',
+    summary: { sets: 3, reps: 6, weight: 165, unit: 'lbs' },
+    e1rm: { value: 205, unit: 'lbs' },
+    sets: historySets(165, 6.5).slice(0, 3),
+  },
+  {
+    id: 'w5',
+    title: 'Week 5',
+    summary: { sets: 4, reps: 8, weight: 190, unit: 'lbs' },
+    e1rm: { value: 241, unit: 'lbs' },
+    tempo: [3, 1, 1, 0],
+    sets: historySets(190, 8.5),
+  },
+  {
+    id: 'w6',
+    title: 'Week 6',
+    summary: { sets: 4, reps: 8, weight: 195, unit: 'lbs' },
+    e1rm: { value: 248, unit: 'lbs' },
+    isPR: true,
+    tempo: [3, 1, 1, 0],
+    sets: historySets(195, 9),
+  },
+]
+
+const history: ExerciseDetailEntry[] = [
+  {
+    id: 's6',
+    title: 'Mon, Jun 16',
+    summary: { sets: 4, reps: 8, weight: 195, unit: 'lbs' },
+    e1rm: { value: 248, unit: 'lbs' },
+    isPR: true,
+    tempo: [3, 1, 1, 0],
+    sets: historySets(195, 9),
+  },
+  {
+    id: 's5',
+    title: 'Mon, Jun 9',
+    summary: { sets: 4, reps: 8, weight: 190, unit: 'lbs' },
+    e1rm: { value: 241, unit: 'lbs' },
+    sets: historySets(190, 8.5),
+  },
+  {
+    id: 's4',
+    title: 'Mon, Jun 2 · Deload',
+    summary: { sets: 3, reps: 6, weight: 165, unit: 'lbs' },
+    e1rm: { value: 205, unit: 'lbs' },
+    sets: historySets(165, 6.5).slice(0, 3),
+  },
+  {
+    id: 's3',
+    title: 'Mon, May 26',
+    summary: { sets: 4, reps: 8, weight: 185, unit: 'lbs' },
+    e1rm: { value: 235, unit: 'lbs' },
+    sets: historySets(185, 8.5),
+  },
+  {
+    id: 's2',
+    title: 'Mon, May 19',
+    summary: { sets: 4, reps: 8, weight: 180, unit: 'lbs' },
+    e1rm: { value: 228, unit: 'lbs' },
+    sets: historySets(180, 8),
+  },
+  {
+    id: 's1',
+    title: 'Mon, May 12',
+    summary: { sets: 4, reps: 8, weight: 175, unit: 'lbs' },
+    e1rm: { value: 222, unit: 'lbs' },
+    sets: historySets(175, 7.5),
+  },
+]
+
+const trend: ExerciseTrend = {
+  data: [
+    { date: '2026-05-12', e1rm: 222 },
+    { date: '2026-05-19', e1rm: 228 },
+    { date: '2026-05-26', e1rm: 235 },
+    { date: '2026-06-02', e1rm: 231 },
+    { date: '2026-06-09', e1rm: 241 },
+    { date: '2026-06-16', e1rm: 248, isPR: true },
+  ],
+  projection: [
+    { date: '2026-06-16', e1rm: 248 },
+    { date: '2026-06-23', e1rm: 253 },
+    { date: '2026-06-30', e1rm: 258 },
+  ],
+  mesoBoundaries: [{ date: '2026-06-02', label: 'Deload' }],
+}
+
+const vbt: ExerciseVbt = {
+  band: [
+    { date: '2026-05-12', bandLow: 40, bandHigh: 70 },
+    { date: '2026-05-26', bandLow: 48, bandHigh: 78 },
+    { date: '2026-06-09', bandLow: 55, bandHigh: 86 },
+    { date: '2026-06-16', bandLow: 60, bandHigh: 92 },
+  ],
+  workouts: [
+    { date: '2026-05-12', load: 52, status: 'within' },
+    { date: '2026-05-26', load: 80, status: 'above' },
+    { date: '2026-06-09', load: 68, status: 'within' },
+    { date: '2026-06-16', load: 58, status: 'below' },
+  ],
+  projection: {
+    withTraining: [
+      { date: '2026-06-16', bandLow: 60, bandHigh: 92 },
+      { date: '2026-06-23', bandLow: 64, bandHigh: 98 },
+    ],
+    withRest: [
+      { date: '2026-06-16', bandLow: 60, bandHigh: 92 },
+      { date: '2026-06-23', bandLow: 54, bandHigh: 84 },
+    ],
+  },
+  sets: [
+    { label: 'Set 1', velocities: [0.72, 0.7, 0.68, 0.66, 0.63, 0.6, 0.57, 0.54] },
+    { label: 'Set 2', velocities: [0.7, 0.67, 0.64, 0.61, 0.58, 0.54, 0.5, 0.46] },
+    { label: 'Set 3', velocities: [0.68, 0.64, 0.6, 0.56, 0.52, 0.47, 0.42, 0.38] },
+    { label: 'Set 4', velocities: [0.65, 0.6, 0.55, 0.5, 0.44, 0.39, 0.34, 0.3] },
+  ],
+}
+
+const meta: Meta<typeof ExerciseDetailPage> = {
+  title: 'Custom/Workout/ExerciseDetailPage',
+  component: ExerciseDetailPage,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  args: {
+    exercise: {
+      name: 'Barbell Bench Press',
+      subtitle: 'Chest · Barbell',
+      unit: 'lbs',
+      currentE1rm: 248,
+    },
+    meso,
+    trend,
+    progression,
+    history,
+    vbt,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ExerciseDetailPage>
+
+export const Default: Story = {}
+
+export const NoVbtData: Story = {
+  args: {
+    exercise: {
+      name: 'Goblet Squat',
+      subtitle: 'Quads · Dumbbell',
+      unit: 'lbs',
+      currentE1rm: 132,
+    },
+    vbt: { band: [], workouts: [], sets: [] },
+  },
+}

--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  ExerciseDetailPage,
+  deriveExerciseStats,
+  toExerciseCardProps,
+  summarizeVbt,
+  type ExerciseDetailEntry,
+  type ExerciseDetailPageProps,
+} from './ExerciseDetailPage'
+
+const entry = (id: string, weight: number, e1rm: number, isPR = false): ExerciseDetailEntry => ({
+  id,
+  title: `Session ${id}`,
+  summary: { sets: 3, reps: 8, weight, unit: 'lbs' },
+  e1rm: { value: e1rm, unit: 'lbs' },
+  isPR,
+  sets: [
+    { mode: 'history', setNumber: 1, reps: 8, weight, rpe: 8, unit: 'lbs' },
+    { mode: 'history', setNumber: 2, reps: 8, weight, rpe: 8.5, unit: 'lbs' },
+  ],
+})
+
+const history: ExerciseDetailEntry[] = [
+  entry('a', 195, 248, true),
+  entry('b', 185, 235),
+  entry('c', 175, 222),
+]
+
+const baseProps: ExerciseDetailPageProps = {
+  exercise: { name: 'Bench Press', subtitle: 'Chest · Barbell', unit: 'lbs', currentE1rm: 248 },
+  meso: {
+    mesoName: 'Hypertrophy',
+    mesoSubtitle: 'Week 6 of 8',
+    statusBadge: { label: 'On Track', variant: 'success' },
+    metrics: [{ label: 'Actual', value: '4×8' }],
+    gauges: [{ label: 'Intensity', level: 0.7 }],
+  },
+  trend: {
+    data: [
+      { date: '2026-05-12', e1rm: 222 },
+      { date: '2026-06-16', e1rm: 248, isPR: true },
+    ],
+  },
+  progression: [entry('w1', 175, 222), entry('w2', 195, 248, true)],
+  history,
+  vbt: {
+    band: [{ date: '2026-05-12', bandLow: 40, bandHigh: 70 }],
+    workouts: [{ date: '2026-05-12', load: 52, status: 'within' }],
+    sets: [
+      { label: 'Set 1', velocities: [0.7, 0.6, 0.5] },
+      { label: 'Set 2', velocities: [0.68, 0.5, 0.34] },
+    ],
+  },
+}
+
+describe('deriveExerciseStats', () => {
+  it('counts sessions, tracks the best e1RM, and tallies PRs', () => {
+    expect(deriveExerciseStats(history)).toEqual({ sessions: 3, bestE1rm: 248, prCount: 1 })
+  })
+
+  it('returns a null best e1RM for an empty history', () => {
+    expect(deriveExerciseStats([])).toEqual({ sessions: 0, bestE1rm: null, prCount: 0 })
+  })
+})
+
+describe('toExerciseCardProps', () => {
+  it('collapses without sets and expands with them', () => {
+    const collapsed = toExerciseCardProps(history[0], false, () => {})
+    expect(collapsed.state).toBe('collapsed')
+    expect(collapsed.sets).toBeUndefined()
+
+    const expanded = toExerciseCardProps(history[0], true, () => {})
+    expect(expanded.state).toBe('expanded')
+    expect(expanded.sets).toHaveLength(2)
+    expect(expanded.name).toBe('Session a')
+  })
+})
+
+describe('summarizeVbt', () => {
+  it('averages every rep and reports the worst within-set loss', () => {
+    const summary = summarizeVbt([
+      { label: 'Set 1', velocities: [1, 0.5] },
+      { label: 'Set 2', velocities: [1, 0.25] },
+    ])
+    expect(summary.meanVelocity).toBeCloseTo(0.6875)
+    expect(summary.velocityLoss).toBe(75)
+  })
+
+  it('is zeroed for no sets', () => {
+    expect(summarizeVbt([])).toEqual({ meanVelocity: 0, velocityLoss: 0 })
+  })
+})
+
+describe('ExerciseDetailPage', () => {
+  it('renders the header and opens on the Progress tab', () => {
+    render(<ExerciseDetailPage {...baseProps} />)
+    expect(screen.getByTestId('exercise-detail-page')).toBeInTheDocument()
+    expect(screen.getByTestId('exercise-detail-page-title')).toHaveTextContent('Bench Press')
+    expect(screen.getByTestId('exercise-detail-page-panel-progress')).toBeInTheDocument()
+    expect(screen.getByTestId('meso-status-card')).toBeInTheDocument()
+    expect(screen.getByTestId('exercise-detail-page-stat-sessions')).toHaveTextContent('3')
+  })
+
+  it('switches tabs to reveal history and advanced panels', () => {
+    render(<ExerciseDetailPage {...baseProps} />)
+
+    fireEvent.click(screen.getByTestId('exercise-detail-page-tab-history'))
+    expect(screen.getByTestId('exercise-detail-page-panel-history')).toBeInTheDocument()
+    expect(screen.queryByTestId('exercise-detail-page-panel-progress')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('exercise-detail-page-tab-advanced'))
+    expect(screen.getByTestId('exercise-detail-page-panel-advanced')).toBeInTheDocument()
+    expect(screen.getByTestId('exercise-detail-page-vbt-summary')).toBeInTheDocument()
+    expect(screen.getAllByTestId('exercise-detail-page-vbt-set')).toHaveLength(2)
+  })
+
+  it('inline-expands a progression entry to reveal its sets', () => {
+    render(<ExerciseDetailPage {...baseProps} />)
+    expect(screen.queryByTestId('exercise-card-sets')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByTestId('exercise-card')[0])
+    expect(screen.getByTestId('exercise-card-sets')).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByTestId('exercise-card-header')[0])
+    expect(screen.queryByTestId('exercise-card-sets')).not.toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
@@ -1,0 +1,631 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { useMemo, useState } from 'react'
+import { View, Text, Pressable, type ViewProps } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { MesoStatusCard, type MesoStatusCardProps } from './MesoStatusCard'
+import {
+  StrengthTrendChart,
+  type StrengthTrendDataPoint,
+  type StrengthTrendChartMesoBoundary,
+} from './StrengthTrendChart'
+import {
+  CapacityBandChart,
+  type CapacityBandDataPoint,
+  type CapacityBandProjection,
+  type WorkoutDot,
+} from './CapacityBandChart'
+import { ExerciseCard, type ExerciseCardProps } from './ExerciseCard'
+import { type SetRowProps } from './SetRow'
+import { VelocityStrip, calculateMeanVelocity, calculateVelocityLoss } from './VelocityStrip'
+
+const SURFACE_ELEVATED = WORKOUT_TOKENS.surface.elevated
+const BORDER_DEFAULT = WORKOUT_TOKENS.border.default
+const BRAND_PRIMARY = '#FF7900'
+const TEXT_PRIMARY = '#F3F4F6'
+const TEXT_SECONDARY = '#9CA3AF'
+const TEXT_TERTIARY = '#6B7280'
+const PAGE_BG = '#0E0E0E'
+
+/** Inner plot width: page width 390 − 16 page padding − 12 card padding on each side. */
+const CHART_WIDTH = 326
+const CHART_HEIGHT = 150
+
+/** Which tab of the exercise detail view is showing. */
+export type ExerciseDetailTab = 'progress' | 'history' | 'advanced'
+
+/** Tabs in display order. */
+export const EXERCISE_DETAIL_TABS: Array<{ key: ExerciseDetailTab; label: string }> = [
+  { key: 'progress', label: 'Progress' },
+  { key: 'history', label: 'History' },
+  { key: 'advanced', label: 'Advanced' },
+]
+
+/** Identity + headline stats for the exercise being inspected. */
+export interface ExerciseDetailHeader {
+  /** Exercise name, e.g. "Barbell Bench Press". */
+  name: string
+  /** Context line, e.g. "Chest · Barbell". */
+  subtitle: string
+  /** Unit used across the page. */
+  unit: 'lbs' | 'kg'
+  /** Current estimated one-rep max, shown as a header pill. */
+  currentE1rm?: number
+}
+
+/**
+ * A single expandable entry — one progression week or one logged session.
+ * Projected onto an `ExerciseCard`, so it collapses to a summary and expands
+ * to its `SetRow` breakdown.
+ */
+export interface ExerciseDetailEntry {
+  /** Stable id for inline-expansion selection. */
+  id: string
+  /** Row title, e.g. "Week 3" or "Mon, Jun 16". */
+  title: string
+  /** Collapsed summary (sets × reps @ weight). */
+  summary?: ExerciseCardProps['summary']
+  /** Estimated one-rep max badge. */
+  e1rm?: ExerciseCardProps['e1rm']
+  /** Flags a personal-record entry. */
+  isPR?: boolean
+  /** Prescribed tempo, revealed when expanded. */
+  tempo?: ExerciseCardProps['tempo']
+  /** Per-set breakdown revealed when expanded. */
+  sets: SetRowProps[]
+}
+
+/** Strength-trend inputs for the Progress tab chart. */
+export interface ExerciseTrend {
+  /** Measured e1RM data points, chronological. */
+  data: StrengthTrendDataPoint[]
+  /** Planned/projected trajectory (dashed line). */
+  projection?: StrengthTrendDataPoint[]
+  /** Mesocycle boundary guides. */
+  mesoBoundaries?: StrengthTrendChartMesoBoundary[]
+}
+
+/** One set's velocity trace for the Advanced tab breakdown. */
+export interface ExerciseVbtSet {
+  /** Row label, e.g. "Set 1". */
+  label: string
+  /** Per-rep mean concentric velocities (m/s). */
+  velocities: number[]
+}
+
+/** Velocity-based-training inputs for the Advanced tab. */
+export interface ExerciseVbt {
+  /** Capacity band shape over time. */
+  band: CapacityBandDataPoint[]
+  /** Sessions plotted against the band. */
+  workouts: WorkoutDot[]
+  /** Optional forward band projection. */
+  projection?: CapacityBandProjection
+  /** Per-set velocity traces for the most recent session. */
+  sets: ExerciseVbtSet[]
+}
+
+/** Page-level roll-up of the logged sessions. */
+export interface ExerciseDetailStats {
+  /** Number of logged sessions. */
+  sessions: number
+  /** Best estimated one-rep max seen, or null if none recorded. */
+  bestE1rm: number | null
+  /** Count of PR entries. */
+  prCount: number
+}
+
+/** Aggregate velocity readout for the Advanced tab. */
+export interface VbtSummary {
+  /** Mean concentric velocity across every logged rep. */
+  meanVelocity: number
+  /** Worst within-set velocity loss (%), i.e. the most-fatigued set. */
+  velocityLoss: number
+}
+
+export interface ExerciseDetailPageProps extends ViewProps {
+  /** Exercise identity + headline stats. */
+  exercise: ExerciseDetailHeader
+  /** Mesocycle context banner (Progress tab). */
+  meso: MesoStatusCardProps
+  /** Strength trend inputs (Progress tab). */
+  trend: ExerciseTrend
+  /** Week-by-week progression entries (Progress tab). */
+  progression: ExerciseDetailEntry[]
+  /** All logged sessions (History tab). */
+  history: ExerciseDetailEntry[]
+  /** Velocity-based-training inputs (Advanced tab). */
+  vbt: ExerciseVbt
+  className?: string
+}
+
+/** Roll up logged sessions into the page summary (pure, testable). */
+export function deriveExerciseStats(entries: ExerciseDetailEntry[]): ExerciseDetailStats {
+  let bestE1rm: number | null = null
+  let prCount = 0
+  for (const entry of entries) {
+    if (entry.e1rm != null && (bestE1rm == null || entry.e1rm.value > bestE1rm)) {
+      bestE1rm = entry.e1rm.value
+    }
+    if (entry.isPR) prCount += 1
+  }
+  return { sessions: entries.length, bestE1rm, prCount }
+}
+
+/** Project an entry onto ExerciseCard props, wiring inline expansion (pure). */
+export function toExerciseCardProps(
+  entry: ExerciseDetailEntry,
+  expanded: boolean,
+  onToggle: () => void
+): ExerciseCardProps {
+  return {
+    name: entry.title,
+    state: expanded ? 'expanded' : 'collapsed',
+    onToggle,
+    summary: entry.summary,
+    e1rm: entry.e1rm,
+    isPR: entry.isPR,
+    tempo: entry.tempo,
+    sets: expanded ? entry.sets : undefined,
+  }
+}
+
+/** Aggregate per-set velocity traces into the Advanced readout (pure). */
+export function summarizeVbt(sets: ExerciseVbtSet[]): VbtSummary {
+  const allReps = sets.flatMap((set) => set.velocities)
+  const meanVelocity = calculateMeanVelocity(allReps)
+  let velocityLoss = 0
+  for (const set of sets) {
+    velocityLoss = Math.max(velocityLoss, calculateVelocityLoss(set.velocities))
+  }
+  return { meanVelocity, velocityLoss }
+}
+
+interface TabBarProps {
+  active: ExerciseDetailTab
+  onSelect: (tab: ExerciseDetailTab) => void
+}
+
+function TabBar({ active, onSelect }: TabBarProps) {
+  return (
+    <View
+      className="flex-row"
+      style={{
+        borderBottomWidth: 1,
+        borderBottomColor: BORDER_DEFAULT,
+      }}
+      accessibilityRole={'tablist' as ViewProps['accessibilityRole']}
+      testID="exercise-detail-page-tabs"
+    >
+      {EXERCISE_DETAIL_TABS.map(({ key, label }) => {
+        const isActive = key === active
+        return (
+          <Pressable
+            key={key}
+            onPress={() => onSelect(key)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isActive }}
+            style={{
+              flex: 1,
+              alignItems: 'center',
+              paddingVertical: 10,
+              borderBottomWidth: 2,
+              borderBottomColor: isActive ? BRAND_PRIMARY : 'transparent',
+            }}
+            testID={`exercise-detail-page-tab-${key}`}
+          >
+            <Text
+              style={{
+                fontSize: 13,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: isActive ? '700' : '500',
+                color: isActive ? TEXT_PRIMARY : TEXT_TERTIARY,
+              }}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+const STAT_CARDS: Array<{ key: keyof ExerciseDetailStats; label: string }> = [
+  { key: 'sessions', label: 'Sessions' },
+  { key: 'bestE1rm', label: 'Best e1RM' },
+  { key: 'prCount', label: 'PRs' },
+]
+
+function StatStrip({ stats, unit }: { stats: ExerciseDetailStats; unit: 'lbs' | 'kg' }) {
+  return (
+    <View className="flex-row" style={{ gap: 8 }} testID="exercise-detail-page-stats">
+      {STAT_CARDS.map(({ key, label }) => {
+        const raw = stats[key]
+        const value = key === 'bestE1rm' ? (raw == null ? '—' : `${raw} ${unit}`) : `${raw}`
+        return (
+          <View
+            key={key}
+            style={{
+              flex: 1,
+              padding: 12,
+              borderRadius: 10,
+              backgroundColor: SURFACE_ELEVATED,
+              borderWidth: 1,
+              borderColor: BORDER_DEFAULT,
+            }}
+            testID={`exercise-detail-page-stat-${key}`}
+          >
+            <Text
+              style={{
+                fontSize: 18,
+                fontFamily: '"Space Grotesk", sans-serif',
+                fontWeight: '700',
+                color: TEXT_PRIMARY,
+              }}
+            >
+              {value}
+            </Text>
+            <Text
+              style={{
+                marginTop: 2,
+                fontSize: 10,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '600',
+                letterSpacing: 0.4,
+                textTransform: 'uppercase',
+                color: TEXT_TERTIARY,
+              }}
+            >
+              {label}
+            </Text>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+function SectionCard({
+  title,
+  children,
+  testID,
+}: {
+  title: string
+  children: React.ReactNode
+  testID: string
+}) {
+  return (
+    <View
+      style={{
+        backgroundColor: SURFACE_ELEVATED,
+        borderWidth: 1,
+        borderColor: BORDER_DEFAULT,
+        borderRadius: 12,
+        padding: 12,
+        gap: 10,
+      }}
+      testID={testID}
+    >
+      <Text
+        style={{
+          fontSize: 11,
+          fontFamily: 'Inter, sans-serif',
+          fontWeight: '600',
+          letterSpacing: 0.6,
+          textTransform: 'uppercase',
+          color: TEXT_TERTIARY,
+        }}
+      >
+        {title}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+interface EntryListProps {
+  entries: ExerciseDetailEntry[]
+  expandedId: string | null
+  onToggle: (id: string) => void
+  emptyLabel: string
+  testID: string
+}
+
+function EntryList({ entries, expandedId, onToggle, emptyLabel, testID }: EntryListProps) {
+  if (entries.length === 0) {
+    return (
+      <Text
+        style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_TERTIARY }}
+        testID={`${testID}-empty`}
+      >
+        {emptyLabel}
+      </Text>
+    )
+  }
+  return (
+    <View style={{ gap: 8 }} testID={testID}>
+      {entries.map((entry) => (
+        <ExerciseCard
+          key={entry.id}
+          {...toExerciseCardProps(entry, entry.id === expandedId, () => onToggle(entry.id))}
+        />
+      ))}
+    </View>
+  )
+}
+
+function VbtBreakdown({ sets }: { sets: ExerciseVbtSet[] }) {
+  return (
+    <View style={{ gap: 10 }} testID="exercise-detail-page-vbt-breakdown">
+      {sets.map((set) => {
+        const mean = calculateMeanVelocity(set.velocities)
+        const loss = calculateVelocityLoss(set.velocities)
+        return (
+          <View
+            key={set.label}
+            className="flex-row items-center"
+            style={{ gap: 10 }}
+            testID="exercise-detail-page-vbt-set"
+          >
+            <Text
+              style={{
+                width: 44,
+                fontSize: 11,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '600',
+                color: TEXT_SECONDARY,
+              }}
+            >
+              {set.label}
+            </Text>
+            <View className="flex-1" style={{ height: 8, justifyContent: 'center' }}>
+              <VelocityStrip velocities={set.velocities} variant="mini" />
+            </View>
+            <Text
+              style={{
+                fontSize: 11,
+                fontFamily: 'Inter, sans-serif',
+                fontVariant: ['tabular-nums'],
+                color: TEXT_TERTIARY,
+              }}
+            >
+              {`${mean.toFixed(2)} · -${loss}%`}
+            </Text>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+function VbtSummaryRow({ summary }: { summary: VbtSummary }) {
+  const cells = [
+    { label: 'Mean Velocity', value: `${summary.meanVelocity.toFixed(2)} m/s` },
+    { label: 'Peak Vel. Loss', value: `-${summary.velocityLoss}%` },
+  ]
+  return (
+    <View className="flex-row" style={{ gap: 8 }} testID="exercise-detail-page-vbt-summary">
+      {cells.map((cell) => (
+        <View
+          key={cell.label}
+          style={{
+            flex: 1,
+            padding: 12,
+            borderRadius: 10,
+            backgroundColor: SURFACE_ELEVATED,
+            borderWidth: 1,
+            borderColor: BORDER_DEFAULT,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 16,
+              fontFamily: '"Space Grotesk", sans-serif',
+              fontWeight: '700',
+              color: TEXT_PRIMARY,
+            }}
+          >
+            {cell.value}
+          </Text>
+          <Text
+            style={{
+              marginTop: 2,
+              fontSize: 10,
+              fontFamily: 'Inter, sans-serif',
+              fontWeight: '600',
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+              color: TEXT_TERTIARY,
+            }}
+          >
+            {cell.label}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/**
+ * ExerciseDetailPage — a tabbed per-exercise view. A shared header (name,
+ * context line, current e1RM pill) sits above a Progress / History / Advanced
+ * tab bar. Progress composes the `MesoStatusCard` context banner, a stats
+ * strip, a `StrengthTrendChart`, and a week-by-week progression list with
+ * inline `ExerciseCard` expansion. History lists every logged session with the
+ * same inline expansion. Advanced surfaces VBT data via a `CapacityBandChart`,
+ * a velocity summary, and a per-set `VelocityStrip` breakdown. Tab and
+ * per-list expansion are page-level state; children keep their own styles.
+ *
+ * @example
+ * <ExerciseDetailPage
+ *   exercise={exercise}
+ *   meso={meso}
+ *   trend={trend}
+ *   progression={progression}
+ *   history={history}
+ *   vbt={vbt}
+ * />
+ */
+export function ExerciseDetailPage({
+  exercise,
+  meso,
+  trend,
+  progression,
+  history,
+  vbt,
+  className,
+  ...props
+}: ExerciseDetailPageProps) {
+  const [tab, setTab] = useState<ExerciseDetailTab>('progress')
+  const [expandedProgressId, setExpandedProgressId] = useState<string | null>(null)
+  const [expandedHistoryId, setExpandedHistoryId] = useState<string | null>(null)
+
+  const stats = useMemo(() => deriveExerciseStats(history), [history])
+  const vbtSummary = useMemo(() => summarizeVbt(vbt.sets), [vbt.sets])
+
+  const toggle =
+    (setId: (updater: (current: string | null) => string | null) => void) => (id: string) =>
+      setId((current) => (current === id ? null : id))
+
+  return (
+    <View
+      className={className}
+      style={{ width: 390, backgroundColor: PAGE_BG }}
+      accessibilityRole={'main' as ViewProps['accessibilityRole']}
+      aria-label={exercise.name}
+      testID="exercise-detail-page"
+      {...props}
+    >
+      <View style={{ padding: 16, gap: 14 }} testID="exercise-detail-page-content">
+        <View
+          className="flex-row items-start justify-between"
+          style={{ gap: 8 }}
+          testID="exercise-detail-page-header"
+        >
+          <View style={{ flexShrink: 1 }}>
+            <Text
+              accessibilityRole="header"
+              style={{
+                fontSize: 20,
+                fontFamily: '"Space Grotesk", sans-serif',
+                fontWeight: '700',
+                color: TEXT_PRIMARY,
+              }}
+              testID="exercise-detail-page-title"
+            >
+              {exercise.name}
+            </Text>
+            <Text
+              style={{
+                marginTop: 2,
+                fontSize: 12,
+                fontFamily: 'Inter, sans-serif',
+                color: TEXT_SECONDARY,
+              }}
+              testID="exercise-detail-page-subtitle"
+            >
+              {exercise.subtitle}
+            </Text>
+          </View>
+          {exercise.currentE1rm != null && (
+            <View
+              style={{
+                paddingVertical: 4,
+                paddingHorizontal: 10,
+                borderRadius: 6,
+                backgroundColor: 'rgba(255,121,0,0.10)',
+                borderWidth: 1,
+                borderColor: 'rgba(255,121,0,0.25)',
+              }}
+              testID="exercise-detail-page-e1rm"
+            >
+              <Text
+                style={{
+                  fontSize: 9,
+                  fontFamily: 'Inter, sans-serif',
+                  fontWeight: '600',
+                  letterSpacing: 0.4,
+                  textTransform: 'uppercase',
+                  color: TEXT_TERTIARY,
+                }}
+              >
+                e1RM
+              </Text>
+              <Text
+                style={{
+                  fontSize: 15,
+                  fontFamily: '"Space Grotesk", sans-serif',
+                  fontWeight: '700',
+                  color: BRAND_PRIMARY,
+                }}
+              >
+                {`${exercise.currentE1rm} ${exercise.unit}`}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        <TabBar active={tab} onSelect={setTab} />
+
+        {tab === 'progress' && (
+          <View style={{ gap: 14 }} testID="exercise-detail-page-panel-progress">
+            <MesoStatusCard {...meso} />
+            <StatStrip stats={stats} unit={exercise.unit} />
+            <SectionCard title="Strength Trend" testID="exercise-detail-page-trend">
+              <StrengthTrendChart
+                data={trend.data}
+                projection={trend.projection}
+                mesoBoundaries={trend.mesoBoundaries}
+                width={CHART_WIDTH}
+                height={CHART_HEIGHT}
+                unit={exercise.unit}
+                animateOnMount={false}
+              />
+            </SectionCard>
+            <SectionCard title="Week-by-Week" testID="exercise-detail-page-progression">
+              <EntryList
+                entries={progression}
+                expandedId={expandedProgressId}
+                onToggle={toggle(setExpandedProgressId)}
+                emptyLabel="No progression logged yet"
+                testID="exercise-detail-page-progression-list"
+              />
+            </SectionCard>
+          </View>
+        )}
+
+        {tab === 'history' && (
+          <View style={{ gap: 14 }} testID="exercise-detail-page-panel-history">
+            <SectionCard title="All Sessions" testID="exercise-detail-page-history">
+              <EntryList
+                entries={history}
+                expandedId={expandedHistoryId}
+                onToggle={toggle(setExpandedHistoryId)}
+                emptyLabel="No sessions logged yet"
+                testID="exercise-detail-page-history-list"
+              />
+            </SectionCard>
+          </View>
+        )}
+
+        {tab === 'advanced' && (
+          <View style={{ gap: 14 }} testID="exercise-detail-page-panel-advanced">
+            <SectionCard title="Capacity Band" testID="exercise-detail-page-capacity">
+              <CapacityBandChart
+                band={vbt.band}
+                workouts={vbt.workouts}
+                projection={vbt.projection}
+                width={CHART_WIDTH}
+                height={CHART_HEIGHT}
+              />
+            </SectionCard>
+            <VbtSummaryRow summary={vbtSummary} />
+            <SectionCard title="Velocity Breakdown" testID="exercise-detail-page-velocity">
+              <VbtBreakdown sets={vbt.sets} />
+            </SectionCard>
+          </View>
+        )}
+      </View>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -111,6 +111,22 @@ export {
   type ProgramBreadcrumb,
 } from './ProgramPlanningPage'
 export {
+  ExerciseDetailPage,
+  deriveExerciseStats,
+  toExerciseCardProps,
+  summarizeVbt,
+  EXERCISE_DETAIL_TABS,
+  type ExerciseDetailPageProps,
+  type ExerciseDetailTab,
+  type ExerciseDetailHeader,
+  type ExerciseDetailEntry,
+  type ExerciseTrend,
+  type ExerciseVbtSet,
+  type ExerciseVbt,
+  type ExerciseDetailStats,
+  type VbtSummary,
+} from './ExerciseDetailPage'
+export {
   MuscleGroup,
   SimpleMuscleGroup,
   SIMPLE_TO_DETAILED,


### PR DESCRIPTION
## TD-03.29 — ExerciseDetailPage template

A tabbed per-exercise view composing already-styled Workout components, following the exact page-model pattern of `TrainingStatusPage` and `ProgramPlanningPage` (pure derive helpers + page-level tab/selection state + story + vitest test). No child redesign.

### Composition
- **Progress**: `MesoStatusCard` context banner, a derived stats strip (sessions / best e1RM / PRs), `StrengthTrendChart` (actual + dashed projection + meso boundary), and a week-by-week progression list with inline `ExerciseCard` expansion.
- **History**: all logged sessions, same inline `ExerciseCard` expansion (collapses to a summary, expands to `SetRow` breakdown).
- **Advanced (VBT)**: `CapacityBandChart`, a velocity summary (mean velocity / peak within-set loss), and a per-set `VelocityStrip` breakdown.

### Tabs & state
Progress / History / Advanced switch via page-level `useState`; each list tracks its own inline-expanded entry. Pure helpers `deriveExerciseStats`, `toExerciseCardProps`, and `summarizeVbt` are unit-tested. The Workout `index.ts` export is add-only.

### Screenshot verification
Storybook **dev** server, `await document.fonts.ready`, animations disabled. Captured all three tabs in **both** themes:
- Progress, History, Advanced all render coherently — tab underline moves, panels swap, no overlap or blank regions.
- The page owns a fixed dark surface (`#0E0E0E`, matching the two sibling page templates), so **light and dark render identically**. Because the page provides its own dark surface, the known pre-existing TD-03.38 child-Card white-on-white issue does **not** surface here; dark is the design-system default and the verification target.

### Gate
`lint` (zero warnings in touched files), `type-check`, `build`, `test` (1371 passed, incl. 8 new), `build-storybook` — all pass. Touched files prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
