### PR TITLE
Add design-freeze workflow script (TD-06.04)

### DIFF
--- a/docs/design-freeze-workflow.md
+++ b/docs/design-freeze-workflow.md
@@ -1,0 +1,122 @@
+# Design Freeze Workflow
+
+Implements TD-06.04: the process (and script) that freezes an approved HTML
+prototype as ground truth before any React implementation work starts on it.
+This is Stage 3 ("Design Freeze") of the HTML-to-React extraction pipeline
+described in the sibling `voltras` repo's `docs/improved-workflow.md`.
+
+## Why this stage exists
+
+Without a freeze point, a prototype can keep evolving (a new animation here, a
+tweaked padding there) while agents are simultaneously building React
+components against a spec that's already stale. The pipeline's own
+retrospective (`voltras` repo, `docs/improved-workflow.md`, Stage 3) traces
+most of a prior session's HTML/React drift to exactly this: no clear moment
+where "the prototype is done, build against it" was declared and recorded.
+
+**Rule:** a component does not get handed to an implementation agent (via
+TD-06.03's prompt template) until it has been through design freeze. If the
+prototype changes after that point, the change goes through a re-freeze (see
+below), never a hand-edit of the React component to "match the new design."
+
+## What "freeze" means, concretely
+
+Three steps, in order, run by `packages/ui/scripts/design-freeze.mjs`:
+
+1. **Tag the HTML file in git.** The script runs `git status --porcelain --
+   <html file>` and refuses to proceed if it reports any change — staged,
+   unstaged, or untracked. This guarantees the freeze point is an exact,
+   already-committed version of the prototype, not a moving target. It then
+   creates an annotated tag at `HEAD`: `design-freeze/<component>-<version>`
+   (version defaults to today's date, override with `--tag-version`).
+
+2. **Extract a CSS property manifest.** Delegates to
+   `extract-css-properties.mjs` (TD-06.02) to read `getComputedStyle` off the
+   frozen prototype element and write a manifest conforming to
+   `css-property-manifest.schema.json` (TD-06.01) to
+   `packages/ui/src/theme/manifest/<component>.manifest.json`.
+
+3. **Generate a specimen-page skeleton.** Reads the matched element's
+   `outerHTML` from the same rendered page and emits a `<ComparisonPair>`
+   snippet — the convention used in `packages/ui/specimen/comparison.tsx` — with
+   the frozen markup inlined as the HTML ground truth and a `TODO` placeholder
+   where the (not-yet-built) React component goes. The script only *emits*
+   this snippet (to stdout or `--out-skeleton <file>`); it does not edit
+   `comparison.tsx` itself, so pasting it in stays a deliberate, reviewable
+   step rather than unattended codegen against a large shared file.
+
+## Usage
+
+```bash
+cd packages/ui
+node scripts/design-freeze.mjs <html> <selector> <component> \
+  [--out-manifest <file>] [--out-skeleton <file>] [--tag-version <v>] \
+  [--skip-git-tag] [--variant <axis>=<value> ...]
+
+# e.g. freezing E1rmBadge from the frozen prototype in the voltras repo:
+node scripts/design-freeze.mjs \
+  ../../../voltras/docs/prototypes/component-demo.html \
+  '.e1rm-badge' \
+  e1rm-badge \
+  --variant size=md \
+  --out-skeleton /tmp/e1rm-badge.skeleton.tsx
+```
+
+Also available as `pnpm design-freeze -- <html> <selector> <component> ...`
+from `packages/ui`.
+
+`--skip-git-tag` runs extraction and skeleton generation without touching git
+— useful for iterating on a manifest before the prototype is actually ready to
+freeze, or for prototypes that live outside this repo's git history.
+
+## Where this fits in the 06.01 → 06.05 pipeline
+
+```
+TD-06.01  CSS property manifest schema        (packages/ui/src/theme/manifest/*.schema.json)
+TD-06.02  extract-css-properties.mjs           (schema-conforming extraction from a rendered page)
+TD-06.04  design-freeze.mjs   ◄── this ticket  (git tag + 06.02 + specimen skeleton, in one gated step)
+TD-06.03  component-implementation.md prompt   (consumes the manifest + specimen entry this produces)
+TD-06.05  implementation checklist             (marks a component done once built against the freeze)
+```
+
+TD-06.02 turns "an HTML file + selector" into a manifest; TD-06.04 wraps that
+in the freeze *gate* — it won't run (or won't tag) against an uncommitted
+prototype, and it also produces the specimen skeleton half of TD-06.03's
+"HTML ground truth" dispatch input. Concretely, after a component's design
+freeze:
+
+- Its manifest (`packages/ui/src/theme/manifest/<component>.manifest.json`) is
+  the `CSS_PROPERTY_MANIFEST_JSON` you paste into TD-06.03's prompt.
+- Its specimen skeleton, once pasted into `comparison.tsx` and filled in, is
+  the `htmlContent` ground truth the same prompt references.
+- Only then is the component `+READY` for an implementation agent.
+
+If a project wires up an automated dispatch gate (PM task states, a `brain
+pm` workflow step, etc.), the check is: *does a `design-freeze/<component>-*`
+tag exist at or after the manifest's current content* — i.e., don't dispatch
+TD-06.03 against a component that hasn't been through this script. This repo
+does not itself run such a gate; it's a process rule for whoever is
+dispatching implementation work.
+
+## Post-freeze changes
+
+If the prototype needs to change after a freeze:
+
+1. Update the HTML prototype and commit it.
+2. Re-run `design-freeze.mjs` — this regenerates the manifest and specimen
+   skeleton and creates a new tag (bump `--tag-version` or accept the new
+   date-based default; tag names are per-component-per-version, so re-freezing
+   never collides with or deletes the prior freeze).
+3. Existing Layer 2/3 tests (computed-style and HTML-vs-React parity, see
+   TD-06.05's checklist) will fail against the new manifest — that failure is
+   the signal for what to update in the React component. Never hand-edit the
+   component to match a new design without going through the manifest first.
+
+## Testing
+
+`packages/ui/src/theme/manifest/design-freeze.test.ts` covers the pure
+functions (tag naming/messages, porcelain-output parsing, skeleton
+generation, arg parsing) the same way `extract-css-properties.test.ts` covers
+TD-06.02 — no real git or Chromium process runs in the test suite. The script
+was additionally smoke-tested by hand against a scratch git repo to confirm
+`git tag` creation and the uncommitted-file rejection both behave correctly.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,6 +51,7 @@
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "extract-css": "node scripts/extract-css-properties.mjs",
+    "design-freeze": "node scripts/design-freeze.mjs",
     "specimen": "vite --config specimen/vite.config.ts",
     "specimen:compare": "vite --config specimen/vite.config.ts --open /comparison.html",
     "test:visual:compare": "playwright test --config playwright.comparison.config.ts",

--- a/packages/ui/scripts/design-freeze.mjs
+++ b/packages/ui/scripts/design-freeze.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Run the design-freeze workflow (TD-06.04) against an approved HTML prototype.
+ *
+ * Implements Stage 3 ("Design Freeze") of the HTML-to-React extraction pipeline
+ * described in the sibling voltras repo's docs/improved-workflow.md: once a
+ * prototype is approved, freeze it as ground truth before any React
+ * implementation work starts, so agents never build against a moving target.
+ *
+ * Three steps, run in order:
+ *
+ *   1. Tag the HTML file in git — refuse to freeze a prototype with
+ *      uncommitted changes, then create an annotated tag at HEAD recording the
+ *      freeze point (`design-freeze/<component>-<version>`).
+ *   2. Extract a CSS property manifest — delegates to
+ *      extract-css-properties.mjs (TD-06.02) and writes a schema-conforming
+ *      (TD-06.01) manifest to packages/ui/src/theme/manifest/<component>.manifest.json.
+ *   3. Generate a specimen-page skeleton — emits a ComparisonPair snippet
+ *      (matching packages/ui/specimen/comparison.tsx's convention) with the
+ *      frozen HTML inlined and a TODO placeholder for the React side, ready to
+ *      paste into the specimen page.
+ *
+ * This script never dispatches implementation work itself — see
+ * docs/agent-prompts/component-implementation.md (TD-06.03) for the prompt
+ * template that consumes the manifest this script produces. A component
+ * should not be handed to that template until it has been frozen here.
+ *
+ * Usage:
+ *   node scripts/design-freeze.mjs <html> <selector> <component> \
+ *     [--out-manifest <file>] [--out-skeleton <file>] [--tag-version <v>] \
+ *     [--skip-git-tag] [--variant <axis>=<value> ...]
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import {
+  extractCssPropertyManifest,
+  parseArgs as parseExtractArgs,
+} from './extract-css-properties.mjs'
+
+/** Default location manifests are frozen to, matching TD-06.01's schema directory. */
+export const DEFAULT_MANIFEST_DIR = 'src/theme/manifest'
+
+/** Build the annotated git tag name a freeze is recorded under. */
+export function buildFreezeTagName(component, version) {
+  if (!component) throw new Error('buildFreezeTagName requires a component name')
+  return `design-freeze/${component}-${version}`
+}
+
+/** Build the message body for the annotated freeze tag. */
+export function buildFreezeTagMessage({ component, htmlPath, selector }) {
+  return (
+    `Design freeze: ${component}\n\n` +
+    `Prototype: ${htmlPath}\n` +
+    `Selector: ${selector}\n` +
+    'No further visual changes to this prototype after this point. ' +
+    'Design changes require a re-freeze (new tag) per docs/design-freeze-workflow.md.'
+  )
+}
+
+/**
+ * Parse `git status --porcelain -- <file>` output and throw if it reports the
+ * file as dirty (staged or unstaged changes, or untracked). A clean result
+ * means the working tree's copy of the file matches HEAD, so HEAD is a valid
+ * freeze point for it.
+ */
+export function assertFileCommitted(porcelainOutput, filePath) {
+  const trimmed = porcelainOutput.trim()
+  if (trimmed.length > 0) {
+    throw new Error(
+      `Cannot freeze ${filePath}: it has uncommitted changes. Commit the prototype first ` +
+        `so the freeze tag points at the exact approved version.\n${trimmed}`
+    )
+  }
+}
+
+/** Run `git status --porcelain -- <file>` and validate it reports no changes. */
+export function verifyHtmlCommitted(htmlPath, { cwd } = {}) {
+  const output = execFileSync('git', ['status', '--porcelain', '--', htmlPath], {
+    cwd,
+    encoding: 'utf8',
+  })
+  assertFileCommitted(output, htmlPath)
+}
+
+/** Create the annotated freeze tag at HEAD. Returns the tag name. */
+export function createFreezeTag({ component, version, htmlPath, selector }, { cwd } = {}) {
+  const tagName = buildFreezeTagName(component, version)
+  const message = buildFreezeTagMessage({ component, htmlPath, selector })
+  execFileSync('git', ['tag', '-a', tagName, '-m', message], { cwd })
+  return tagName
+}
+
+/** Slugify a variant-axes object into a specimen testId/label suffix, e.g. { size: 'md' } -> 'size-md'. */
+export function slugifyVariant(baseVariant) {
+  if (!baseVariant || Object.keys(baseVariant).length === 0) return ''
+  return Object.entries(baseVariant)
+    .map(([axis, value]) => `${axis}-${value}`)
+    .join('-')
+}
+
+/**
+ * Build a specimen-page skeleton snippet for a frozen component, matching the
+ * <ComparisonPair> convention in packages/ui/specimen/comparison.tsx: the
+ * frozen HTML inlined verbatim as ground truth, a TODO placeholder for the
+ * not-yet-implemented React side.
+ */
+export function generateSpecimenSkeleton({ component, htmlSnippet, baseVariant }) {
+  if (!component) throw new Error('generateSpecimenSkeleton requires a component name')
+  if (!htmlSnippet) throw new Error('generateSpecimenSkeleton requires an htmlSnippet')
+
+  const slug = slugifyVariant(baseVariant)
+  const testId = `compare-${component}${slug ? `-${slug}` : ''}`
+  const label = `${component}${slug ? ` ${slug.replace(/-/g, ' ')}` : ''}`
+  const escapedHtml = htmlSnippet.replace(/`/g, '\\`')
+
+  return (
+    `{/* TODO(design-freeze): ${component} — replace the placeholder React child\n` +
+    `   once its component is implemented per docs/agent-prompts/component-implementation.md. */}\n` +
+    `<ComparisonPair\n` +
+    `  testId="${testId}"\n` +
+    `  label="${label}"\n` +
+    `  htmlContent={\`${escapedHtml}\`}\n` +
+    `>\n` +
+    `  {/* TODO: render <${component} /> here */}\n` +
+    `</ComparisonPair>\n`
+  )
+}
+
+/**
+ * Read the matched element's outerHTML from the rendered prototype, so the
+ * specimen skeleton can inline the exact frozen markup as ground truth rather
+ * than a placeholder comment. Mirrors extractStyleMapFromHtml's page-loading
+ * approach (TD-06.02) but reads markup instead of computed style.
+ */
+export async function extractOuterHtmlFromHtml(htmlPath, selector) {
+  const { chromium } = await import('@playwright/test')
+  const browser = await chromium.launch()
+  try {
+    const page = await browser.newPage()
+    await page.goto(pathToFileURL(path.resolve(htmlPath)).href, { waitUntil: 'networkidle' })
+    await page.waitForSelector(selector)
+    return await page.evaluate((sel) => {
+      const element = document.querySelector(sel)
+      if (!element) throw new Error(`No element matched selector: ${sel}`)
+      return element.outerHTML
+    }, selector)
+  } finally {
+    await browser.close()
+  }
+}
+
+/**
+ * Run the full design-freeze workflow. Returns the manifest, tag name (or
+ * null), and specimen skeleton snippet built from the frozen markup.
+ */
+export async function runDesignFreeze({
+  htmlPath,
+  selector,
+  component,
+  version,
+  baseVariant,
+  skipGitTag = false,
+  cwd,
+}) {
+  let tagName = null
+  if (!skipGitTag) {
+    verifyHtmlCommitted(htmlPath, { cwd })
+    tagName = createFreezeTag({ component, version, htmlPath, selector }, { cwd })
+  }
+
+  const manifest = await extractCssPropertyManifest({ htmlPath, selector, component, baseVariant })
+  const htmlSnippet = await extractOuterHtmlFromHtml(htmlPath, selector)
+
+  const skeleton = generateSpecimenSkeleton({ component, htmlSnippet, baseVariant })
+
+  return { manifest, tagName, skeleton }
+}
+
+/** Parse CLI argv for design-freeze, layering its own flags on parseExtractArgs. */
+export function parseArgs(argv) {
+  const outManifestIndex = argv.indexOf('--out-manifest')
+  const outSkeletonIndex = argv.indexOf('--out-skeleton')
+  const tagVersionIndex = argv.indexOf('--tag-version')
+  const skipGitTag = argv.includes('--skip-git-tag')
+
+  const consumedIndices = new Set(
+    [outManifestIndex, outSkeletonIndex, tagVersionIndex]
+      .filter((index) => index >= 0)
+      .flatMap((index) => [index, index + 1])
+  )
+  const stripped = argv.filter((arg, i) => !consumedIndices.has(i) && arg !== '--skip-git-tag')
+
+  const { htmlPath, selector, component, baseVariant } = parseExtractArgs(stripped)
+
+  return {
+    htmlPath,
+    selector,
+    component,
+    baseVariant,
+    outManifest: outManifestIndex >= 0 ? argv[outManifestIndex + 1] : undefined,
+    outSkeleton: outSkeletonIndex >= 0 ? argv[outSkeletonIndex + 1] : undefined,
+    version:
+      tagVersionIndex >= 0 ? argv[tagVersionIndex + 1] : new Date().toISOString().slice(0, 10),
+    skipGitTag,
+  }
+}
+
+async function main() {
+  const {
+    htmlPath,
+    selector,
+    component,
+    baseVariant,
+    outManifest,
+    outSkeleton,
+    version,
+    skipGitTag,
+  } = parseArgs(process.argv.slice(2))
+
+  if (!htmlPath || !selector || !component) {
+    console.error(
+      'Usage: node scripts/design-freeze.mjs <html> <selector> <component> ' +
+        '[--out-manifest <file>] [--out-skeleton <file>] [--tag-version <v>] ' +
+        '[--skip-git-tag] [--variant <axis>=<value> ...]'
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const manifestPath = outManifest ?? path.join(DEFAULT_MANIFEST_DIR, `${component}.manifest.json`)
+
+  const { manifest, tagName, skeleton } = await runDesignFreeze({
+    htmlPath,
+    selector,
+    component,
+    version,
+    baseVariant,
+    skipGitTag,
+  })
+
+  await mkdir(path.dirname(path.resolve(manifestPath)), { recursive: true })
+  await writeFile(path.resolve(manifestPath), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  console.log(`Wrote ${manifestPath} (${manifest.properties.length} properties)`)
+
+  if (tagName) {
+    console.log(`Tagged HEAD as ${tagName}`)
+  } else {
+    console.log('Skipped git tag (--skip-git-tag)')
+  }
+
+  if (outSkeleton) {
+    await mkdir(path.dirname(path.resolve(outSkeleton)), { recursive: true })
+    await writeFile(path.resolve(outSkeleton), skeleton, 'utf8')
+    console.log(
+      `Wrote specimen skeleton to ${outSkeleton} — paste into packages/ui/specimen/comparison.tsx`
+    )
+  } else {
+    console.log('\n--- specimen skeleton (paste into packages/ui/specimen/comparison.tsx) ---\n')
+    console.log(skeleton)
+  }
+}
+
+const invokedDirectly = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error.message ?? error)
+    process.exitCode = 1
+  })
+}

--- a/packages/ui/src/theme/manifest/design-freeze.test.ts
+++ b/packages/ui/src/theme/manifest/design-freeze.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildFreezeTagName,
+  buildFreezeTagMessage,
+  assertFileCommitted,
+  slugifyVariant,
+  generateSpecimenSkeleton,
+  parseArgs,
+} from '../../../scripts/design-freeze.mjs'
+
+describe('buildFreezeTagName', () => {
+  it('namespaces the tag under design-freeze/ with the component and version', () => {
+    expect(buildFreezeTagName('e1rm-badge', '2026-06-30')).toBe(
+      'design-freeze/e1rm-badge-2026-06-30'
+    )
+  })
+
+  it('throws when component is missing', () => {
+    expect(() => buildFreezeTagName('', '1')).toThrow(/requires a component name/)
+  })
+})
+
+describe('buildFreezeTagMessage', () => {
+  it('records the prototype path and selector the freeze covers', () => {
+    const message = buildFreezeTagMessage({
+      component: 'status-dot',
+      htmlPath: 'docs/prototypes/component-demo.html',
+      selector: '.status-dot',
+    })
+
+    expect(message).toContain('Design freeze: status-dot')
+    expect(message).toContain('docs/prototypes/component-demo.html')
+    expect(message).toContain('.status-dot')
+    expect(message).toContain('re-freeze')
+  })
+})
+
+describe('assertFileCommitted', () => {
+  it('does not throw for a clean porcelain result', () => {
+    expect(() => assertFileCommitted('', 'docs/prototypes/component-demo.html')).not.toThrow()
+    expect(() => assertFileCommitted('   \n', 'docs/prototypes/component-demo.html')).not.toThrow()
+  })
+
+  it('throws with the porcelain output when the file has uncommitted changes', () => {
+    expect(() =>
+      assertFileCommitted(
+        ' M docs/prototypes/component-demo.html\n',
+        'docs/prototypes/component-demo.html'
+      )
+    ).toThrow(/uncommitted changes/)
+  })
+
+  it('throws for an untracked file', () => {
+    expect(() => assertFileCommitted('?? new-prototype.html\n', 'new-prototype.html')).toThrow(
+      /uncommitted changes/
+    )
+  })
+})
+
+describe('slugifyVariant', () => {
+  it('returns an empty string when there are no variant axes', () => {
+    expect(slugifyVariant(undefined)).toBe('')
+    expect(slugifyVariant({})).toBe('')
+  })
+
+  it('joins axis/value pairs with hyphens', () => {
+    expect(slugifyVariant({ size: 'md' })).toBe('size-md')
+    expect(slugifyVariant({ variant: 'solid', size: 'md' })).toBe('variant-solid-size-md')
+  })
+})
+
+describe('generateSpecimenSkeleton', () => {
+  it('embeds the frozen markup and a TODO placeholder for the React side', () => {
+    const skeleton = generateSpecimenSkeleton({
+      component: 'e1rm-badge',
+      htmlSnippet: '<div class="e1rm-badge md">217 lbs</div>',
+    })
+
+    expect(skeleton).toContain('testId="compare-e1rm-badge"')
+    expect(skeleton).toContain('label="e1rm-badge"')
+    expect(skeleton).toContain('<div class="e1rm-badge md">217 lbs</div>')
+    expect(skeleton).toContain('<ComparisonPair')
+    expect(skeleton).toContain('render <e1rm-badge /> here')
+  })
+
+  it('suffixes testId and label with the slugified baseVariant', () => {
+    const skeleton = generateSpecimenSkeleton({
+      component: 'status-dot',
+      htmlSnippet: '<div class="status-dot sm success"></div>',
+      baseVariant: { size: 'sm', variant: 'success' },
+    })
+
+    expect(skeleton).toContain('testId="compare-status-dot-size-sm-variant-success"')
+    expect(skeleton).toContain('label="status-dot size sm variant success"')
+  })
+
+  it('escapes backticks in the markup so the template literal stays valid', () => {
+    const skeleton = generateSpecimenSkeleton({
+      component: 'quote',
+      htmlSnippet: '<div>`backtick`</div>',
+    })
+
+    expect(skeleton).toContain('\\`backtick\\`')
+  })
+
+  it('throws when required fields are missing', () => {
+    expect(() => generateSpecimenSkeleton({ component: '', htmlSnippet: '<div></div>' })).toThrow(
+      /requires a component name/
+    )
+    expect(() => generateSpecimenSkeleton({ component: 'x', htmlSnippet: '' })).toThrow(
+      /requires an htmlSnippet/
+    )
+  })
+})
+
+describe('parseArgs', () => {
+  it('parses positional args and design-freeze-specific flags', () => {
+    const result = parseArgs([
+      'docs/prototypes/component-demo.html',
+      '.e1rm-badge',
+      'e1rm-badge',
+      '--out-manifest',
+      'src/theme/manifest/e1rm-badge.manifest.json',
+      '--out-skeleton',
+      'e1rm-badge.skeleton.tsx',
+      '--tag-version',
+      '2026-06-30',
+      '--variant',
+      'size=md',
+    ])
+
+    expect(result).toMatchObject({
+      htmlPath: 'docs/prototypes/component-demo.html',
+      selector: '.e1rm-badge',
+      component: 'e1rm-badge',
+      outManifest: 'src/theme/manifest/e1rm-badge.manifest.json',
+      outSkeleton: 'e1rm-badge.skeleton.tsx',
+      version: '2026-06-30',
+      baseVariant: { size: 'md' },
+      skipGitTag: false,
+    })
+  })
+
+  it('defaults tag version to an ISO date and recognizes --skip-git-tag', () => {
+    const result = parseArgs([
+      'docs/prototypes/component-demo.html',
+      '.badge',
+      'badge',
+      '--skip-git-tag',
+    ])
+
+    expect(result.skipGitTag).toBe(true)
+    expect(result.version).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})


### PR DESCRIPTION
## Summary

- Implements Stage 3 ("Design Freeze") of the HTML-to-React extraction pipeline: `packages/ui/scripts/design-freeze.mjs` verifies an HTML prototype is committed, tags HEAD (`design-freeze/<component>-<version>`), extracts a TD-06.01-schema-conforming manifest via TD-06.02's `extract-css-properties.mjs`, and emits a `<ComparisonPair>` specimen skeleton (matching `packages/ui/specimen/comparison.tsx`'s convention) with the frozen markup inlined.
- The skeleton is only printed/written to a file, never auto-inserted into `comparison.tsx` — pasting it in stays a deliberate step rather than unattended codegen against a large shared file.
- `docs/design-freeze-workflow.md` documents the process and how it fits between TD-06.02 (extraction) and TD-06.03 (agent prompt template): a component's manifest + specimen entry from this step are exactly what TD-06.03's prompt consumes, and a component shouldn't be dispatched to an implementation agent until it's been through this freeze. Also documents the post-freeze re-freeze cycle from the pipeline's `docs/improved-workflow.md` methodology (sibling `voltras` repo).
- `packages/ui/src/theme/manifest/design-freeze.test.ts` covers the pure functions (tag naming/messages, porcelain-output parsing, skeleton generation, arg parsing), following the same no-real-git/no-real-Chromium pattern as TD-06.02's own test file. The script was additionally smoke-tested by hand against a scratch git repo (real `git tag` creation, real uncommitted-file rejection) and against the repo's own extraction fixture.

TD-06.02 (the extraction script this depends on) is merged (#51); TD-06.04 was genuinely unblocked.

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `pnpm type-check` — pass
- [x] `pnpm build` — pass
- [x] `pnpm test` — 1405/1405 tests pass across 87 files, including 14 new tests in `design-freeze.test.ts`
- [x] `pnpm build-storybook` — compiles
- [x] Manual smoke test: ran `design-freeze.mjs` against `extract-css-properties.fixture.html`, verified the emitted manifest validates against the schema and the skeleton embeds real `outerHTML`
- [x] Manual smoke test: ran against a scratch git repo to confirm `git tag` creation and rejection of an uncommitted prototype file both work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)