### PR TITLE
Fix TD-04.10: port comparison specimen to current atom props (harness runnable)

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -974,7 +974,7 @@ function App() {
         label="TempoDisplay colored md"
         htmlContent={`<div class="tempo-display md-size tempo-colored"><span class="tempo-value"><span class="t-con">1</span><span class="t-dash">-</span><span class="t-hold">1</span><span class="t-dash">-</span><span class="t-ecc">3</span><span class="t-dash">-</span><span class="t-idle">0</span></span></div>`}
       >
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored />
+        <TempoDisplay tempo={[1, 1, 3, 0]} colored />
       </ComparisonPair>
 
       <ComparisonPair
@@ -982,7 +982,7 @@ function App() {
         label="TempoDisplay mono md"
         htmlContent={`<div class="tempo-display md-size"><span class="tempo-value mono">1-1-3-0</span></div>`}
       >
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} colored={false} />
+        <TempoDisplay tempo={[1, 1, 3, 0]} colored={false} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -990,7 +990,7 @@ function App() {
         label="TempoDisplay colored sm"
         htmlContent={`<div class="tempo-display sm-size tempo-colored"><span class="tempo-value"><span class="t-con">1</span><span class="t-dash">-</span><span class="t-hold">1</span><span class="t-dash">-</span><span class="t-ecc">3</span><span class="t-dash">-</span><span class="t-idle">0</span></span></div>`}
       >
-        <TempoDisplay concentric={1} hold={1} eccentric={3} idle={0} size="sm" colored />
+        <TempoDisplay tempo={[1, 1, 3, 0]} size="sm" colored />
       </ComparisonPair>
 
       {/* ── 7. DeviationBar ── */}
@@ -1020,7 +1020,7 @@ function App() {
         label="IntensityBar 20% (building)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill building" style="height:20%"></div></div><span class="intensity-label">20%</span></div>`}
       >
-        <IntensityBar level={20} height={36} showLabel />
+        <IntensityBar level={0.2} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1028,7 +1028,7 @@ function App() {
         label="IntensityBar 75% (approaching)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill approaching" style="height:75%"></div></div><span class="intensity-label">75%</span></div>`}
       >
-        <IntensityBar level={75} height={36} showLabel />
+        <IntensityBar level={0.75} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1036,7 +1036,7 @@ function App() {
         label="IntensityBar 100% (target gradient)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill target" style="height:100%"></div></div><span class="intensity-label">100%</span></div>`}
       >
-        <IntensityBar level={100} height={36} showLabel />
+        <IntensityBar level={1} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1044,7 +1044,7 @@ function App() {
         label="IntensityBar 110% (over + bulge)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill over-1" style="height:100%"></div><div class="intensity-bulge over-1" style="width:8px;height:8px"></div></div><span class="intensity-label">110%</span></div>`}
       >
-        <IntensityBar level={110} height={36} showLabel />
+        <IntensityBar level={1.1} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1052,7 +1052,7 @@ function App() {
         label="IntensityBar 50% at target (blue glow)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill building at-target" style="height:50%"></div><div class="intensity-line-target" style="bottom:50%"></div></div><span class="intensity-label">50%</span></div>`}
       >
-        <IntensityBar level={50} target={50} height={36} showLabel />
+        <IntensityBar level={0.5} threshold={0.5} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1060,7 +1060,7 @@ function App() {
         label="IntensityBar 120% (over-2)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill over-2" style="height:100%"></div><div class="intensity-bulge over-2" style="width:10px;height:10px"></div></div><span class="intensity-label">120%</span></div>`}
       >
-        <IntensityBar level={120} height={36} showLabel />
+        <IntensityBar level={1.2} size={36} />
       </ComparisonPair>
 
       <ComparisonPair
@@ -1068,7 +1068,7 @@ function App() {
         label="IntensityBar 130% (over-3)"
         htmlContent={`<div class="intensity-bar"><div class="intensity-track" style="height:36px"><div class="intensity-fill over-3" style="height:100%"></div><div class="intensity-bulge over-3" style="width:11px;height:11px"></div></div><span class="intensity-label">130%</span></div>`}
       >
-        <IntensityBar level={130} height={36} showLabel />
+        <IntensityBar level={1.3} size={36} />
       </ComparisonPair>
 
       {/* ── 9. WorkoutPill ── */}
@@ -1087,6 +1087,8 @@ function App() {
           missed: '\u2014 ',
         }
         const prefix = prefixes[status] ?? ''
+        // The prototype's `active` state was renamed `current` in the component.
+        const reactStatus = status === 'active' ? 'current' : status
         return (
           <ComparisonPair
             key={status}
@@ -1094,7 +1096,7 @@ function App() {
             label={`WorkoutPill ${status}`}
             htmlContent={`<div class="workout-pill ${status}">${prefix}${names[status]}</div>`}
           >
-            <WorkoutPill name={names[status]} status={status} />
+            <WorkoutPill name={names[status]} status={reactStatus} />
           </ComparisonPair>
         )
       })}


### PR DESCRIPTION
## TD-04.10 — port the stale comparison specimen so the visual harness runs

`comparison.tsx` (the HTML-vs-React page the Playwright visual harness loads) called several atoms with prop shapes that no longer exist, so the React column threw and the **entire** harness (`test:visual:compare`) was unrunnable.

### Ported (stale → current)
- **TempoDisplay** — `concentric/hold/eccentric/idle` → `tempo:[n,n,n,n]` tuple. This one actually threw `tempo is not iterable`, blanking every specimen.
- **IntensityBar** — `level` 0–100 + `height`/`showLabel`/`target` → `level` 0–1 + `size`/`threshold`. The unknown props were being spread onto the DOM as invalid attributes (console errors).
- **WorkoutPill** — React `status="active"` → `"current"` (the state was renamed; the prototype markup + `compare-workout-pill-active` testid keep `active`).

### Result — harness is now fully runnable
- **Both columns render with 0 console/page errors** (verified headless: 72 compare pairs, 183 React atoms, all TempoDisplays/IntensityBars present, zero errors).
- `npx playwright test --config playwright.comparison.config.ts` runs end-to-end: **65 of 84 computed-style checks pass** (was 0 — the page threw).

### The 19 remaining failures are genuine drift (findings, not render bugs)
The comparison HTML is verbatim from the frozen `component-demo.html`; these are real places the React atoms have drifted from that frozen ground truth — exactly what the harness exists to surface:
- **TempoDisplay (3)** — React adds a "TEMPO" label and uses eccentric-first amber/gray vs the demo's concentric-first orange/blue/teal.
- **IntensityBar (7)** — API changed to `level` 0–1 with no percent label and no >100% over-states; the demo shows 20–130% with a % label.
- **PrBadge (3)** — fontSize 10 vs 12, border 0.12 vs 0.3, gap.
- **PlaceholderStrip single (1)** — React is a dashed transparent border; the demo is a solid `#3A3A3A` fill.
- **MuscleGroupChip (5)** — padding 3/9 vs 2/8, `Inter` vs `Nunito Sans`, fontSize 11 vs 10.

These feed the atom/design-fix backlog (e.g. TD-03.39). No component was modified (out of scope).

### On using the #59 ground-truth functions — deferred, with reasoning
I kept the existing inline HTML strings rather than swapping them for `htmlGroundTruth.tsx`. Both encode the **same** frozen demo, so the swap is a maintainability refactor (remove duplicated CSS/markup) that does **not** change any pass/fail result — while the `comparison.visual.test.ts` (44 cases) selects the HTML column by CSS class (`.weight-badge`, `.status-dot`, …) that the inline-style functions don't emit, so swapping requires rewriting all 44 selectors and risks re-breaking the now-runnable harness. Since the ticket's goal (harness runnable, both columns error-free) is met, I recommend the string→function consolidation be done in the 04.06 parity layer that owns those selectors, rather than bundled here. Happy to do it next if you'd prefer.

### Verify
- `pnpm lint` 0 errors (92 pre-existing warnings unchanged); `pnpm type-check` clean beyond the pre-existing react-hook-form failures. (specimen/ is outside tsc/eslint; the working dev-server render + Playwright run are the proof.)
- Scope: `specimen/comparison.tsx` only; no atoms/tests modified.