### PR TITLE
Fix TD-05.08: complete token codegen source + global.css drift guard

### DIFF
--- a/packages/ui/src/theme/config.completeness.test.ts
+++ b/packages/ui/src/theme/config.completeness.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { darkThemeCSSVars, lightThemeCSSVars } from './config'
+
+/**
+ * Drift guard for the token codegen source (TD-05.08).
+ *
+ * `config.ts` (darkThemeCSSVars / lightThemeCSSVars) is the source that
+ * `tokens-css.ts` renders into `dist/tokens.css`. It must stay a complete,
+ * value-accurate mirror of the `:root` / `.light` custom properties in
+ * `global.css`; otherwise the generated stylesheet silently drifts from the
+ * design system (the exact gap this ticket closed). This test fails if
+ * global.css gains a `:root` var that config.ts does not cover, or if any
+ * shared var's value diverges.
+ */
+
+const themeDir = path.dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(path.join(themeDir, 'global.css'), 'utf8')
+
+/**
+ * global.css :root vars intentionally excluded from the codegen source.
+ * Empty today — every :root var is mirrored. Add a var here (with a reason)
+ * only if it is genuinely prototype-irrelevant, rather than silently skipping.
+ */
+const CODEGEN_ALLOWLIST = new Set<string>([])
+
+function parseVarBlock(header: RegExp): Map<string, string> {
+  const match = css.match(header)
+  if (!match) throw new Error(`could not locate CSS block for ${header}`)
+  const vars = new Map<string, string>()
+  for (const line of match[1].split('\n')) {
+    const declaration = line.match(/^\s*(--[a-z0-9-]+):\s*(.+?);\s*$/i)
+    if (declaration) vars.set(declaration[1], declaration[2].trim())
+  }
+  return vars
+}
+
+const globalDark = parseVarBlock(/:root\s*\{([\s\S]*?)\n\s*\}/)
+const globalLight = parseVarBlock(/\.light,\s*\n?\s*:root\.light\s*\{([\s\S]*?)\n\s*\}/)
+
+const cases = [
+  ['dark', globalDark, darkThemeCSSVars as Record<string, string>],
+  ['light', globalLight, lightThemeCSSVars as Record<string, string>],
+] as const
+
+describe('token codegen completeness (config.ts vs global.css)', () => {
+  it('parses both global.css theme blocks', () => {
+    expect(globalDark.size).toBeGreaterThan(90)
+    expect(globalLight.size).toBe(globalDark.size)
+  })
+
+  for (const [mode, globalVars, cfg] of cases) {
+    it(`${mode}: config covers every global.css :root var with the exact value`, () => {
+      const missing: string[] = []
+      const mismatched: string[] = []
+      for (const [name, value] of globalVars) {
+        if (CODEGEN_ALLOWLIST.has(name)) continue
+        if (!(name in cfg)) {
+          missing.push(name)
+        } else if (cfg[name] !== value) {
+          mismatched.push(`${name}: global='${value}' config='${cfg[name]}'`)
+        }
+      }
+      expect(missing, 'global.css vars missing from config.ts codegen source').toEqual([])
+      expect(mismatched, 'value drift between config.ts and global.css').toEqual([])
+    })
+
+    it(`${mode}: config emits no var absent from global.css`, () => {
+      const extra = Object.keys(cfg).filter(
+        (name) => !globalVars.has(name) && !CODEGEN_ALLOWLIST.has(name),
+      )
+      expect(extra, 'config.ts vars not present in global.css :root').toEqual([])
+    })
+  }
+})

--- a/packages/ui/src/theme/config.ts
+++ b/packages/ui/src/theme/config.ts
@@ -7,6 +7,35 @@
 
 import { semanticColorsLight, semanticColorsDark, type ThemeMode } from './tokens/semantic'
 
+// Theme-independent custom properties: identical in light and dark in
+// global.css (RGB glow decompositions, font families, animation tokens). Kept
+// as literals since they are not part of the semantic COLOR maps, and spread
+// into both theme maps so codegen mirrors global.css exactly.
+const themeIndependentCSSVars = {
+  // RGB decomposed values for glow shadows
+  '--color-brand-primary-rgb': '255, 121, 0',
+  '--color-brand-secondary-rgb': '64, 109, 135',
+  '--color-status-success-rgb': '20, 184, 166',
+  '--color-status-error-rgb': '209, 67, 67',
+  '--color-status-warning-rgb': '255, 176, 32',
+  '--color-status-info-rgb': '33, 150, 243',
+  '--color-background-base-rgb': '16, 16, 16',
+
+  // Font families
+  '--font-family-sans': "'Inter'",
+  '--font-family-body': "'Nunito Sans'",
+  '--font-family-heading': "'Space Grotesk'",
+  '--font-family-mono': "'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace",
+
+  // Animation tokens
+  '--ease-out': 'cubic-bezier(0.22, 1, 0.36, 1)',
+  '--ease-in-out': 'cubic-bezier(0.65, 0, 0.35, 1)',
+  '--ease-spring': 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+  '--duration-fast': '150ms',
+  '--duration-normal': '250ms',
+  '--duration-slow': '400ms',
+} as const
+
 // CSS custom properties for light mode
 export const lightThemeCSSVars = {
   '--color-brand-primary': semanticColorsLight['brand-primary'],
@@ -57,6 +86,67 @@ export const lightThemeCSSVars = {
   '--color-interactive-disabled': semanticColorsLight['interactive-disabled'],
 
   '--color-divider': semanticColorsLight['divider'],
+
+  '--color-brand-primary-hover': semanticColorsLight['brand-primary-hover'],
+  '--color-brand-primary-active': semanticColorsLight['brand-primary-active'],
+  '--color-brand-secondary-hover': semanticColorsLight['brand-secondary-hover'],
+  '--color-brand-secondary-active': semanticColorsLight['brand-secondary-active'],
+
+  '--color-status-success-light': semanticColorsLight['status-success-light'],
+  '--color-status-success-dark': semanticColorsLight['status-success-dark'],
+  '--color-status-error-light': semanticColorsLight['status-error-light'],
+  '--color-status-error-dark': semanticColorsLight['status-error-dark'],
+  '--color-status-warning-light': semanticColorsLight['status-warning-light'],
+  '--color-status-warning-dark': semanticColorsLight['status-warning-dark'],
+  '--color-status-info-light': semanticColorsLight['status-info-light'],
+  '--color-status-info-dark': semanticColorsLight['status-info-dark'],
+
+  '--color-on-status-success': semanticColorsLight['on-status-success'],
+  '--color-on-status-error': semanticColorsLight['on-status-error'],
+  '--color-on-status-warning': semanticColorsLight['on-status-warning'],
+  '--color-on-status-info': semanticColorsLight['on-status-info'],
+
+  '--color-result-improve': semanticColorsLight['result-improve'],
+  '--color-result-improve-light': semanticColorsLight['result-improve-light'],
+  '--color-result-improve-dark': semanticColorsLight['result-improve-dark'],
+  '--color-result-degrade': semanticColorsLight['result-degrade'],
+  '--color-result-degrade-light': semanticColorsLight['result-degrade-light'],
+  '--color-result-degrade-dark': semanticColorsLight['result-degrade-dark'],
+  '--color-result-inconclusive': semanticColorsLight['result-inconclusive'],
+  '--color-result-inconclusive-light': semanticColorsLight['result-inconclusive-light'],
+  '--color-result-neutral': semanticColorsLight['result-neutral'],
+
+  '--color-on-result-improve': semanticColorsLight['on-result-improve'],
+  '--color-on-result-degrade': semanticColorsLight['on-result-degrade'],
+  '--color-on-result-inconclusive': semanticColorsLight['on-result-inconclusive'],
+
+  '--color-data-1': semanticColorsLight['data-1'],
+  '--color-data-2': semanticColorsLight['data-2'],
+  '--color-data-3': semanticColorsLight['data-3'],
+  '--color-data-4': semanticColorsLight['data-4'],
+  '--color-data-5': semanticColorsLight['data-5'],
+  '--color-data-6': semanticColorsLight['data-6'],
+  '--color-data-7': semanticColorsLight['data-7'],
+  '--color-data-8': semanticColorsLight['data-8'],
+  '--color-data-9': semanticColorsLight['data-9'],
+  '--color-data-10': semanticColorsLight['data-10'],
+
+  '--color-text-link-hover': semanticColorsLight['text-link-hover'],
+
+  '--color-surface-overlay': semanticColorsLight['surface-overlay'],
+  '--color-surface-input': semanticColorsLight['surface-input'],
+
+  '--color-border-input': semanticColorsLight['border-input'],
+  '--color-border-input-hover': semanticColorsLight['border-input-hover'],
+  '--color-border-input-focus': semanticColorsLight['border-input-focus'],
+  '--color-border-input-error': semanticColorsLight['border-input-error'],
+
+  '--color-interactive-disabled-text': semanticColorsLight['interactive-disabled-text'],
+
+  '--color-avatar-background': semanticColorsLight['avatar-background'],
+  '--color-avatar-text': semanticColorsLight['avatar-text'],
+
+  ...themeIndependentCSSVars,
 } as const
 
 // CSS custom properties for dark mode (default)
@@ -109,6 +199,67 @@ export const darkThemeCSSVars = {
   '--color-interactive-disabled': semanticColorsDark['interactive-disabled'],
 
   '--color-divider': semanticColorsDark['divider'],
+
+  '--color-brand-primary-hover': semanticColorsDark['brand-primary-hover'],
+  '--color-brand-primary-active': semanticColorsDark['brand-primary-active'],
+  '--color-brand-secondary-hover': semanticColorsDark['brand-secondary-hover'],
+  '--color-brand-secondary-active': semanticColorsDark['brand-secondary-active'],
+
+  '--color-status-success-light': semanticColorsDark['status-success-light'],
+  '--color-status-success-dark': semanticColorsDark['status-success-dark'],
+  '--color-status-error-light': semanticColorsDark['status-error-light'],
+  '--color-status-error-dark': semanticColorsDark['status-error-dark'],
+  '--color-status-warning-light': semanticColorsDark['status-warning-light'],
+  '--color-status-warning-dark': semanticColorsDark['status-warning-dark'],
+  '--color-status-info-light': semanticColorsDark['status-info-light'],
+  '--color-status-info-dark': semanticColorsDark['status-info-dark'],
+
+  '--color-on-status-success': semanticColorsDark['on-status-success'],
+  '--color-on-status-error': semanticColorsDark['on-status-error'],
+  '--color-on-status-warning': semanticColorsDark['on-status-warning'],
+  '--color-on-status-info': semanticColorsDark['on-status-info'],
+
+  '--color-result-improve': semanticColorsDark['result-improve'],
+  '--color-result-improve-light': semanticColorsDark['result-improve-light'],
+  '--color-result-improve-dark': semanticColorsDark['result-improve-dark'],
+  '--color-result-degrade': semanticColorsDark['result-degrade'],
+  '--color-result-degrade-light': semanticColorsDark['result-degrade-light'],
+  '--color-result-degrade-dark': semanticColorsDark['result-degrade-dark'],
+  '--color-result-inconclusive': semanticColorsDark['result-inconclusive'],
+  '--color-result-inconclusive-light': semanticColorsDark['result-inconclusive-light'],
+  '--color-result-neutral': semanticColorsDark['result-neutral'],
+
+  '--color-on-result-improve': semanticColorsDark['on-result-improve'],
+  '--color-on-result-degrade': semanticColorsDark['on-result-degrade'],
+  '--color-on-result-inconclusive': semanticColorsDark['on-result-inconclusive'],
+
+  '--color-data-1': semanticColorsDark['data-1'],
+  '--color-data-2': semanticColorsDark['data-2'],
+  '--color-data-3': semanticColorsDark['data-3'],
+  '--color-data-4': semanticColorsDark['data-4'],
+  '--color-data-5': semanticColorsDark['data-5'],
+  '--color-data-6': semanticColorsDark['data-6'],
+  '--color-data-7': semanticColorsDark['data-7'],
+  '--color-data-8': semanticColorsDark['data-8'],
+  '--color-data-9': semanticColorsDark['data-9'],
+  '--color-data-10': semanticColorsDark['data-10'],
+
+  '--color-text-link-hover': semanticColorsDark['text-link-hover'],
+
+  '--color-surface-overlay': semanticColorsDark['surface-overlay'],
+  '--color-surface-input': semanticColorsDark['surface-input'],
+
+  '--color-border-input': semanticColorsDark['border-input'],
+  '--color-border-input-hover': semanticColorsDark['border-input-hover'],
+  '--color-border-input-focus': semanticColorsDark['border-input-focus'],
+  '--color-border-input-error': semanticColorsDark['border-input-error'],
+
+  '--color-interactive-disabled-text': semanticColorsDark['interactive-disabled-text'],
+
+  '--color-avatar-background': semanticColorsDark['avatar-background'],
+  '--color-avatar-text': semanticColorsDark['avatar-text'],
+
+  ...themeIndependentCSSVars,
 } as const
 
 // Helper to get CSS vars for a theme mode

--- a/packages/ui/src/theme/tokens-css.ts
+++ b/packages/ui/src/theme/tokens-css.ts
@@ -2,9 +2,11 @@
  * Token CSS Generator
  *
  * Emits a static `:root {}` CSS block from the canonical theme token maps
- * (`darkThemeCSSVars` / `lightThemeCSSVars`). HTML prototypes import the
- * generated stylesheet so they always resolve to the exact same values as
- * the design system. Pure codegen: deterministic and diffable against source.
+ * (`darkThemeCSSVars` / `lightThemeCSSVars`). Those maps mirror every `:root`
+ * custom property in `theme/global.css` — completeness and value parity are
+ * enforced by `config.completeness.test.ts`, so HTML prototypes that import the
+ * generated stylesheet resolve to the exact same values as the design system.
+ * Pure codegen: deterministic and diffable against source.
  *
  * Dark mode is the default (`:root`); light mode is activated with `.light`,
  * matching the convention in `theme/global.css`.


### PR DESCRIPTION
## TD-05.08 — token codegen was 62% incomplete vs global.css

`config.ts` (`darkThemeCSSVars`/`lightThemeCSSVars`) is the codegen source that `tokens-css.ts` renders into `dist/tokens.css` (imported by the HTML prototypes). It covered only **40 of global.css's 105** `:root` vars, so the generated stylesheet silently omitted **65** tokens — and `tokens-css.ts`'s doc claim that prototypes "always resolve to the exact same values as the design system" was false for the majority. The existing `tokens-css.test.ts` only checked self-consistency vs `config.ts`, never vs `global.css`.

### What changed
- **48 missing color vars** → ported into both theme maps referencing the semantic color source (`semanticColorsDark/Light`), matching the existing pattern. Verified up front that all 48 exist there with **0 value drift** vs global.css (dark and light).
- **17 theme-independent non-color vars** (`-rgb` glow decompositions, `--font-family-*`, `--ease-*`, `--duration-*`) → added as a shared `themeIndependentCSSVars` literal spread into both maps. These aren't part of the semantic COLOR maps and are identical in light/dark, so a single literal source is correct and DRY.
- **`config.completeness.test.ts`** (the key deliverable) — parses global.css's `:root` and `.light` blocks and asserts `config.ts` covers **every** var with the **exact value**, in both directions (no missing, no drift, no extra). Includes an explicit, documented **empty `CODEGEN_ALLOWLIST`** so any future intentional exclusion is deliberate rather than silent.
- Corrected the misleading `tokens-css.ts` doc comment (now accurate and points at the enforcing test).

### Missing var count / allowlist
65 vars added (48 color + 17 theme-independent). **Intentional allowlist: empty** — every global.css `:root` var is now mirrored.

### Drift guard proven
Temporarily removed `--color-data-5` from `config.ts` → the test failed with `global.css vars missing from config.ts codegen source: expected [ '--color-data-5' ] to deeply equal []`, then restored.

### Verify (no NEW failures beyond the known pre-existing react-hook-form missing-dep)
- `pnpm lint` — pass (0 errors; 92 pre-existing warnings, unchanged).
- `pnpm type-check` — no new errors (only pre-existing react-hook-form).
- `pnpm test` — 1410/1410 pass (+5 new); 87/88 files, the 1 failing file is the pre-existing react-hook-form example.
- `pnpm build` — pass; regenerates `dist/tokens.css` from **40 → 105 vars per block**, now containing the previously-missing tokens with correct theme-specific values (e.g. `--color-text-link-hover` dark `#60A5FA` / light `#3832A0`; `--color-avatar-background` dark `#4B5563` / light `#6B7280`). `dist/` is gitignored, so not committed.

Baseline comparisons were done with `git show HEAD:` / direct edit-and-restore, not `git stash`.