### PR TITLE
Fix TD-04.09: specimen Vite config (react-native-web + svg resolution)

### DIFF
--- a/packages/ui/specimen/stubs/react-native-body-highlighter.tsx
+++ b/packages/ui/specimen/stubs/react-native-body-highlighter.tsx
@@ -1,0 +1,15 @@
+/**
+ * Specimen-only stub for `react-native-body-highlighter`.
+ *
+ * The package ships no web build, and its Node-targeted ESM interop resolves
+ * `react` through a dynamic `require()` that throws in a browser ESM context
+ * ("Dynamic require of 'react' is not supported"). Its sole consumer, BodyMap,
+ * is not part of the HTML-vs-React atom comparison the specimen renders, but it
+ * is pulled in eagerly via the `custom/Workout` barrel. Aliasing it to this
+ * no-op default (see specimen/vite.config.ts) lets the barrel load so the atom
+ * specimens can render. BodyMap itself cannot be exercised in the specimen
+ * until the upstream package gains a web build.
+ */
+export default function BodyHighlighterStub(): null {
+  return null
+}

--- a/packages/ui/specimen/vite.config.ts
+++ b/packages/ui/specimen/vite.config.ts
@@ -3,13 +3,53 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from 'tailwindcss'
 import autoprefixer from 'autoprefixer'
 import path from 'path'
+import {
+  reactNativeSvgWebResolver,
+  reactNativeSvgWebResolverEsbuild,
+  svgWebAliases,
+  webResolveExtensions,
+} from '../vite-rn-svg-plugins'
 
+/**
+ * Specimen dev server (drives the Playwright visual harness in
+ * `playwright.comparison.config.ts`). The comparison page imports the whole
+ * `custom/Workout` barrel, which transitively pulls in `react-native-svg` (and,
+ * via BodyMap, `react-native-body-highlighter`). Both ship native (Flow) Fabric
+ * sources that a Node/esbuild resolver loads instead of their `.web.js`
+ * siblings, crashing dep pre-bundling. This reuses the resolution already
+ * proven in `vitest.config.ts` via `vite-rn-svg-plugins`:
+ *   - alias bare `react-native` -> `react-native-web` (exact match only, so RN's
+ *     own `react-native/Libraries/...` subpaths are left for the svg resolver),
+ *   - alias `react-native-svg` -> its ESM build and rewrite its relative imports
+ *     to their `.web.js` siblings (Vite plugin + esbuild optimizer replay),
+ *   - `.web.*`-first extension order so web platform files win over native,
+ *   - exclude `react-native-svg` from optimizeDeps so it flows through the
+ *     plugin above rather than being pre-bundled from its Flow sources.
+ *
+ * `react-native-body-highlighter` has no web build and its Node-ESM interop uses
+ * a dynamic `require('react')` that throws in the browser; BodyMap (its only
+ * consumer) is not part of the atom comparison, so it is aliased to a no-op stub
+ * (see specimen/stubs) purely to let the barrel load.
+ */
 export default defineConfig({
-  plugins: [react({ jsxImportSource: 'nativewind' })],
+  plugins: [reactNativeSvgWebResolver(), react({ jsxImportSource: 'nativewind' })],
   root: __dirname,
   resolve: {
-    alias: {
-      'react-native': 'react-native-web',
+    alias: [
+      ...svgWebAliases,
+      { find: /^react-native$/, replacement: 'react-native-web' },
+      {
+        find: /^react-native-body-highlighter$/,
+        replacement: path.resolve(__dirname, 'stubs/react-native-body-highlighter.tsx'),
+      },
+    ],
+    extensions: webResolveExtensions,
+  },
+  optimizeDeps: {
+    exclude: ['react-native-svg', 'react-native-body-highlighter'],
+    esbuildOptions: {
+      resolveExtensions: webResolveExtensions,
+      plugins: [reactNativeSvgWebResolverEsbuild()],
     },
   },
   css: {


### PR DESCRIPTION
## TD-04.09 — specimen Vite config: react-native-web + svg resolution

The specimen dev server (which the Playwright visual harness in `playwright.comparison.config.ts` launches via `pnpm specimen`) crashed on start. Root cause, reproduced:

```
Error: Build failed with 1 error:
.../react-native-svg/lib/module/fabric/TextPathNativeComponent.js: ERROR: Cannot read file:
  packages/ui/react-native-web/Libraries/Utilities/codegenNativeComponent
```

The plain `{'react-native': 'react-native-web'}` string alias rewrote react-native-svg's **Fabric subpath** import (`react-native/Libraries/...`) to a non-existent relative path, and esbuild dep pre-bundling then loaded react-native-svg's native **Flow** sources instead of their `.web.js` siblings.

### Fix (mirrors the resolution already proven in `vitest.config.ts` via `vite-rn-svg-plugins.ts`)
- **exact-match** `react-native` → `react-native-web` alias (regex `/^react-native$/`), so RN's own `react-native/Libraries/...` subpaths are left for the svg resolver instead of being mis-rewritten;
- alias `react-native-svg` → its ESM build (`svgWebAliases`) + `reactNativeSvgWebResolver()` plugin that rewrites its relative imports to `.web.js` siblings, **replayed inside the optimizeDeps esbuild pass** via `reactNativeSvgWebResolverEsbuild()`;
- `.web.*`-first `resolve.extensions` (`webResolveExtensions`) so web files win over native;
- `optimizeDeps.exclude` react-native-svg so it flows through the plugin above rather than being pre-bundled from Flow sources.
- **react-native-body-highlighter** (pulled in via the `custom/Workout` barrel by BodyMap) ships no web build and its Node-ESM interop uses a dynamic `require('react')` that throws in the browser (`Dynamic require of "react" is not supported`). BodyMap is not part of the atom comparison, so it's aliased to a small no-op **specimen stub** purely to let the barrel load.

### Verification
- **Specimen dev server serves cleanly.** Loaded via headless chromium: `index.html` (the scaffold specimen) renders every React atom with **0 console/page errors** — 14 `status-dot` React nodes, ~22 KB of `#root` DOM. This exercises the full resolution chain (react-native-web + react-native-svg + nativewind + tailwind).
- **Production build passes**: `vite build --config specimen/vite.config.ts` → 1904 modules, no errors (was failing before at dep pre-bundle).
- `pnpm lint` 0 errors (92 pre-existing warnings, unchanged); `pnpm type-check` clean beyond the pre-existing react-hook-form failures. (specimen/ is outside tsc/eslint scope; the working build + serve is the proof.)

### Is the 04.04/05/06 harness now runnable? — partial, honest status
The **config half is fixed**: react-native-web + svg resolve and the specimen serves/renders. The **remaining blocker is content, not config**: `comparison.tsx` is stale against current atom APIs — e.g. it calls `<TempoDisplay concentric={} hold={} .../>` but the component now takes a `tempo: [n,n,n,n]` tuple, so its React column throws `tempo is not iterable` (and IntensityBar `level` 0–100 vs 0–1, etc.). That is the specimen **port** work (backlog TD-04.10), out of this ticket's "fix the config" scope. Once `comparison.tsx` is updated to the current atom props, the harness runs against this config — proven by `index.html` (which already uses current APIs) rendering error-free through the same config.

Scope: specimen config + stub only; no component/source changes.