### PR TITLE
Cross-platform ThemeProvider + native-safe SetRow (native-theming Wave 1)

### DIFF
--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -106,11 +106,11 @@ export function SetRow({
           </Text>
         ) : (
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 13,
               fontWeight: '600',
               fontFamily: 'Inter, sans-serif',
-              color: 'var(--color-text-secondary)',
             }}
           >
             {setNumber}
@@ -123,10 +123,10 @@ export function SetRow({
         testID="set-row-previous"
       >
         <Text
+          className="text-text-secondary"
           style={{
             fontSize: 12,
             fontFamily: 'Inter, sans-serif',
-            color: 'var(--color-text-secondary)',
           }}
         >
           {previous
@@ -141,11 +141,11 @@ export function SetRow({
       >
         {isActive && reps == null && targets ? (
           <Text
+            className="text-text-tertiary"
             style={{
               fontSize: 13,
               fontStyle: 'italic',
               fontFamily: 'Inter, sans-serif',
-              color: 'var(--color-text-tertiary)',
             }}
             testID="set-row-target-reps"
           >
@@ -153,11 +153,11 @@ export function SetRow({
           </Text>
         ) : (
           <Text
+            className={reps != null ? 'text-text-primary' : 'text-text-tertiary'}
             style={{
               fontSize: 14,
               fontWeight: '600',
               fontFamily: 'Inter, sans-serif',
-              color: reps != null ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
             }}
           >
             {reps != null ? reps : '\u2014'}
@@ -171,11 +171,11 @@ export function SetRow({
       >
         {isActive && weight == null && targets ? (
           <Text
+            className="text-text-tertiary"
             style={{
               fontSize: 13,
               fontStyle: 'italic',
               fontFamily: 'Inter, sans-serif',
-              color: 'var(--color-text-tertiary)',
             }}
             testID="set-row-target-weight"
           >
@@ -183,11 +183,11 @@ export function SetRow({
           </Text>
         ) : (
           <Text
+            className={weight != null ? 'text-text-primary' : 'text-text-tertiary'}
             style={{
               fontSize: 14,
               fontWeight: '600',
               fontFamily: 'Inter, sans-serif',
-              color: weight != null ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
             }}
           >
             {weight != null ? roundWeight(weight) : '\u2014'}
@@ -200,11 +200,14 @@ export function SetRow({
         testID="set-row-rpe"
       >
         <Text
+          className={rpe != null ? undefined : 'text-text-tertiary'}
           style={{
             fontSize: 13,
             fontWeight: '600',
             fontFamily: 'Inter, sans-serif',
-            color: rpe != null ? rpeColor(rpe) : 'var(--color-text-tertiary)',
+            // rpeColor returns a concrete hex (native-safe); only the tertiary
+            // fallback needs the className token.
+            color: rpe != null ? rpeColor(rpe) : undefined,
           }}
         >
           {rpe != null ? roundRpe(rpe) : '\u2014'}

--- a/packages/ui/src/test/nativewind-stub.ts
+++ b/packages/ui/src/test/nativewind-stub.ts
@@ -1,0 +1,13 @@
+// Web test stub for `nativewind`.
+//
+// The real `nativewind` pulls react-native-css-interop → RN's Flow-typed
+// sources, which the jsdom/react-native-web test environment can't parse
+// ("Unexpected token 'typeof'"). Only `ThemeProvider` imports nativewind (for
+// `vars()`), and only for its NATIVE behavior — on web the color tokens resolve
+// from `global.css`, so an identity `vars()` is a faithful web stand-in.
+// Aliased in `vitest.config.ts`; the real package is used at build/native.
+
+/** Identity stand-in for nativewind's `vars()` — returns the token map as-is. */
+export function vars(values: Record<string, string>): Record<string, string> {
+  return values
+}

--- a/packages/ui/src/theme/ThemeProvider.test.tsx
+++ b/packages/ui/src/theme/ThemeProvider.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Text } from 'react-native'
+import { ThemeProvider } from './ThemeProvider'
+
+describe('ThemeProvider', () => {
+  it('renders its children', () => {
+    render(
+      <ThemeProvider>
+        <Text>inside</Text>
+      </ThemeProvider>,
+    )
+    expect(screen.getByText('inside')).toBeInTheDocument()
+  })
+
+  it('accepts a light mode without error', () => {
+    render(
+      <ThemeProvider mode="light">
+        <Text>light</Text>
+      </ThemeProvider>,
+    )
+    expect(screen.getByText('light')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+// Cross-platform theme provider (TD native-theming).
+//
+// Registers titan's semantic color tokens as runtime CSS variables via
+// nativewind's `vars()` so that className color tokens (`text-text-secondary`,
+// `bg-surface-raised`, `border-border`, …) resolve on NATIVE React Native — the
+// native equivalent of the `:root {}` block `global.css` provides on web.
+//
+// Why this exists: titan's Workout organisms reference semantic colors as CSS
+// variables. On web (the dashboard, react-native-web) those come from
+// `global.css`. On native (the mobile app) nothing defined them, so any titan
+// component using a `--color-*` token rendered with an unresolved (black) color.
+// Wrap the mobile app root in `<ThemeProvider>` and the tokens resolve on-device.
+//
+// The var maps are the SAME canonical `darkThemeCSSVars` / `lightThemeCSSVars`
+// that generate `global.css`, so native and web resolve to identical values.
+import { vars } from 'nativewind'
+import { View, type ViewProps } from 'react-native'
+import { darkThemeCSSVars, lightThemeCSSVars } from './config'
+
+export type ThemeProviderMode = 'dark' | 'light'
+
+// Precomputed once — `vars()` is pure, so the same style object is reused across
+// renders. Native == web because these are the maps `tokens-css` emits.
+const MODE_VARS = {
+  dark: vars(darkThemeCSSVars),
+  light: vars(lightThemeCSSVars),
+}
+
+export interface ThemeProviderProps extends ViewProps {
+  /** Theme mode to register. Mobile is dark-only today; defaults to `dark`. */
+  mode?: ThemeProviderMode
+}
+
+/**
+ * Wrap the app root so descendant titan components' `--color-*` className tokens
+ * resolve on native. Fills its parent (`flex: 1`) by default; pass `style` to
+ * override. On web it is harmless (the dashboard already loads `global.css`).
+ */
+export function ThemeProvider({
+  mode = 'dark',
+  style,
+  children,
+  ...props
+}: ThemeProviderProps): React.JSX.Element {
+  return (
+    <View style={[MODE_VARS[mode], { flex: 1 }, style]} {...props}>
+      {children}
+    </View>
+  )
+}

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -4,6 +4,7 @@ export * from './config'
 export * from './shadows'
 export * from './elevation'
 export * from './manifest'
+export { ThemeProvider, type ThemeProviderProps, type ThemeProviderMode } from './ThemeProvider'
 
 // Re-export commonly used items
 export { getSemanticColors, type ThemeMode } from './tokens/semantic'

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import {
@@ -40,6 +41,13 @@ export default defineConfig({
     alias: [
       ...svgWebAliases,
       { find: /^react-native$/, replacement: 'react-native-web' },
+      // nativewind pulls RN Flow sources jsdom can't parse; only ThemeProvider
+      // imports it (for native `vars()`). Stub it on web — tokens come from
+      // global.css there. Real package used at build/native.
+      {
+        find: /^nativewind$/,
+        replacement: fileURLToPath(new URL('./src/test/nativewind-stub.ts', import.meta.url)),
+      },
       { find: '@', replacement: './src' },
     ],
     extensions: webResolveExtensions,


### PR DESCRIPTION
## What

titan's Workout organisms reference semantic colors as `var(--color-*)` CSS variables in **inline styles**. Those resolve on web (dashboard, via `global.css`) but **native RN can't parse them** → any such organism renders black/invisible on the mobile app. This is the blocker for the mobile `SetLog→SetRow` swap (VLT-09.33a) and the dashboard↔mobile convergence keystone.

**This PR is Wave 1: the shared infra + the reference component** that the remaining ~20 organisms follow.

## Two-part fix

1. **`ThemeProvider`** (`theme/ThemeProvider.tsx`) — registers the semantic color tokens as runtime CSS variables via nativewind `vars()`, the native equivalent of `global.css`'s `:root`. Built from the **same canonical `darkThemeCSSVars`/`lightThemeCSSVars`** maps that generate `global.css`, so native == web. Mobile wraps its app root in it.
2. **`SetRow`** — convert its 7 inline `var()` colors → nativewind className tokens (`text-text-secondary`, …), which resolve against the provider's `vars()` on native *and* `global.css` on web. Dynamic `rpeColor(rpe)` stays inline (already concrete hex).

## Test infra

Alias `nativewind` → a tiny web stub in `vitest.config.ts` — it pulls RN Flow sources jsdom can't parse, and only `ThemeProvider` imports it (for native `vars()`; on web tokens come from `global.css`).

## Verify (web)

- `type-check` — 0 new errors (11 pre-existing react-hook-form)
- `vitest` — **1439 pass** (+2 provider); SetRow 22 pass
- `lint` — clean
- `build` (tsup) — CJS+ESM+DTS green
- **Storybook-vet SetRow** — all variants render correct colors (secondary set#, primary reps/weight, `rpeColor` RPE, tertiary targets, orange next-set highlight); **0 console errors**

Native rendering is bench-confirmed when mobile mounts the provider.

## Next
Wave 2 (fleet): the other ~20 `var()`-organisms converted to className tokens using this SetRow as the template. Wave 3: mobile SetLog→SetRow swap (now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)