### PR TITLE
Give Table real ARIA table semantics instead of role="none" (TD-03.44)

### DIFF
--- a/packages/ui/src/components/custom/Table/Table.test.tsx
+++ b/packages/ui/src/components/custom/Table/Table.test.tsx
@@ -515,6 +515,33 @@ describe('Table', () => {
       expect(screen.getByRole('button', { name: /sort by name/i })).toBeInTheDocument()
     })
 
+    it('exposes real ARIA table semantics (table/rowgroup/row/columnheader/cell)', () => {
+      renderBasicTable()
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      // header rowgroup + body rowgroup
+      expect(screen.getAllByRole('rowgroup')).toHaveLength(2)
+      // 1 header row + 2 body rows
+      expect(screen.getAllByRole('row')).toHaveLength(3)
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3)
+      expect(screen.getAllByRole('cell')).toHaveLength(6)
+    })
+
+    it('sortable header reflects sort state via aria-sort', () => {
+      render(
+        <Table sortColumn="name" sortDirection="asc" onSort={vi.fn()}>
+          <TableHeader>
+            <TableRow>
+              <TableHeaderCell sortKey="name">Name</TableHeaderCell>
+              <TableHeaderCell sortKey="email">Email</TableHeaderCell>
+            </TableRow>
+          </TableHeader>
+        </Table>
+      )
+      const [name, email] = screen.getAllByRole('columnheader')
+      expect(name).toHaveAttribute('aria-sort', 'ascending')
+      expect(email).toHaveAttribute('aria-sort', 'none')
+    })
+
     it('pagination buttons have accessible labels', () => {
       render(
         <TablePagination

--- a/packages/ui/src/components/custom/Table/Table.tsx
+++ b/packages/ui/src/components/custom/Table/Table.tsx
@@ -101,7 +101,7 @@ export function Table({
     >
       <View className={cn('w-full', className)} {...props}>
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <View className="w-full min-w-full">
+          <View role="table" className="w-full min-w-full">
             {isLoading ? (
               <TableLoadingSkeleton rowCount={loadingRowCount} />
             ) : (
@@ -125,7 +125,7 @@ export interface TableHeaderProps {
 export function TableHeader({ children, className }: TableHeaderProps) {
   return (
     <View
-      accessibilityRole="none"
+      role="rowgroup"
       className={cn('bg-background-subtle rounded-t-lg', className)}
     >
       {children}
@@ -143,7 +143,7 @@ export interface TableBodyProps {
  */
 export function TableBody({ children, className }: TableBodyProps) {
   return (
-    <View accessibilityRole="none" className={className}>
+    <View role="rowgroup" className={className}>
       {children}
     </View>
   )
@@ -171,7 +171,7 @@ export function TableRow({
 }: TableRowProps) {
   return (
     <View
-      accessibilityRole="none"
+      role="row"
       className={cn(
         'flex-row border-b border-divider',
         isHoverable && 'web:hover:bg-interactive-hover',
@@ -212,6 +212,13 @@ export function TableHeaderCell({
   const { sortColumn, sortDirection, onSort } = useContext(TableContext)
   const isSorted = sortKey && sortColumn === sortKey
   const isSortable = !!sortKey && !!onSort
+  const ariaSort = isSorted
+    ? sortDirection === 'asc'
+      ? 'ascending'
+      : sortDirection === 'desc'
+        ? 'descending'
+        : 'none'
+    : 'none'
 
   const handlePress = (e: any) => {
     if (isSortable && sortKey) {
@@ -245,27 +252,35 @@ export function TableHeaderCell({
   )
 
   if (isSortable) {
+    // columnheader cell wraps the sort button so it carries proper table
+    // semantics (role + aria-sort) while the inner control keeps its button role.
     return (
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={`Sort by ${children}`}
-        onPress={handlePress}
+      <View
+        role="columnheader"
+        aria-sort={ariaSort}
         style={width ? { width } : { flex: 1 }}
-        className={cn(
-          'flex-row items-center px-4 py-3',
-          alignStyles[align],
-          'web:hover:bg-interactive-hover active:bg-interactive-active',
-          className
-        )}
-        {...props}
       >
-        {content}
-      </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Sort by ${children}`}
+          onPress={handlePress}
+          className={cn(
+            'flex-row items-center px-4 py-3',
+            alignStyles[align],
+            'web:hover:bg-interactive-hover active:bg-interactive-active',
+            className
+          )}
+          {...props}
+        >
+          {content}
+        </Pressable>
+      </View>
     )
   }
 
   return (
     <View
+      role="columnheader"
       style={width ? { width } : { flex: 1 }}
       className={cn(
         'flex-row items-center px-4 py-3',
@@ -306,6 +321,7 @@ export function TableCell({
 
   return (
     <View
+      role="cell"
       style={width ? { width } : { flex: 1 }}
       className={cn(
         'justify-center px-4 py-3.5',


### PR DESCRIPTION
## What

`TableHeader`/`TableBody`/`TableRow` hardcoded `accessibilityRole="none"` and cells carried no role, so screen readers saw the dashboard set-log (and every other `Table` consumer) as a flat pile of generic containers — forcing consumers to work around it with a region landmark + `aria-live` (VMCP-01.49).

Apply the W3C role model via the cross-platform `role` prop (react-native-web maps it to the DOM `role` attribute; native RN ignores unknown roles gracefully — same pattern already used by `MesoStatusCard`/`PrHistoryModal`):

| Element | role |
|---|---|
| inner grid `View` | `table` |
| `TableHeader` / `TableBody` | `rowgroup` |
| `TableRow` | `row` |
| `TableHeaderCell` | `columnheader` (+ `aria-sort` reflecting sort state) |
| `TableCell` | `cell` |

The **sortable** header wraps its sort control in the `columnheader` cell so the cell gets proper table semantics *and* the inner `Pressable` keeps its `button` role (the existing "sortable header has button role" test still passes).

## Verification

- `pnpm test src/components/custom/Table/` — 43 passed, incl. 2 new role/`aria-sort` regression tests and the existing `jest-axe` no-violations checks (new roles are valid ARIA)
- Full suite — 1414 passed (the one failing *file*, `examples/react-hook-form`, is a pre-existing missing-dep artifact that fails identically on `main`)
- `pnpm type-check` — 11 errors, identical to `main`; none in `Table.tsx`
- `pnpm lint` — 0 errors
- `pnpm build` — success

## Flows to the app

Once the mobile app bumps off `@titan-design/react-ui@0.1.1` (VLT-09.33), it inherits the same table semantics for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)