### PR TITLE
Add TempoBar live phase-fill component (VW-18 S2)

### DIFF
--- a/packages/ui/src/components/custom/Workout/TempoBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { TempoBar } from './TempoBar'
+
+const meta: Meta<typeof TempoBar> = {
+  title: 'Custom/Workout/TempoBar',
+  component: TempoBar,
+  tags: ['autodocs'],
+  argTypes: {
+    activePhase: {
+      control: 'select',
+      options: [null, 'concentric', 'hold', 'eccentric'],
+      description: 'Phase currently in progress (null = idle)',
+    },
+    phaseElapsedMs: { control: 'number', description: 'Elapsed ms in the active phase' },
+    completed: { control: 'object', description: 'Completed phase durations (ms)' },
+    target: { control: 'object', description: 'Per-phase target durations (seconds)' },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 240 }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof TempoBar>
+
+// tempo target: 1s concentric, 1s hold-top, 3s eccentric
+const TARGET = { concentric: 1, hold: 1, eccentric: 3 }
+
+export const Idle: Story = {
+  args: { activePhase: null, phaseElapsedMs: 0, target: TARGET },
+}
+
+export const ConcentricActive: Story = {
+  args: { activePhase: 'concentric', phaseElapsedMs: 600, target: TARGET },
+}
+
+export const EccentricMidRep: Story = {
+  args: {
+    activePhase: 'eccentric',
+    phaseElapsedMs: 1500,
+    completed: { concentric: 900, hold: 1000 },
+    target: TARGET,
+  },
+}
+
+export const BehindPace: Story = {
+  args: {
+    activePhase: 'eccentric',
+    phaseElapsedMs: 4200,
+    completed: { concentric: 1600, hold: 1000 },
+    target: TARGET,
+  },
+}
+
+export const RepComplete: Story = {
+  args: {
+    activePhase: null,
+    phaseElapsedMs: 0,
+    completed: { concentric: 950, hold: 1050, eccentric: 3100 },
+    target: TARGET,
+  },
+}
+
+export const NoTarget: Story = {
+  args: {
+    activePhase: 'concentric',
+    phaseElapsedMs: 800,
+  },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <View style={{ gap: 20 }}>
+      <TempoBar activePhase={null} phaseElapsedMs={0} target={TARGET} />
+      <TempoBar activePhase="concentric" phaseElapsedMs={600} target={TARGET} />
+      <TempoBar
+        activePhase="eccentric"
+        phaseElapsedMs={1500}
+        completed={{ concentric: 900, hold: 1000 }}
+        target={TARGET}
+      />
+      <TempoBar
+        activePhase={null}
+        phaseElapsedMs={0}
+        completed={{ concentric: 950, hold: 1050, eccentric: 3100 }}
+        target={TARGET}
+      />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/TempoBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import {
+  TempoBar,
+  getTempoPacingState,
+  getTempoFillPct,
+  TEMPO_PACING,
+} from './TempoBar'
+
+const TARGET = { concentric: 1, hold: 1, eccentric: 3 }
+
+describe('getTempoPacingState', () => {
+  it('returns none when there is no target', () => {
+    expect(getTempoPacingState(1000, null)).toBe('none')
+  })
+
+  it('returns none for a sub-threshold target', () => {
+    expect(getTempoPacingState(1000, TEMPO_PACING.minPhaseDurationMs - 1)).toBe('none')
+  })
+
+  it('returns on-pace when within the behind threshold', () => {
+    expect(getTempoPacingState(1000, 1000)).toBe('on-pace')
+    expect(getTempoPacingState(1100, 1000)).toBe('on-pace') // +10%, under 15%
+  })
+
+  it('returns behind once elapsed exceeds the behind threshold', () => {
+    expect(getTempoPacingState(1200, 1000)).toBe('behind') // +20%, over 15%
+  })
+})
+
+describe('getTempoFillPct', () => {
+  it('fills fully when there is no target', () => {
+    expect(getTempoFillPct(500, null)).toBe(100)
+  })
+
+  it('is proportional to elapsed vs target', () => {
+    expect(getTempoFillPct(500, 1000)).toBe(50)
+  })
+
+  it('clamps at 100 when past target', () => {
+    expect(getTempoFillPct(2000, 1000)).toBe(100)
+  })
+})
+
+describe('TempoBar', () => {
+  it('renders the bar with phase labels', () => {
+    render(<TempoBar activePhase={null} phaseElapsedMs={0} target={TARGET} />)
+    expect(screen.getByTestId('tempo-bar')).toBeInTheDocument()
+    expect(screen.getByText('Con')).toBeInTheDocument()
+    expect(screen.getByText('Hold')).toBeInTheDocument()
+    expect(screen.getByText('Ecc')).toBeInTheDocument()
+  })
+
+  it('renders the active segment with an elapsed/target label', () => {
+    render(<TempoBar activePhase="concentric" phaseElapsedMs={600} target={TARGET} />)
+    expect(screen.getByTestId('tempo-segment-active-Con')).toBeInTheDocument()
+    expect(screen.getByText('0.6 / 1.0')).toBeInTheDocument()
+  })
+
+  it('shows only elapsed when the active phase has no target', () => {
+    render(<TempoBar activePhase="concentric" phaseElapsedMs={800} />)
+    expect(screen.getByText('0.8')).toBeInTheDocument()
+  })
+
+  it('marks a completed phase that hit its target with a check', () => {
+    render(
+      <TempoBar
+        activePhase="hold"
+        phaseElapsedMs={100}
+        completed={{ concentric: 950 }}
+        target={TARGET}
+      />,
+    )
+    expect(screen.getByTestId('tempo-segment-completed-Con')).toBeInTheDocument()
+    expect(screen.getByText('0.9 ✓')).toBeInTheDocument()
+  })
+
+  it('marks a completed phase that missed its target with a cross', () => {
+    render(
+      <TempoBar
+        activePhase="hold"
+        phaseElapsedMs={100}
+        completed={{ eccentric: 4000 }}
+        target={TARGET}
+      />,
+    )
+    // eccentric target 3s, 4s elapsed => behind => cross
+    expect(screen.getByText('4.0 ✗')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <TempoBar
+        activePhase="eccentric"
+        phaseElapsedMs={1500}
+        completed={{ concentric: 900, hold: 1000 }}
+        target={TARGET}
+      />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/custom/Workout/TempoBar.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.tsx
@@ -1,0 +1,215 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+
+const t = getSemanticColors('dark')
+
+/**
+ * Titan-local phase key. Consumers map their own movement-phase enum onto this
+ * presentational key at the call site — TempoBar owns rendering only.
+ */
+export type TempoPhaseKey = 'concentric' | 'hold' | 'eccentric'
+
+/** Pacing tuning shared with the fill/pacing helpers below. */
+export const TEMPO_PACING = {
+  behindThresholdPct: 0.15,
+  minPhaseDurationMs: 500,
+} as const
+
+export type TempoPacingState = 'none' | 'on-pace' | 'behind'
+
+/**
+ * Classify how a phase's elapsed time tracks against its target duration.
+ * `none` when there is no meaningful target; `behind` once elapsed exceeds the
+ * target by more than the behind threshold; `on-pace` otherwise.
+ */
+export function getTempoPacingState(
+  elapsedMs: number,
+  targetMs: number | null,
+): TempoPacingState {
+  if (!targetMs || targetMs < TEMPO_PACING.minPhaseDurationMs) return 'none'
+  const ratio = elapsedMs / targetMs
+  if (ratio > 1 + TEMPO_PACING.behindThresholdPct) return 'behind'
+  return 'on-pace'
+}
+
+/** Fill percentage (0–100) for the active phase; full when no target is set. */
+export function getTempoFillPct(elapsedMs: number, targetMs: number | null): number {
+  if (!targetMs) return 100
+  return Math.min(100, (elapsedMs / targetMs) * 100)
+}
+
+interface PhaseConfig {
+  label: string
+  color: string
+  flex: number
+}
+
+const PHASE_ORDER: TempoPhaseKey[] = ['concentric', 'hold', 'eccentric']
+
+const PHASE_CONFIG: Record<TempoPhaseKey, PhaseConfig> = {
+  concentric: { label: 'Con', color: t['status-success'], flex: 2 },
+  hold: { label: 'Hold', color: t['brand-primary'], flex: 1 },
+  eccentric: { label: 'Ecc', color: t['status-warning'], flex: 3 },
+}
+
+export interface TempoBarProps extends ViewProps {
+  /** Phase currently in progress, or null when idle/at rest. */
+  activePhase: TempoPhaseKey | null
+  /** Elapsed time (ms) within the active phase. */
+  phaseElapsedMs: number
+  /** Completed phase durations (ms) for the current rep, keyed by phase. */
+  completed?: Partial<Record<TempoPhaseKey, number>>
+  /** Optional per-phase target durations (seconds) for pacing feedback. */
+  target?: Partial<Record<TempoPhaseKey, number>>
+  className?: string
+}
+
+/**
+ * TempoBar — live rep phase progression indicator.
+ *
+ * Renders a segmented bar (Con → Hold → Ecc) where the active phase fills in
+ * real time and completed phases show their duration with a ✓/✗ pacing mark.
+ * Presentational only: the consumer derives which phase is active, its elapsed
+ * time, and completed durations, then feeds them in.
+ */
+export function TempoBar({
+  activePhase,
+  phaseElapsedMs,
+  completed,
+  target,
+  className,
+  ...props
+}: TempoBarProps) {
+  return (
+    <View className={className} testID="tempo-bar" {...props}>
+      {/* Phase labels */}
+      <View style={{ flexDirection: 'row', marginBottom: 4 }}>
+        {PHASE_ORDER.map((phase) => {
+          const config = PHASE_CONFIG[phase]
+          return (
+            <View key={phase} style={{ flex: config.flex, alignItems: 'center' }}>
+              <Text style={{ fontSize: 10, color: t['text-disabled'] }}>{config.label}</Text>
+            </View>
+          )
+        })}
+      </View>
+
+      {/* Segmented bar */}
+      <View style={{ flexDirection: 'row', gap: 2, height: 20 }}>
+        {PHASE_ORDER.map((phase) => {
+          const config = PHASE_CONFIG[phase]
+          const isActive = activePhase === phase
+          const completedMs = completed?.[phase]
+          const targetSec = target?.[phase]
+          const targetMs = targetSec != null ? targetSec * 1000 : null
+
+          return (
+            <View
+              key={phase}
+              style={{
+                flex: config.flex,
+                backgroundColor: alpha('#ffffff', 0.06),
+                borderRadius: 4,
+                overflow: 'hidden',
+              }}
+            >
+              {isActive ? (
+                <ActiveSegment
+                  config={config}
+                  phaseElapsedMs={phaseElapsedMs}
+                  targetMs={targetMs}
+                />
+              ) : completedMs != null ? (
+                <CompletedSegment config={config} completedMs={completedMs} targetMs={targetMs} />
+              ) : null}
+            </View>
+          )
+        })}
+      </View>
+    </View>
+  )
+}
+
+function ActiveSegment({
+  config,
+  phaseElapsedMs,
+  targetMs,
+}: {
+  config: PhaseConfig
+  phaseElapsedMs: number
+  targetMs: number | null
+}) {
+  const pacing = getTempoPacingState(phaseElapsedMs, targetMs)
+  const barColor = pacing === 'behind' ? t['status-error'] : config.color
+  const fillPct = getTempoFillPct(phaseElapsedMs, targetMs)
+
+  const label = targetMs
+    ? `${formatDuration(phaseElapsedMs)} / ${formatDuration(targetMs)}`
+    : formatDuration(phaseElapsedMs)
+
+  return (
+    <View style={{ height: '100%', position: 'relative' }} testID={`tempo-segment-active-${config.label}`}>
+      <View
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: `${fillPct}%`,
+          backgroundColor: alpha(barColor, 0.3),
+          borderRadius: 4,
+        }}
+      />
+      <View
+        style={{
+          height: '100%',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Text style={{ fontSize: 12, fontWeight: '700', color: barColor }}>{label}</Text>
+      </View>
+    </View>
+  )
+}
+
+function CompletedSegment({
+  config,
+  completedMs,
+  targetMs,
+}: {
+  config: PhaseConfig
+  completedMs: number
+  targetMs: number | null
+}) {
+  const pacing = getTempoPacingState(completedMs, targetMs)
+  const hitTarget = pacing !== 'behind'
+  const indicator =
+    targetMs && targetMs >= TEMPO_PACING.minPhaseDurationMs ? (hitTarget ? ' ✓' : ' ✗') : ''
+
+  return (
+    <View
+      style={{
+        height: '100%',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: alpha(config.color, 0.15),
+      }}
+      testID={`tempo-segment-completed-${config.label}`}
+    >
+      <Text style={{ fontSize: 12, fontWeight: '500', color: alpha(config.color, 0.7) }}>
+        {formatDuration(completedMs)}
+        {indicator}
+      </Text>
+    </View>
+  )
+}
+
+function formatDuration(ms: number): string {
+  const s = ms / 1000
+  return s < 10 ? s.toFixed(1) : Math.round(s).toString()
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -9,6 +9,15 @@ export { PrBadge, type PrBadgeProps, type PRType } from './PrBadge'
 export { StatusDot, type StatusDotVariant, type StatusDotProps } from './StatusDot'
 export { PlaceholderStrip, type PlaceholderStripProps } from './PlaceholderStrip'
 export { TempoDisplay, type TempoDisplayProps } from './TempoDisplay'
+export {
+  TempoBar,
+  type TempoBarProps,
+  type TempoPhaseKey,
+  type TempoPacingState,
+  TEMPO_PACING,
+  getTempoPacingState,
+  getTempoFillPct,
+} from './TempoBar'
 export { DeviationBar, type DeviationBarProps } from './DeviationBar'
 export { IntensityBar, type IntensityBarProps } from './IntensityBar'
 export { WorkoutPill, type WorkoutPillProps, type WorkoutPillStatus } from './WorkoutPill'


### PR DESCRIPTION
## What

Ports the mobile app's live rep-tempo phase-fill bar (`voltras/mobile/src/components/exercise/TempoBar.tsx`) **up into titan** as a new presentational component, alongside the existing static `TempoDisplay` badge. This is **VW-18 slice S2** — bidirectional convergence: the dashboard gains live tempo now, and mobile consumes it back after the titan bump (S1, already landed).

`TempoBar` renders a segmented **Con → Hold → Ecc** bar where the active phase fills in real time and completed phases show their duration with a ✓/✗ pacing mark. Behind-pace turns the active segment red.

## Design — framework-agnostic

titan owns *rendering only*. The consumer maps its own movement-phase enum onto titan's local `TempoPhaseKey` (`'concentric' | 'hold' | 'eccentric'`) and supplies elapsed / completed / target state. **No `@voltras/workout-analytics` dependency reaches titan** (the mobile source imported `MovementPhase` from WA; that stays at the call site).

Exports the pacing/fill helpers (`getTempoPacingState`, `getTempoFillPct`, `TEMPO_PACING`) so mobile can drop its local copies when it adopts this.

## Verify (no hardware)

- `type-check` — 0 new errors (11 pre-existing `react-hook-form` example errors unchanged on main)
- `vitest` — 13 new TempoBar tests (pacing/fill math + rendered output); full suite **1437 pass** (only the pre-existing `react-hook-form` example file fails to resolve its missing dep)
- `eslint` touched files — clean
- `build` (tsup + tokens) — success
- **Storybook-vet** — idle / concentric-active / eccentric-mid-rep / rep-complete / behind-pace-red all render correctly, **0 console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)