### PR TITLE
Add TD-05.03: runtime token-resolution Playwright test

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "specimen": "vite --config specimen/vite.config.ts",
     "specimen:compare": "vite --config specimen/vite.config.ts --open /comparison.html",
     "test:visual:compare": "playwright test --config playwright.comparison.config.ts",
+    "test:visual:tokens": "playwright test --config playwright.tokens.config.ts",
     "prepublishOnly": "tsup && vitest --run"
   },
   "peerDependencies": {

--- a/packages/ui/playwright.tokens.config.ts
+++ b/packages/ui/playwright.tokens.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * Token-resolution harness (TD-05.03). Mirrors playwright.comparison.config.ts
+ * but targets only `token-resolution.spec.ts`, served by the same specimen dev
+ * server.
+ */
+export default defineConfig({
+  testDir: './specimen',
+  testMatch: '**/token-resolution.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:5200',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1200, height: 900 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm specimen --port 5200',
+    port: 5200,
+    reuseExistingServer: true,
+    timeout: 60000,
+  },
+})

--- a/packages/ui/specimen/token-resolution.spec.ts
+++ b/packages/ui/specimen/token-resolution.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+import { colorTokenNames, expectedByTheme } from './token-source'
+
+/**
+ * Runtime token-resolution guard (TD-05.03).
+ *
+ * Loads the token specimen (NativeWind + theme CSS configured), and for every
+ * color token asserts the browser's COMPUTED color equals the source-of-truth
+ * value in `src/theme/config.ts` — in both dark and light. This complements
+ * TD-05.08's source-level config-vs-global.css drift guard: this one catches a
+ * theme-config change that silently alters what a token resolves to in the
+ * BROWSER (e.g. a wrong `var()` mapping or an unresolved variable).
+ *
+ * Scope: color tokens only. `-rgb` decompositions (not standalone colors) and
+ * the non-color font / easing / duration tokens are excluded — they don't
+ * surface as a comparable computed color; a `bg-*` swatch of them resolves to
+ * `rgba(0, 0, 0, 0)`.
+ */
+
+interface Rgba {
+  r: number
+  g: number
+  b: number
+  a: number
+}
+
+function parseColor(value: string): Rgba | null {
+  const v = value.trim()
+  const hex = v.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i)
+  if (hex) {
+    let h = hex[1]
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('')
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+      a: 1,
+    }
+  }
+  const rgb = v.match(/^rgba?\(([^)]+)\)$/i)
+  if (rgb) {
+    const parts = rgb[1].split(',').map((p) => p.trim())
+    if (parts.length < 3) return null
+    return {
+      r: Number(parts[0]),
+      g: Number(parts[1]),
+      b: Number(parts[2]),
+      a: parts[3] != null ? Number(parts[3]) : 1,
+    }
+  }
+  return null
+}
+
+function colorsEqual(a: Rgba | null, b: Rgba | null): boolean {
+  if (!a || !b) return false
+  return a.r === b.r && a.g === b.g && a.b === b.b && Math.abs(a.a - b.a) <= 0.02
+}
+
+test.describe('token resolution: browser computed value matches config source of truth', () => {
+  test('the token set is non-empty (guards a broken token source)', () => {
+    expect(colorTokenNames.length).toBeGreaterThan(50)
+  })
+
+  for (const theme of ['dark', 'light'] as const) {
+    test(`${theme}: all ${colorTokenNames.length} color tokens resolve to their config value`, async ({
+      page,
+    }) => {
+      await page.goto('/tokens.html', { waitUntil: 'networkidle' })
+      await page.evaluate((t) => {
+        document.documentElement.classList.toggle('light', t === 'light')
+      }, theme)
+
+      const expected = expectedByTheme[theme]
+      const mismatches: string[] = []
+
+      for (const name of colorTokenNames) {
+        const swatch = page.locator(`[data-token="${name}"]`)
+        await expect(swatch, `missing swatch for ${name}`).toHaveCount(1)
+        const computed = await swatch.evaluate(
+          (el) => getComputedStyle(el).backgroundColor,
+        )
+        if (!colorsEqual(parseColor(expected[name]), parseColor(computed))) {
+          mismatches.push(`${name}: config="${expected[name]}" computed="${computed}"`)
+        }
+      }
+
+      expect(mismatches, `Token resolution mismatches (${theme}):\n${mismatches.join('\n')}`).toEqual(
+        [],
+      )
+    })
+  }
+})

--- a/packages/ui/specimen/token-source.ts
+++ b/packages/ui/specimen/token-source.ts
@@ -1,0 +1,16 @@
+import { darkThemeCSSVars, lightThemeCSSVars } from '../src/theme/config'
+
+/**
+ * Shared source of truth for the token-resolution specimen + Playwright test.
+ * The color tokens whose runtime `var()` value the test asserts against the
+ * theme maps in `src/theme/config.ts`. Excludes `-rgb` decompositions (not
+ * standalone colors; used only inside `rgba(var(--x-rgb), a)`).
+ */
+export const colorTokenNames: string[] = Object.keys(darkThemeCSSVars).filter(
+  (name) => name.startsWith('--color-') && !name.endsWith('-rgb'),
+)
+
+export const expectedByTheme = {
+  dark: darkThemeCSSVars as Record<string, string>,
+  light: lightThemeCSSVars as Record<string, string>,
+} as const

--- a/packages/ui/specimen/tokens.html
+++ b/packages/ui/specimen/tokens.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Titan Design — Token Resolution</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        background: #101010;
+        color: #f3f4f6;
+        font-family: Inter, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./tokens.tsx"></script>
+  </body>
+</html>

--- a/packages/ui/specimen/tokens.tsx
+++ b/packages/ui/specimen/tokens.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import '../src/theme/global.css'
+import { colorTokenNames } from './token-source'
+
+/**
+ * Token-resolution specimen. Renders one swatch per color token, coloured by
+ * the token's CSS custom property (`var(--color-*)`) so the browser resolves it
+ * exactly as a NativeWind `bg-*` class would (tailwind.config.js maps every
+ * `bg-*` class to the same `var(--color-*)`). `token-resolution.spec.ts` reads
+ * each swatch's computed colour, in both themes, and asserts it matches the
+ * source-of-truth value in `src/theme/config.ts`.
+ */
+function App() {
+  return (
+    <div style={{ padding: 16, fontFamily: 'sans-serif' }}>
+      <h1 style={{ fontSize: 16, margin: '0 0 12px' }}>Token Resolution Specimen</h1>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+        {colorTokenNames.map((name) => (
+          <div
+            key={name}
+            data-token={name}
+            title={name}
+            style={{
+              width: 44,
+              height: 44,
+              backgroundColor: `var(${name})`,
+              border: '1px solid #808080',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const container = document.getElementById('root')
+if (container) {
+  createRoot(container).render(<App />)
+}


### PR DESCRIPTION
## TD-05.03 — runtime token-resolution guard

Asserts that every color token resolves in the **browser** to its source-of-truth value in `src/theme/config.ts`, in **both** dark and light. This complements TD-05.08's source-level config-vs-global.css drift guard: that one is static; this one catches a theme-config change that silently alters what a token resolves to **at runtime** — a wrong `var()` mapping, an unresolved variable — which a source-level check can't see.

### How it works
- **`specimen/token-source.ts`** — the shared color-token list, derived off `config.ts` (so new tokens are auto-covered), plus the expected per-theme value maps. Excludes `-rgb` decompositions (not standalone colors).
- **`specimen/tokens.{tsx,html}`** — a swatch per token, colored by `var(--color-*)` — exactly what a NativeWind `bg-*` class resolves to (tailwind.config.js maps every `bg-*` → the same `var(--color-*)`).
- **`specimen/token-resolution.spec.ts`** — for each theme (dark default, light via `.light` on `<html>`), reads each swatch's computed `backgroundColor` and compares it (parsed to rgba, alpha-tolerant) to the config value.
- **`playwright.tokens.config.ts`** + `test:visual:tokens` script — mirror the comparison harness on the same specimen dev server.

### Coverage
- **88 color tokens × 2 themes** (176 assertions), fully data-driven off `config.ts`.
- Out of scope, documented in the spec: `-rgb` decompositions and the non-color `--font-family-*` / `--ease-*` / `--duration-*` tokens — none surface as a comparable computed color (a `bg-*` swatch of them resolves to `rgba(0,0,0,0)`).

### Why `var()` swatches rather than literal `bg-*` classes
`tailwind.config.js` scans `content: ['./src/**/*']` only, so `bg-*` classes authored in `specimen/` would be purged (no CSS generated). Rendering each token via `var(--color-*)` tests the identical browser resolution the `bg-*` class produces, is purge-proof, and stays fully data-driven.

### Verification (ran end-to-end, chromium)
```
npx playwright test --config playwright.tokens.config.ts
  3 passed (3.5s)   # token-set guard + dark (88) + light (88)
```
Proved the guard bites: temporarily setting `--color-brand-primary: #123456` in global.css failed the dark test with
`--color-brand-primary: config="#FF7900" computed="rgb(18, 52, 86)"` (then reverted).

`pnpm lint` 0 errors (92 pre-existing warnings unchanged); `pnpm type-check` clean beyond the pre-existing react-hook-form failures; targeted `tsc` on the new files is clean. (specimen/ + root playwright config are outside the repo tsc/eslint scope; the passing Playwright run is the proof.) Baselines via `git show HEAD:` / edit-and-restore.