### PR TITLE
Fix TD-03.38: light-theme white-on-white text in workout cards

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -1,7 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useState } from 'react'
 import { View, Text, Pressable } from 'react-native'
-import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 import { VelocityStrip } from './VelocityStrip'
 import { PlaceholderStrip } from './PlaceholderStrip'
 import { WeightBadge } from './WeightBadge'
@@ -35,10 +34,18 @@ export interface ExerciseCardProps {
 }
 
 const COLORS = {
-  textPrimary: '#F3F4F6',
-  textSecondary: '#9CA3AF',
-  textTertiary: '#6B7280',
+  // Theme-aware tokens: text foregrounds and this card's own surfaces/borders
+  // must flip together so text stays readable in both light and dark. The
+  // expanded/pressed surfaces are self-owned here (not from a themed Card), so
+  // hardcoding dark values would leave dark-on-dark once the text flips.
+  // react-native-web passes the CSS var through to the inline style.
+  textPrimary: 'var(--color-text-primary)',
+  textSecondary: 'var(--color-text-secondary)',
+  textTertiary: 'var(--color-text-tertiary)',
   brandPrimary: '#FF7900',
+  surfaceRaised: 'var(--color-surface-raised)',
+  surfaceElevated: 'var(--color-surface-elevated)',
+  borderDefault: 'var(--color-border-default)',
 }
 
 const COLUMN_HEADERS = ['SET', 'PREV', 'REPS', 'LBS', 'RPE'] as const
@@ -132,9 +139,7 @@ function CollapsedCard({
           padding: 12,
           paddingHorizontal: 14,
           cursor: 'pointer',
-          backgroundColor: pressed
-            ? WORKOUT_TOKENS.surface.raised
-            : 'transparent',
+          backgroundColor: pressed ? COLORS.surfaceRaised : 'transparent',
           ...borderRadius,
           ...supersetMargin,
         }}
@@ -227,9 +232,9 @@ function ExpandedCard({
   return (
     <View
       style={{
-        backgroundColor: WORKOUT_TOKENS.surface.elevated,
+        backgroundColor: COLORS.surfaceElevated,
         borderWidth: 1,
-        borderColor: WORKOUT_TOKENS.border.default,
+        borderColor: COLORS.borderDefault,
         ...borderRadius,
         ...supersetMargin,
       }}
@@ -249,7 +254,7 @@ function ExpandedCard({
             paddingHorizontal: 14,
             paddingBottom: 10,
             borderBottomWidth: 1,
-            borderBottomColor: WORKOUT_TOKENS.border.default,
+            borderBottomColor: COLORS.borderDefault,
           }}
         >
           <Text

--- a/packages/ui/src/components/custom/Workout/MesoCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.tsx
@@ -9,8 +9,10 @@ const BRAND_PRIMARY = '#FF7900'
 const BRAND_PRIMARY_DARK = '#C45E00'
 const BRAND_PRIMARY_LIGHT = '#FFB066'
 const BORDER_DEFAULT = '#1F1F1F'
-const TEXT_PRIMARY = '#F3F4F6'
-const TEXT_SECONDARY = '#9CA3AF'
+// Theme-aware foregrounds: resolve to a readable color in both light and dark
+// (react-native-web passes the CSS var through to the inline style).
+const TEXT_PRIMARY = 'var(--color-text-primary)'
+const TEXT_SECONDARY = 'var(--color-text-secondary)'
 
 /** Gradient stops for the 3px top accent: dark -> primary -> light. */
 const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
@@ -43,9 +43,11 @@ export interface WorkoutCardProps extends ViewProps {
 }
 
 const COLORS = {
-  textPrimary: '#F3F4F6',
-  textSecondary: '#9CA3AF',
-  textTertiary: '#6B7280',
+  // Theme-aware foregrounds: resolve to a readable color in both light and dark
+  // (react-native-web passes the CSS var through to the inline style).
+  textPrimary: 'var(--color-text-primary)',
+  textSecondary: 'var(--color-text-secondary)',
+  textTertiary: 'var(--color-text-tertiary)',
   statusSuccess: '#14B8A6',
   brandPrimary: '#FF7900',
   borderDefault: '#1F1F1F',


### PR DESCRIPTION
## TD-03.38 — light-theme white-on-white in MesoCard/WorkoutCard/ExerciseCard

### Root cause
In light theme these three cards rendered hardcoded dark-theme text (`#F3F4F6`) on `Card`'s themed light-mode surface (`#FAFAFA` — `Card.tsx:114-116` returns this via `useTheme()`), so titles/names went white-on-white and unreadable. Dark theme was unaffected (which is why it shipped). Traps in the token set: light-mode `--color-surface-raised` is `#F3F4F6`, identical to dark-mode `--color-text-primary`.

### Fix
Swap the hardcoded text-color constants for the theme-aware CSS custom properties, which flip per theme via the same `.light` class the surfaces already use (react-native-web passes the `var()` string straight to the inline style — the exact pattern already used by `MuscleGroupChip`):
- `#F3F4F6` → `var(--color-text-primary)`
- `#9CA3AF` → `var(--color-text-secondary)`
- `#6B7280` → `var(--color-text-tertiary)`

`ExerciseCard` additionally owns its expanded/pressed **surfaces** (not a themed `Card`), so `WORKOUT_TOKENS.surface.*`/`border.default` are switched to `var(--color-surface-*/border-default)` too. Without this, flipping only the text would flip readable-white to dark on a still-dark `#191919` surface (dark-on-dark). `MesoCard.BORDER_DEFAULT` is intentionally left as hex — it feeds `Animated.interpolate`, which cannot parse `var()`.

### Files
- `WorkoutCard.tsx` — 3 text tokens
- `MesoCard.tsx` — 2 text tokens (title + subheader)
- `ExerciseCard.tsx` — 3 text tokens + 3 surface/border tokens; drop now-unused `WORKOUT_TOKENS` import

### Verify (no NEW failures beyond the known pre-existing react-hook-form missing-dep)
- `pnpm lint` — pass (0 errors; 92 pre-existing warnings unchanged).
- `pnpm type-check` — no errors in changed files (pre-existing `react-hook-form` failures only).
- `pnpm test` — the 3 components' suites pass (ExerciseCard 28, MesoCard 15, WorkoutCard 15); full run 1402/1402 tests pass, only the pre-existing `react-hook-form` example file fails.
- `pnpm build` — pass.

### Visual proof (Storybook dev server, both themes)
Static `build-storybook` fails on the pre-existing `react-hook-form` missing dep (Rollup can't resolve it while bundling the preview), so I used the Storybook **dev** server (Vite compiles on demand, never touching those stories) and screenshotted three stories in both themes, before and after.
- **MesoCard Expanded** — before/light: "Accumulation" title invisible (white-on-white); after/light: dark and readable; dark theme unchanged.
- **WorkoutCard Expanded** — before/light: "Upper A" + nested "Bench Press"/"Incline DB Press" invisible; after/light: all readable; dark unchanged.
- **ExerciseCard ExpandedWithSets** — after/light: surface flips light, name/headers readable (no dark-on-dark); dark unchanged.

### Out of scope (broader blast radius, separate follow-ups)
The same hardcoded-color class of bug exists in ~16 other workout components (e.g. `WorkoutPill`, `WeekRow`, `SetRow`, the `*Page` components' `PAGE_BG='#0E0E0E'`). Visible in the MesoCard screenshots as dark `WorkoutPill`s and faint `WeekRow` week labels — those are child components not in this ticket's scope.