### PR TITLE
Extract shared velocity/RPE performance scale onto a single token source (TD-03.43)

### DIFF
--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -2,6 +2,7 @@
 import { View, Text } from 'react-native'
 import { VelocityStrip } from './VelocityStrip'
 import { PrBadge, type PRType } from './PrBadge'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 
 export type SetRowMode = 'active' | 'completed' | 'history'
 
@@ -22,11 +23,13 @@ export interface SetRowProps {
   targets?: { reps: number; weight: number }
 }
 
+// RPE color maps onto the canonical performance scale (see workout-tokens.ts).
+// Direction is inverted vs velocity: higher RPE = harder = red.
 function getRPEColor(rpe: number): string {
-  if (rpe >= 9.5) return '#ff4757'
-  if (rpe >= 8.5) return '#ffa502'
-  if (rpe >= 7) return '#ffd43b'
-  return '#2ed573'
+  if (rpe >= 9.5) return WORKOUT_TOKENS.scale.red
+  if (rpe >= 8.5) return WORKOUT_TOKENS.scale.orange
+  if (rpe >= 7) return WORKOUT_TOKENS.scale.yellow
+  return WORKOUT_TOKENS.scale.green
 }
 
 function formatAccessibilityLabel(

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -1,6 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 
 export interface VelocityStripProps extends ViewProps {
   velocities: number[]
@@ -12,12 +13,8 @@ export interface VelocityStripProps extends ViewProps {
   className?: string
 }
 
-const VEL_COLORS = {
-  green: '#2ed573',
-  yellow: '#ffd43b',
-  orange: '#ffa502',
-  red: '#ff4757',
-}
+// Canonical scale shared with SetRow's RPE color (see theme/workout-tokens.ts).
+const VEL_COLORS = WORKOUT_TOKENS.scale
 
 export function getVelocityZoneColor(velocity: number): string {
   if (velocity >= 1.0) return 'vel-green'
@@ -164,7 +161,7 @@ export function VelocityStrip({
           paddingBottom: expanded ? 24 : 0,
           paddingHorizontal: expanded ? 6 : 0,
           paddingVertical: expanded ? undefined : 8,
-          backgroundColor: expanded ? '#1C1C1C' : 'transparent',
+          backgroundColor: expanded ? 'var(--color-surface-raised)' : 'transparent',
           overflow: expanded ? 'visible' : 'hidden',
         },
       ]}
@@ -191,7 +188,7 @@ export function VelocityStrip({
               {expanded && (
                 <Animated.View style={{ opacity: labelOpacity, alignItems: 'center', position: 'absolute', top: -13, left: 0, right: 0 }} accessibilityElementsHidden>
                   <Text
-                    style={{ fontSize: 8, fontWeight: '600', color: '#9CA3AF' }}
+                    style={{ fontSize: 8, fontWeight: '600', color: 'var(--color-text-secondary)' }}
                     testID={`velocity-label-${i}`}
                   >
                     {v.toFixed(2)}
@@ -252,7 +249,7 @@ export function VelocityStrip({
           <Text
             style={{
               fontSize: 10,
-              color: '#9CA3AF',
+              color: 'var(--color-text-secondary)',
               fontFamily: 'Inter, sans-serif',
             }}
           >
@@ -261,7 +258,7 @@ export function VelocityStrip({
           <Text
             style={{
               fontSize: 10,
-              color: '#9CA3AF',
+              color: 'var(--color-text-secondary)',
               fontFamily: 'Inter, sans-serif',
               ...getLossStyle(loss),
             }}

--- a/packages/ui/src/theme/workout-tokens.ts
+++ b/packages/ui/src/theme/workout-tokens.ts
@@ -3,8 +3,15 @@
  * Use these inline instead of Tailwind classes.
  */
 export const WORKOUT_TOKENS = {
-  // Velocity zones (not in Tailwind)
-  velocity: {
+  // Canonical 4-band performance scale — the single source for BOTH the
+  // VelocityStrip zone bars and the SetRow RPE color (TD-03.43). The direction
+  // is intentionally inverted between the two consumers: for velocity, green =
+  // fastest/best; for RPE, green = easiest. Each component maps its own
+  // thresholds onto these four colors. Kept as vivid data-viz values (distinct
+  // from the muted status tokens) and theme-independent, so — like the heatmap
+  // scale below — they are consumed inline as a JS import rather than CSS vars.
+  // A JS import also resolves on native RN, unlike var(--…) strings.
+  scale: {
     green: '#2ed573',
     yellow: '#ffd43b',
     orange: '#ffa502',


### PR DESCRIPTION
## What

The 4-band velocity/RPE color palette (`#2ed573 / #ffd43b / #ffa502 / #ff4757`) lived in **three unlinked copies** — `WORKOUT_TOKENS.velocity` (which had zero consumers), `VelocityStrip.VEL_COLORS`, and `SetRow.getRPEColor`. The two Workout components that must agree on the scale could silently drift.

This consolidates them onto a single source, `WORKOUT_TOKENS.scale`:

- **`workout-tokens.ts`** — renamed `velocity` → `scale` (values unchanged), documented as the canonical shared scale for both velocity zones (green = fastest) and RPE (green = easiest); the inverted direction is intentional.
- **`VelocityStrip.tsx`** — `VEL_COLORS` now references `WORKOUT_TOKENS.scale`; also tokenized the two remaining hardcoded theme colors: `#1C1C1C → var(--color-surface-raised)` and `#9CA3AF → var(--color-text-secondary)` (matching `SetRow`'s existing pattern).
- **`SetRow.tsx`** — `getRPEColor` reads from `WORKOUT_TOKENS.scale`.

## Why a JS import, not CSS vars

The scale is theme-independent vivid data-viz (same rationale as the existing `heatmap` scale), and a JS import resolves on **native RN as well as react-native-web** — matters for the mobile-convergence path (VLT-09.33), where `var(--…)` strings won't resolve natively.

## Behavior

Behavior-neutral in the dark (default) theme — identical hex throughout. The two `var()` swaps resolve to the same values in dark and now correctly adapt in light (previously the expanded strip stayed dark even in light theme).

## Verification

- `pnpm type-check` — 11 errors, **identical to main** (all pre-existing `react-hook-form` examples); zero in touched files
- `pnpm lint` — 0 errors
- `pnpm test` — 578 passed (incl. `config.completeness`, untouched — reused existing CSS vars)
- `pnpm build` — success, `tokens.css` regenerated

## Out of scope (noted for follow-up)

- SetRow set-type *badge* accent (`#ffa502`) is a distinct semantic use, not the intensity scale — intentionally left.
- Whether to later harmonize the scale onto titan's primitive palette (green.500/amber/red.600) is a separate design decision; this PR keeps the vivid values verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)