### PR TITLE
Move workout display formatting into a shared util components own

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -7,6 +7,7 @@ import { WeightBadge } from './WeightBadge'
 import { PrBadge } from './PrBadge'
 import { TempoDisplay } from './TempoDisplay'
 import { SetRow, type SetRowProps } from './SetRow'
+import { roundWeight } from '../../../utils/workout-format'
 
 export type ExerciseCardState = 'collapsed' | 'expanded' | 'upcoming'
 
@@ -99,7 +100,7 @@ function getSupersetMargin(
 
 function formatSummary(summary: ExerciseCardProps['summary']): string {
   if (!summary) return ''
-  return `${summary.sets}\u00D7${summary.reps} @ ${summary.weight} ${summary.unit}`
+  return `${summary.sets}\u00D7${summary.reps} @ ${roundWeight(summary.weight)} ${summary.unit}`
 }
 
 function formatAccessibilityLabel(
@@ -178,7 +179,7 @@ function CollapsedCard({
           )}
           {e1rm && (
             <WeightBadge
-              value={e1rm.value}
+              value={roundWeight(e1rm.value)}
               unit={e1rm.unit}
               size="sm"
               showIcon={false}
@@ -291,7 +292,7 @@ function ExpandedCard({
           )}
           {e1rm && (
             <WeightBadge
-              value={e1rm.value}
+              value={roundWeight(e1rm.value)}
               unit={e1rm.unit}
               size="sm"
               showIcon={false}

--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -2,7 +2,7 @@
 import { View, Text } from 'react-native'
 import { VelocityStrip } from './VelocityStrip'
 import { PrBadge, type PRType } from './PrBadge'
-import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { roundRpe, rpeColor, roundWeight } from '../../../utils/workout-format'
 
 export type SetRowMode = 'active' | 'completed' | 'history'
 
@@ -23,15 +23,6 @@ export interface SetRowProps {
   targets?: { reps: number; weight: number }
 }
 
-// RPE color maps onto the canonical performance scale (see workout-tokens.ts).
-// Direction is inverted vs velocity: higher RPE = harder = red.
-function getRPEColor(rpe: number): string {
-  if (rpe >= 9.5) return WORKOUT_TOKENS.scale.red
-  if (rpe >= 8.5) return WORKOUT_TOKENS.scale.orange
-  if (rpe >= 7) return WORKOUT_TOKENS.scale.yellow
-  return WORKOUT_TOKENS.scale.green
-}
-
 function formatAccessibilityLabel(
   setNumber: number,
   reps: number | null,
@@ -39,7 +30,7 @@ function formatAccessibilityLabel(
   unit: string,
 ): string {
   const repsText = reps != null ? `${reps} reps` : 'no reps'
-  const weightText = weight != null ? `at ${weight} ${unit}` : ''
+  const weightText = weight != null ? `at ${roundWeight(weight)} ${unit}` : ''
   return `Set ${setNumber}: ${repsText}${weightText ? ` ${weightText}` : ''}`
 }
 
@@ -139,7 +130,7 @@ export function SetRow({
           }}
         >
           {previous
-            ? `${previous.reps} x ${previous.weight}`
+            ? `${previous.reps} x ${roundWeight(previous.weight)}`
             : '\u2014'}
         </Text>
       </View>
@@ -188,7 +179,7 @@ export function SetRow({
             }}
             testID="set-row-target-weight"
           >
-            {targets.weight}
+            {roundWeight(targets.weight)}
           </Text>
         ) : (
           <Text
@@ -199,7 +190,7 @@ export function SetRow({
               color: weight != null ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
             }}
           >
-            {weight != null ? weight : '\u2014'}
+            {weight != null ? roundWeight(weight) : '\u2014'}
           </Text>
         )}
       </View>
@@ -213,10 +204,10 @@ export function SetRow({
             fontSize: 13,
             fontWeight: '600',
             fontFamily: 'Inter, sans-serif',
-            color: rpe != null ? getRPEColor(rpe) : 'var(--color-text-tertiary)',
+            color: rpe != null ? rpeColor(rpe) : 'var(--color-text-tertiary)',
           }}
         >
-          {rpe != null ? rpe : '\u2014'}
+          {rpe != null ? roundRpe(rpe) : '\u2014'}
         </Text>
       </View>
 

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -1,6 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useState, useCallback } from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
+import { roundTempo } from '../../../utils/workout-format'
 
 export interface TempoDisplayProps extends ViewProps {
   /** Tempo values: [eccentric, pauseBottom, concentric, pauseTop] in seconds */
@@ -76,7 +77,8 @@ export function TempoDisplay({
   ...props
 }: TempoDisplayProps) {
   const [showTooltip, setShowTooltip] = useState(false)
-  const [eccentric, pauseBottom, concentric, pauseTop] = tempo
+  // Round exact (unrounded) tempo seconds to the 1-dp display granularity.
+  const [eccentric, pauseBottom, concentric, pauseTop] = roundTempo(tempo)
   const isSm = size === 'sm'
   const fontSize = isSm ? 9 : 11
   const monoColor = TEXT_TERTIARY

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { formatVelocity } from '../../../utils/workout-format'
 
 export interface VelocityStripProps extends ViewProps {
   velocities: number[]
@@ -191,7 +192,7 @@ export function VelocityStrip({
                     style={{ fontSize: 8, fontWeight: '600', color: 'var(--color-text-secondary)' }}
                     testID={`velocity-label-${i}`}
                   >
-                    {v.toFixed(2)}
+                    {formatVelocity(v)}
                   </Text>
                 </Animated.View>
               )}
@@ -210,7 +211,7 @@ export function VelocityStrip({
                 }
                 testID={`velocity-bar-${i}`}
                 accessibilityRole="image"
-                accessibilityLabel={`Rep ${i + 1}: ${v.toFixed(2)} meters per second`}
+                accessibilityLabel={`Rep ${i + 1}: ${formatVelocity(v)} meters per second`}
               />
             </View>
           )
@@ -222,7 +223,7 @@ export function VelocityStrip({
                 style={{ flex: 1, height: '100%' }}
                 onPress={() => onRepPress(i, v)}
                 accessibilityRole="button"
-                accessibilityLabel={`Rep ${i + 1}: ${v.toFixed(2)} meters per second, tap for details`}
+                accessibilityLabel={`Rep ${i + 1}: ${formatVelocity(v)} meters per second, tap for details`}
                 testID={`velocity-bar-pressable-${i}`}
               >
                 {bar}
@@ -253,7 +254,7 @@ export function VelocityStrip({
               fontFamily: 'Inter, sans-serif',
             }}
           >
-            {meanZone} {'\u00B7'} {meanVelocity.toFixed(2)} m/s
+            {meanZone} {'\u00B7'} {formatVelocity(meanVelocity)} m/s
           </Text>
           <Text
             style={{

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -27,3 +27,13 @@ export type {
   FormErrors,
   FormTouched,
 } from './form'
+export {
+  roundRpe,
+  rpeColor,
+  roundWeight,
+  formatVelocity,
+  roundTempo,
+  formatSignedPct,
+  formatPrescription,
+} from './workout-format'
+export type { PrescriptionInput } from './workout-format'

--- a/packages/ui/src/utils/workout-format.test.ts
+++ b/packages/ui/src/utils/workout-format.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  roundRpe,
+  rpeColor,
+  roundWeight,
+  formatVelocity,
+  roundTempo,
+  formatSignedPct,
+  formatPrescription,
+} from './workout-format'
+import { WORKOUT_TOKENS } from '../theme/workout-tokens'
+
+describe('roundRpe', () => {
+  it('rounds an exact RPE to the nearest 0.5', () => {
+    expect(roundRpe(8.3)).toBe(8.5)
+    expect(roundRpe(8.24)).toBe(8)
+    expect(roundRpe(9)).toBe(9)
+    expect(roundRpe(7.75)).toBe(8)
+  })
+})
+
+describe('rpeColor', () => {
+  it('bands onto the canonical scale, red for hardest', () => {
+    expect(rpeColor(9.5)).toBe(WORKOUT_TOKENS.scale.red)
+    expect(rpeColor(8.5)).toBe(WORKOUT_TOKENS.scale.orange)
+    expect(rpeColor(7)).toBe(WORKOUT_TOKENS.scale.yellow)
+    expect(rpeColor(6.9)).toBe(WORKOUT_TOKENS.scale.green)
+  })
+})
+
+describe('roundWeight', () => {
+  it('rounds to a whole unit', () => {
+    expect(roundWeight(62.4)).toBe(62)
+    expect(roundWeight(62.5)).toBe(63)
+    expect(roundWeight(60)).toBe(60)
+  })
+})
+
+describe('formatVelocity', () => {
+  it('formats m/s to 2 decimal places', () => {
+    expect(formatVelocity(0.6)).toBe('0.60')
+    expect(formatVelocity(1.234)).toBe('1.23')
+  })
+})
+
+describe('roundTempo', () => {
+  it('rounds each phase to 1 dp', () => {
+    expect(roundTempo([2.34, 0, 1.06, 0.5])).toEqual([2.3, 0, 1.1, 0.5])
+  })
+})
+
+describe('formatSignedPct', () => {
+  it('renders a signed percentage from a ratio', () => {
+    expect(formatSignedPct(0.09)).toBe('+9%')
+    expect(formatSignedPct(-0.05)).toBe('-5%')
+    expect(formatSignedPct(0)).toBe('0%')
+  })
+})
+
+describe('formatPrescription', () => {
+  it('builds a full prescription string', () => {
+    expect(formatPrescription({ repsLow: 8, repsHigh: 10, weightLbs: 62, rpe: 8 })).toBe(
+      '8–10 @ 62 lb · RPE 8'
+    )
+  })
+
+  it('collapses an equal rep range to a single number', () => {
+    expect(formatPrescription({ repsLow: 5, repsHigh: 5, weightLbs: 100 })).toBe('5 @ 100 lb')
+  })
+
+  it('omits missing parts', () => {
+    expect(formatPrescription({ rpe: 7 })).toBe('RPE 7')
+    expect(formatPrescription({ weightLbs: 50 })).toBe('50 lb')
+  })
+
+  it('returns null when there is nothing to show', () => {
+    expect(formatPrescription(null)).toBeNull()
+    expect(formatPrescription(undefined)).toBeNull()
+    expect(formatPrescription({})).toBeNull()
+  })
+})

--- a/packages/ui/src/utils/workout-format.ts
+++ b/packages/ui/src/utils/workout-format.ts
@@ -1,0 +1,83 @@
+// Font mapping context: presentation-only helpers, no rendering.
+import { WORKOUT_TOKENS } from '../theme/workout-tokens'
+
+/**
+ * Presentation helpers for workout metrics.
+ *
+ * The data layer (`@voltras/workout-analytics` view-model derivations) supplies
+ * EXACT, unrounded values; these turn them into the rounded / banded / formatted
+ * forms a view renders. Keeping display munging here — in the design system, not
+ * the analytics layer — is the render half of the model↔render split: one view
+ * can round while another (or a hover) shows the exact value from the same real
+ * data. Workout components consume these so the rules live in one place.
+ */
+
+/** Round an exact RPE onto its conventional 0.5 granularity for display. */
+export function roundRpe(rpe: number): number {
+  return Math.round(rpe * 2) / 2
+}
+
+/**
+ * Color band for an RPE on the canonical performance scale. Higher RPE = harder
+ * = red (direction inverted vs velocity, which shares the same scale). Bands:
+ * `<7` green, `7–8.5` yellow, `8.5–9.5` orange, `≥9.5` red.
+ */
+export function rpeColor(rpe: number): string {
+  if (rpe >= 9.5) return WORKOUT_TOKENS.scale.red
+  if (rpe >= 8.5) return WORKOUT_TOKENS.scale.orange
+  if (rpe >= 7) return WORKOUT_TOKENS.scale.yellow
+  return WORKOUT_TOKENS.scale.green
+}
+
+/** Round a weight or e1RM to a whole unit for compact display. */
+export function roundWeight(weight: number): number {
+  return Math.round(weight)
+}
+
+/** Format an exact velocity (m/s) to the 2-dp string shown on the velocity strip. */
+export function formatVelocity(velocity: number): string {
+  return velocity.toFixed(2)
+}
+
+/** Round an exact tempo tuple (seconds) to 1 dp per phase for display. */
+export function roundTempo(
+  tempo: [number, number, number, number]
+): [number, number, number, number] {
+  return tempo.map((v) => Math.round(v * 10) / 10) as [number, number, number, number]
+}
+
+/** Signed percentage label for a deviation ratio, e.g. `+9%` / `-5%` / `0%`. */
+export function formatSignedPct(ratio: number): string {
+  const pct = Math.round(ratio * 100)
+  return `${pct > 0 ? '+' : ''}${pct}%`
+}
+
+/** Structured prescription for the active exercise (from the plan). */
+export interface PrescriptionInput {
+  repsLow?: number
+  repsHigh?: number
+  weightLbs?: number
+  rpe?: number
+}
+
+/**
+ * Human prescription string, e.g. `"8–10 @ 62 lb · RPE 8"`. `null` when there is
+ * nothing to show. Presentation-only: the plan supplies the numbers, this shapes
+ * the label.
+ */
+export function formatPrescription(p: PrescriptionInput | null | undefined): string | null {
+  if (p == null) return null
+  let reps: string | null = null
+  if (p.repsLow != null && p.repsHigh != null) {
+    reps = p.repsLow === p.repsHigh ? `${p.repsLow}` : `${p.repsLow}–${p.repsHigh}`
+  } else if (p.repsLow != null) {
+    reps = `${p.repsLow}`
+  }
+  const weight = p.weightLbs != null ? `${p.weightLbs} lb` : null
+  const head = [reps, weight].filter((s): s is string => s != null).join(' @ ')
+  const rpe = p.rpe != null ? `RPE ${p.rpe}` : null
+  const full = [head.length > 0 ? head : null, rpe]
+    .filter((s): s is string => s != null)
+    .join(' · ')
+  return full.length > 0 ? full : null
+}


### PR DESCRIPTION
## What

Adds `packages/ui/src/utils/workout-format.ts` — the **render half** of the dashboard↔mobile model↔render split — and routes the workout components through it.

Utils: `roundRpe`, `rpeColor`, `roundWeight`, `formatVelocity`, `roundTempo`, `formatSignedPct`, `formatPrescription`.

Components now format internally via the util instead of expecting pre-rounded input:
- **SetRow** — RPE rounds to 0.5 + bands color (`rpeColor` extracted from the old local `getRPEColor`); weight/prev/target weights round
- **TempoDisplay** — rounds tempo seconds to 1 dp
- **ExerciseCard** — rounds summary weight + e1RM value
- **VelocityStrip** — single-sources its `m/s` formatting through `formatVelocity`

## Why

Per the operator's model-vs-render principle: `@voltras/workout-analytics` (v1.5.0) now supplies **exact, unrounded** derivations; the design system owns display munging. `deriveRpe` is the template — WA owns the RIR derivation + null validity, titan owns rounding onto the 0.5 RPE bands. Keeping formatting in one shared util (not per-component, not in the data layer) means one view can round while another shows the exact value.

**Behavior-neutral for existing callers:** prop types are unchanged (numbers in) — components just round for display now. The rounding matches what the dashboard's mapper previously did, so rendered output is identical.

## Tests

- `workout-format.test.ts` — 10 tests for the util
- Existing SetRow/TempoDisplay/ExerciseCard/VelocityStrip suites (95 tests) still green — confirms behavior-neutrality

Ships alongside the already-merged TD-03.42 Phase A bodymap subpath (#71) in the **0.3.0** release.