### PR TITLE
Fix TD-03.40: guard NaN/invalid inline styles in workout components

### DIFF
--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.test.tsx
@@ -139,3 +139,15 @@ describe('MesoProgressBar', () => {
     })
   })
 })
+
+describe('MesoProgressBar invalid weekCount (flex guard)', () => {
+  it('clamps zero and negative weekCount to a valid flex of 1', () => {
+    const edgeMesos: Meso[] = [
+      { id: 'z', name: 'Zero', weekCount: 0, status: 'upcoming' },
+      { id: 'n', name: 'Neg', weekCount: -3, status: 'upcoming' },
+    ]
+    render(<MesoProgressBar mesos={edgeMesos} activeMesoId={null} onMesoPress={vi.fn()} />)
+    expect(screen.getByTestId('meso-segment-z')).toHaveStyle({ flex: 1 })
+    expect(screen.getByTestId('meso-segment-n')).toHaveStyle({ flex: 1 })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
@@ -66,9 +66,13 @@ function MesoSegment({ meso, isActive, onPress }: SegmentProps) {
     ? clampProgress(meso.currentWeek, meso.weekCount)
     : 0
 
+  // weekCount drives the segment's flex width; guard 0 / negative so flex stays
+  // a valid positive value and the segment never collapses out of the layout.
+  const segmentFlex = Math.max(1, meso.weekCount)
+
   return (
     <Pressable
-      style={{ flex: meso.weekCount }}
+      style={{ flex: segmentFlex }}
       onPress={() => onPress(meso.id)}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}

--- a/packages/ui/src/components/custom/Workout/RestTimer.test.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.test.tsx
@@ -143,3 +143,13 @@ describe('RestTimer', () => {
     })
   })
 })
+
+describe('RestTimer zero-duration timer (NaN guard)', () => {
+  it('emits a valid 100% width (not NaN) when totalSeconds is 0', () => {
+    const { container } = render(
+      <RestTimer {...defaultProps} totalSeconds={0} elapsedMs={0} />,
+    )
+    expect(screen.getByTestId('rest-timer-progress-fill')).toHaveStyle({ width: '100%' })
+    expect(container.innerHTML).not.toContain('NaN')
+  })
+})

--- a/packages/ui/src/components/custom/Workout/RestTimer.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.tsx
@@ -28,7 +28,10 @@ export function RestTimer({
   const minutes = Math.floor(remainingSec / 60)
   const seconds = remainingSec % 60
   const timeDisplay = `${minutes}:${String(seconds).padStart(2, '0')}`
-  const progressPct = Math.min(100, (elapsedMs / (totalSeconds * 1000)) * 100)
+  // A zero-duration timer is already complete; guard the 0 / 0 === NaN case
+  // that would otherwise emit width:'NaN%'.
+  const totalMs = totalSeconds * 1000
+  const progressPct = totalMs > 0 ? Math.min(100, (elapsedMs / totalMs) * 100) : 100
 
   return (
     <View

--- a/packages/ui/src/components/custom/Workout/StatusDot.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.tsx
@@ -12,6 +12,7 @@ export type StatusDotVariant =
 
 export interface StatusDotProps extends ViewProps {
   variant: StatusDotVariant
+  /** Center glyph. Only rendered at size="md"; the 8px "sm" dot is too small to fit one. */
   icon?: 'check' | 'exclamation' | 'dash'
   size?: 'sm' | 'md'
   /** Adds a subtle glow effect in the variant color */

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
@@ -232,3 +232,13 @@ describe('calculateMeanVelocity', () => {
     expect(calculateMeanVelocity([])).toBe(0)
   })
 })
+
+describe('VelocityStrip all-zero velocities (NaN guard)', () => {
+  it('emits a valid 0% bar height (not NaN) when every velocity is zero (expanded)', () => {
+    render(<VelocityStrip velocities={[0, 0, 0]} expanded />)
+    // Without the guard, 0 / (0 * 1.15) === NaN and the bar height becomes
+    // 'NaN%' (dropped by jsdom, leaving no height); the guard flattens to '0%'.
+    expect(screen.getByTestId('velocity-bar-0')).toHaveStyle({ height: '0%' })
+    expect(screen.getByTestId('velocity-bar-2')).toHaveStyle({ height: '0%' })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -178,7 +178,10 @@ export function VelocityStrip({
       >
         {velocities.map((v, i) => {
           const zone = getVelocityZoneColor(v)
-          const barHeightPct = Math.round((v / (maxVelocity * 1.15)) * 100)
+          // Guard all-zero velocities (idle / pre-rep): maxVelocity === 0 makes
+          // this 0 / 0 === NaN and emits height:'NaN%'. Flatten the bars instead.
+          const barHeightPct =
+            maxVelocity > 0 ? Math.round((v / (maxVelocity * 1.15)) * 100) : 0
 
           const bar = (
             <View


### PR DESCRIPTION
## TD-03.40 — NaN / invalid-style guards

Three unguarded computations emitted invalid CSS from division-by-zero / raw counts. All are reachable from valid prop values.

### Fixes (each with a fail-before / pass-after regression test)
| Component | Bug | Repro | Guard |
|---|---|---|---|
| `VelocityStrip.tsx:181` | `v / (maxVelocity * 1.15)` is `0/0 = NaN` when every velocity is 0 → `height:'NaN%'` on expanded bars | `velocities={[0,0,0]}` + `expanded` (all reps report 0 velocity, e.g. idle/pre-rep) | `maxVelocity > 0 ? … : 0` (flatten bars) |
| `RestTimer.tsx:31` | `elapsedMs / (totalSeconds*1000)` is `0/0 = NaN` for a zero-duration timer → `width:'NaN%'` | `totalSeconds={0} elapsedMs={0}` | `totalMs > 0 ? … : 100` (zero-duration = complete) |
| `MesoProgressBar.tsx:71` | segment `flex` was raw `weekCount`; `0` collapses the segment out of layout, negative is invalid flex | `weekCount: 0` or `-3` | `Math.max(1, weekCount)` (matches existing `clampProgress`) |

Also (optional item, folded in): documented that `StatusDot`'s `icon` only renders at `size="md"` — the 8px `sm` dot is too small to fit a glyph, so the always-optional prop is silently ignored at the default size. JSDoc only, no behavior change.

### Regression tests — each confirmed fail-before/pass-after
Ran each new test with the source guard stashed (fails) and restored (passes):
- VelocityStrip all-zero expanded: asserts `velocity-bar-*` renders `height: '0%'` (before: `'NaN%'`, dropped by jsdom → no height → fail).
- RestTimer `totalSeconds=0`: asserts `rest-timer-progress-fill` `width: '100%'` (before: NaN → fail).
- MesoProgressBar `weekCount` 0 and -3: asserts segment `flex: 1` (before: `flex: 0` / `-3` → fail).

### Verify (no NEW failures beyond the known pre-existing react-hook-form missing-dep)
- `pnpm lint` — pass (0 errors; 92 pre-existing warnings, unchanged).
- `pnpm type-check` — no errors in changed files (only the pre-existing react-hook-form failures remain).
- `pnpm test` — 1405/1405 tests pass (+3 new); 86/87 files, the 1 failing file is the pre-existing react-hook-form example.
- `pnpm build` — pass.

Scope: VelocityStrip, RestTimer, MesoProgressBar (+ StatusDot doc line) only. The dark hardcoded theme tokens still present in RestTimer/others are the separate TD-03.39 blast radius, deliberately untouched here.

Note: skipped the optional dev-server screenshot — the VelocityStrip regression test asserts the exact emitted bar style (`height: '0%'`), which is stronger proof than a screenshot that the invalid value is gone.