### PR TITLE
Fix TD-03.41: ExerciseCard weight-column header reflects unit (LBS/KG)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseCard.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.test.tsx
@@ -100,6 +100,30 @@ describe('ExerciseCard', () => {
       expect(headers).toHaveTextContent('RPE')
     })
 
+    it('shows the KG weight header when the unit is kg', () => {
+      render(
+        <ExerciseCard
+          {...expandedProps}
+          summary={{ sets: 3, reps: 8, weight: 84, unit: 'kg' }}
+        />,
+      )
+      const headers = screen.getByTestId('exercise-card-column-headers')
+      expect(headers).toHaveTextContent('KG')
+      expect(headers).not.toHaveTextContent('LBS')
+    })
+
+    it('derives the weight header from the sets unit when summary is absent', () => {
+      render(
+        <ExerciseCard
+          name="Squat"
+          state="expanded"
+          onToggle={vi.fn()}
+          sets={[{ mode: 'completed', setNumber: 1, reps: 8, weight: 60, unit: 'kg' }]}
+        />,
+      )
+      expect(screen.getByTestId('exercise-card-column-headers')).toHaveTextContent('KG')
+    })
+
     it('renders SetRow components', () => {
       render(<ExerciseCard {...expandedProps} />)
       const setRows = screen.getAllByTestId('set-row')

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -48,7 +48,10 @@ const COLORS = {
   borderDefault: 'var(--color-border-default)',
 }
 
-const COLUMN_HEADERS = ['SET', 'PREV', 'REPS', 'LBS', 'RPE'] as const
+/** Column headers; the weight column reflects the card's unit (LBS / KG). */
+function buildColumnHeaders(unit: 'lbs' | 'kg'): string[] {
+  return ['SET', 'PREV', 'REPS', unit.toUpperCase(), 'RPE']
+}
 
 function getSupersetBorderRadius(
   position: ExerciseCardProps['supersetPosition'],
@@ -228,6 +231,10 @@ function ExpandedCard({
 }: ExerciseCardProps) {
   const borderRadius = getSupersetBorderRadius(supersetPosition)
   const supersetMargin = getSupersetMargin(supersetPosition)
+  // Summary is the card-level authority for the weight column; fall back to the
+  // first set's unit, then lbs. (Mixed per-set units keep the card-level label.)
+  const unit = summary?.unit ?? sets?.[0]?.unit ?? 'lbs'
+  const columnHeaders = buildColumnHeaders(unit)
 
   return (
     <View
@@ -314,7 +321,7 @@ function ExpandedCard({
         }}
         testID="exercise-card-column-headers"
       >
-        {COLUMN_HEADERS.map((header, i) => {
+        {columnHeaders.map((header, i) => {
           const widths = [36, undefined, 44, 56, 36]
           const width = widths[i]
           const isFlex = width === undefined


### PR DESCRIPTION
## TD-03.41 — ExerciseCard column header hardcoded "LBS"

`COLUMN_HEADERS = ['SET','PREV','REPS','LBS','RPE']` was a module constant never conditioned on unit, so an expanded ExerciseCard rendered with `summary.unit: 'kg'` (or kg sets) showed **"LBS"** above kg values, even though WeightBadge/SetRow branch on unit correctly.

### Fix
- Replaced the constant with `buildColumnHeaders(unit)` → `['SET','PREV','REPS', unit.toUpperCase(), 'RPE']`.
- In `ExpandedCard`, resolve the unit as `summary?.unit ?? sets?.[0]?.unit ?? 'lbs'` — the card/summary level is authoritative for the column header; the first set's unit is a fallback (mixed per-set units keep the single card-level label, per the ticket). Other headers unchanged.

### Tests
- Existing "renders column headers" (lbs) still asserts `LBS`.
- Added: kg summary renders `KG` and not `LBS`; and the header derives from the sets' unit when `summary` is absent.

### Verify (no NEW failures beyond the known pre-existing react-hook-form)
- `pnpm lint` 0 errors (92 pre-existing warnings unchanged).
- `pnpm type-check` clean beyond the pre-existing react-hook-form failures.
- `pnpm test` 1412/1412 pass (+2 new); ExerciseCard suite 30/30; only the pre-existing react-hook-form example file fails.
- `pnpm build` pass.

Scope: `ExerciseCard.tsx` + its test only. Baselines via `git show HEAD:`.