### PR TITLE
Sever react-native-body-highlighter from the titan barrel (TD-03.42)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-design/react-ui",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Cross-platform design system built on Gluestack UI",
   "author": "Henry Jewkes",
   "license": "MIT",
@@ -24,6 +24,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./bodymap": {
+      "react-native": "./src/bodymap.ts",
+      "types": "./dist/bodymap.d.ts",
+      "import": "./dist/bodymap.mjs",
+      "require": "./dist/bodymap.js"
     },
     "./theme": {
       "react-native": "./src/theme/index.ts",

--- a/packages/ui/src/bodymap.ts
+++ b/packages/ui/src/bodymap.ts
@@ -1,0 +1,37 @@
+// Subpath entry: @titan-design/react-ui/bodymap
+//
+// Isolates the runtime surface that depends on `react-native-body-highlighter`
+// (imported at module top-level by BodyMap.tsx and muscleTaxonomy.ts) so the
+// main barrel can stay body-highlighter-free and tree-shakeable. Everything
+// re-exported here transitively pulls that native SVG dependency; consumers who
+// render the muscle map import from this subpath instead of the root barrel.
+export { BodyMap, type BodyMapProps, type BodyMapData } from './components/custom/Workout/BodyMap'
+export {
+  BodyMapDetailPanel,
+  type BodyMapDetailPanelProps,
+  type ContributingExercise,
+  type UpcomingExercise,
+} from './components/custom/Workout/BodyMapDetailPanel'
+export {
+  TrainingStatusPage,
+  deriveTrainingSummary,
+  toBodyMapData,
+  type TrainingStatusPageProps,
+  type TrainingStatusMuscle,
+  type TrainingStatusSummary,
+} from './components/custom/Workout/TrainingStatusPage'
+export {
+  MuscleGroup,
+  SimpleMuscleGroup,
+  SIMPLE_TO_DETAILED,
+  DETAILED_TO_SIMPLE,
+  MUSCLE_TO_SVG_SLUGS,
+  MUSCLE_TO_CATEGORY,
+  MUSCLE_DISPLAY_NAMES,
+  SIMPLE_DISPLAY_NAMES,
+  DEFAULT_VOLUME_LANDMARKS,
+  VOLUME_STATUS_LABELS,
+  getHeatmapColor,
+  type MovementCategory,
+  type VolumeLandmarks,
+} from './components/custom/Workout/muscleTaxonomy'

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -79,20 +79,20 @@ export {
   type WorkoutDot,
   type WorkoutDotStatus,
 } from './CapacityBandChart'
-export { BodyMap, type BodyMapProps, type BodyMapData } from './BodyMap'
-export {
-  BodyMapDetailPanel,
-  type BodyMapDetailPanelProps,
-  type ContributingExercise,
-  type UpcomingExercise,
+// BodyMap / BodyMapDetailPanel / TrainingStatusPage depend on
+// `react-native-body-highlighter` at runtime. Their VALUE exports live behind the
+// `@titan-design/react-ui/bodymap` subpath to keep this barrel body-highlighter-free.
+// Type-only re-exports stay here (erased at build, so no runtime pull).
+export type { BodyMapProps, BodyMapData } from './BodyMap'
+export type {
+  BodyMapDetailPanelProps,
+  ContributingExercise,
+  UpcomingExercise,
 } from './BodyMapDetailPanel'
-export {
-  TrainingStatusPage,
-  deriveTrainingSummary,
-  toBodyMapData,
-  type TrainingStatusPageProps,
-  type TrainingStatusMuscle,
-  type TrainingStatusSummary,
+export type {
+  TrainingStatusPageProps,
+  TrainingStatusMuscle,
+  TrainingStatusSummary,
 } from './TrainingStatusPage'
 export {
   ProgramPlanningPage,
@@ -126,20 +126,14 @@ export {
   type ExerciseDetailStats,
   type VbtSummary,
 } from './ExerciseDetailPage'
-export {
+// muscleTaxonomy imports `react-native-body-highlighter` at runtime. Its value
+// exports (incl. the MuscleGroup / SimpleMuscleGroup enums) live behind the
+// `@titan-design/react-ui/bodymap` subpath. Only type-only re-exports stay here.
+export type {
   MuscleGroup,
   SimpleMuscleGroup,
-  SIMPLE_TO_DETAILED,
-  DETAILED_TO_SIMPLE,
-  MUSCLE_TO_SVG_SLUGS,
-  MUSCLE_TO_CATEGORY,
-  MUSCLE_DISPLAY_NAMES,
-  SIMPLE_DISPLAY_NAMES,
-  DEFAULT_VOLUME_LANDMARKS,
-  VOLUME_STATUS_LABELS,
-  getHeatmapColor,
-  type MovementCategory,
-  type VolumeLandmarks,
+  MovementCategory,
+  VolumeLandmarks,
 } from './muscleTaxonomy'
 export {
   ActiveWorkoutPage,

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    bodymap: 'src/bodymap.ts',
     'theme/index': 'src/theme/index.ts',
     'theme/tokens-css': 'src/theme/tokens-css.ts',
   },


### PR DESCRIPTION
## Problem

`@titan-design/react-ui`'s main barrel is a deep `export *` chain:
`src/index.ts` -> `components/index.ts` -> `custom/index.ts` -> `Workout/index.ts`.
That `Workout/index.ts` barrel re-exported, **at runtime**, `BodyMap`,
`BodyMapDetailPanel`, `TrainingStatusPage`, and `muscleTaxonomy`'s value
helpers (including the `MuscleGroup`/`SimpleMuscleGroup` enums). Both
`Workout/BodyMap.tsx` and `Workout/muscleTaxonomy.ts` import
`react-native-body-highlighter` at module top-level, and
`TrainingStatusPage.tsx` imports `BodyMap` at runtime.

Net effect: importing **anything** from the barrel (e.g. `{ Metric }`)
statically pulled `react-native-body-highlighter` — a JSX-preserved,
untranspiled native SVG package — into every consumer's module graph.
`sideEffects: false` is already set but cannot fix a **static** re-export.

## Change (approved breaking barrel-split)

- **New subpath** `@titan-design/react-ui/bodymap` (`src/bodymap.ts`)
  re-exports the body-highlighter-dependent runtime surface: `BodyMap`,
  `BodyMapDetailPanel`, `TrainingStatusPage` (+ `deriveTrainingSummary`,
  `toBodyMapData`), and all `muscleTaxonomy` value exports.
- **Barrel keeps type-only re-exports** (`export type { ... }`) for
  `BodyMapProps`, `BodyMapData`, `BodyMapDetailPanelProps`,
  `TrainingStatusPage*` types, `MuscleGroup`/`SimpleMuscleGroup` (as types),
  `MovementCategory`, `VolumeLandmarks` — erased at build, zero runtime pull.
- `tsup.config.ts`: added `bodymap` entry. `package.json`: added `./bodymap`
  to the exports map.
- **Version `0.2.7` -> `0.3.0`** (pre-1.0 breaking export change).

Note: `TrainingStatusPage`'s **values** had to move too (it imports `BodyMap`
at runtime); the ticket framed the surface as BodyMap + BodyMapDetailPanel +
muscleTaxonomy, but leaving TrainingStatusPage on the barrel would keep pulling
body-highlighter. Its types remain on the barrel.

## Grep-proof (after `pnpm build`)

| bundle | `react-native-body-highlighter` refs |
|---|---|
| `dist/index.js` (barrel, cjs) | **0** |
| `dist/index.mjs` (barrel, esm) | **0** |
| `dist/bodymap.js` (subpath, cjs) | **1** |
| `dist/bodymap.mjs` (subpath, esm) | **1** |

Coupling severed: the barrel no longer pulls body-highlighter; it lives only
behind the subpath.

## Verification (from `packages/ui`)

- `pnpm type-check` — 11 errors, all pre-existing in `examples/react-hook-form`
  (missing local `react-hook-form` dep); **zero new**.
- `pnpm lint` — 0 errors (92 pre-existing warnings; none in touched files).
- `pnpm test -- --run` — 87 files / 1414 tests pass; only the pre-existing
  `examples/react-hook-form/ReactHookForm.test.tsx` fails (stale local install,
  passes in CI).
- `pnpm build` — succeeds; emits `dist/bodymap.{js,mjs,d.ts}` and regenerates
  `dist/tokens.css`.

## Follow-ups (not in this PR)

- **Phase B (publish):** manual `pnpm publish` of `@titan-design/react-ui@0.3.0`
  (credentialed, user-run).
- **Phase C (consumer):** voltras-mcp dashboard migrates its BodyMap value import
  to `@titan-design/react-ui/bodymap` and scopes the rn-svg Vite plumbing to that
  subpath. Requires 0.3.0 published first.

## Deferred granularity

Scope kept tight to severing body-highlighter. No per-atom subpaths were added
(`Metric`, `Card*`, `ExerciseCard`, etc. stay on the now-clean barrel); further
subpath granularity can be a separate change if a consumer needs it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)