### PR TITLE
Native-safe the remaining 20 Workout organisms (native-theming Wave 2)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ActiveWorkoutPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ActiveWorkoutPage.tsx
@@ -6,14 +6,9 @@ import { InputBar } from './InputBar'
 import { RestTimer } from './RestTimer'
 import { SupersetWrapper } from './SupersetWrapper'
 import { type SetRowProps } from './SetRow'
+import { resolveColor } from '../../../theme/resolve-color'
 
-const SURFACE_ELEVATED = 'var(--color-surface-elevated)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
-const PAGE_BG = 'var(--color-background-base)'
 
 /** Where an exercise sits in the during-workout flow. */
 export type ActiveExerciseStatus = 'completed' | 'active' | 'upcoming'
@@ -232,11 +227,11 @@ function WorkoutHeader({
         <View style={{ flexShrink: 1 }}>
           <Text
             accessibilityRole="header"
+            className="text-text-primary"
             style={{
               fontSize: 20,
               fontFamily: '"Space Grotesk", sans-serif',
               fontWeight: '700',
-              color: TEXT_PRIMARY,
             }}
             testID="active-workout-page-title"
           >
@@ -244,11 +239,11 @@ function WorkoutHeader({
           </Text>
           {subtitle != null && (
             <Text
+              className="text-text-secondary"
               style={{
                 marginTop: 2,
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_SECONDARY,
               }}
               testID="active-workout-page-subtitle"
             >
@@ -269,13 +264,13 @@ function WorkoutHeader({
             {`${progress.completedExercises}/${progress.totalExercises}`}
           </Text>
           <Text
+            className="text-text-tertiary"
             style={{
               fontSize: 10,
               fontFamily: 'Inter, sans-serif',
               fontWeight: '600',
               letterSpacing: 0.4,
               textTransform: 'uppercase',
-              color: TEXT_TERTIARY,
             }}
           >
             {`${progress.completedSets}/${progress.totalSets} sets`}
@@ -283,7 +278,8 @@ function WorkoutHeader({
         </View>
       </View>
       <View
-        style={{ height: 4, backgroundColor: BORDER_DEFAULT, borderRadius: 2 }}
+        className="bg-border"
+        style={{ height: 4, borderRadius: 2 }}
         testID="active-workout-page-progress-track"
       >
         <View
@@ -314,10 +310,9 @@ function ExerciseList({ groups, focusedId, onToggle }: ExerciseListProps) {
           return (
             <View
               key={group.exercise.id}
+              className="bg-surface-elevated border-border"
               style={{
-                backgroundColor: SURFACE_ELEVATED,
                 borderWidth: 1,
-                borderColor: BORDER_DEFAULT,
                 borderRadius: 12,
               }}
             >
@@ -395,8 +390,8 @@ export function ActiveWorkoutPage({
 
   return (
     <View
-      className={className}
-      style={{ position: 'relative', width: 390, backgroundColor: PAGE_BG }}
+      className={['bg-background-base', className].filter(Boolean).join(' ')}
+      style={{ position: 'relative', width: 390 }}
       accessibilityRole={'main' as ViewProps['accessibilityRole']}
       aria-label={title}
       testID="active-workout-page"
@@ -409,7 +404,7 @@ export function ActiveWorkoutPage({
 
       {(showRest || showInput) && (
         <View
-          style={{ borderTopWidth: 1, borderTopColor: BORDER_DEFAULT }}
+          style={{ borderTopWidth: 1, borderTopColor: resolveColor('border-default') }}
           testID="active-workout-page-bottom-bar"
         >
           {showRest && rest != null ? (

--- a/packages/ui/src/components/custom/Workout/BodyMap.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMap.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 import BodyHighlighter, { type ExtendedBodyPart, type Slug } from 'react-native-body-highlighter'
 import { cn } from '../../../utils/cn'
+import { resolveColor } from '../../../theme/resolve-color'
 import {
   MuscleGroup,
   SimpleMuscleGroup,
@@ -27,8 +28,6 @@ const Body = ((BodyHighlighter as unknown as { default?: typeof BodyHighlighter 
 const OUTLINE_FILL = 'rgba(255,255,255,0.08)'
 const OUTLINE_BORDER = 'rgba(255,255,255,0.12)'
 const BODY_SCALE = 0.8 // 200x400 intrinsic -> ~160x320 px
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
 
 export interface BodyMapData {
   muscleGroup: MuscleGroup
@@ -217,10 +216,10 @@ export function BodyMap({
 
       {legend.length === 0 ? (
         <Text
+          className="text-text-secondary"
           style={{
             marginTop: 8,
             fontSize: 12,
-            color: TEXT_SECONDARY,
             textAlign: 'center',
             fontFamily: 'Inter, sans-serif',
           }}
@@ -276,7 +275,7 @@ function ViewToggle({ view, onViewChange }: ViewToggleProps) {
               borderRadius: 9999,
               backgroundColor: active ? 'rgba(255,121,0,0.16)' : 'transparent',
               borderWidth: 1,
-              borderColor: active ? '#FF7900' : 'var(--color-border-strong)',
+              borderColor: active ? '#FF7900' : resolveColor('border-strong'),
             }}
             testID={`body-map-toggle-${side}`}
           >
@@ -285,7 +284,7 @@ function ViewToggle({ view, onViewChange }: ViewToggleProps) {
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: active ? '700' : '500',
-                color: active ? '#FF7900' : TEXT_SECONDARY,
+                color: active ? '#FF7900' : resolveColor('text-secondary'),
                 textTransform: 'capitalize',
               }}
             >
@@ -313,6 +312,7 @@ function MuscleButton({ entry, highlighted, onMusclePress }: MuscleButtonProps) 
       accessibilityRole="button"
       accessibilityLabel={label}
       aria-pressed={highlighted}
+      className="bg-surface-raised"
       style={{
         flexDirection: 'row',
         alignItems: 'center',
@@ -321,8 +321,7 @@ function MuscleButton({ entry, highlighted, onMusclePress }: MuscleButtonProps) 
         paddingVertical: 3,
         borderRadius: 9999,
         borderWidth: 1,
-        borderColor: highlighted ? '#FF7900' : 'var(--color-border-default)',
-        backgroundColor: 'var(--color-surface-raised)',
+        borderColor: highlighted ? '#FF7900' : resolveColor('border-default'),
       }}
       testID={`body-map-muscle-${entry.key}`}
     >
@@ -332,11 +331,11 @@ function MuscleButton({ entry, highlighted, onMusclePress }: MuscleButtonProps) 
         testID={`body-map-muscle-dot-${entry.key}`}
       />
       <Text
+        className="text-text-primary"
         style={{
           fontSize: 11,
           fontFamily: 'Inter, sans-serif',
           fontWeight: '500',
-          color: TEXT_PRIMARY,
         }}
         accessibilityElementsHidden
       >

--- a/packages/ui/src/components/custom/Workout/BodyMapDetailPanel.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMapDetailPanel.tsx
@@ -19,14 +19,7 @@ import {
   type VolumeStatus,
 } from './muscleTaxonomy'
 
-const SURFACE_ELEVATED = 'var(--color-surface-elevated)'
-const SURFACE_RAISED = 'var(--color-surface-raised)'
-const BORDER_STRONG = 'var(--color-border-strong)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
 
 /** Volume track gradient: status-info (blue) -> result-improve (teal) -> status-error (red). */
 const VOLUME_GRADIENT = 'linear-gradient(90deg, #2196F3 0%, #14B8A6 50%, #D14343 100%)'
@@ -205,8 +198,8 @@ export function BodyMapDetailPanel({
         accessibilityRole={'dialog' as ViewProps['accessibilityRole']}
         accessibilityLabel={dialogLabel}
         aria-label={dialogLabel}
+        className="bg-surface-elevated"
         style={{
-          backgroundColor: SURFACE_ELEVATED,
           borderTopLeftRadius: 16,
           borderTopRightRadius: 16,
           maxHeight: '88%',
@@ -224,7 +217,8 @@ export function BodyMapDetailPanel({
           testID="body-map-detail-panel-handle"
         >
           <View
-            style={{ width: 40, height: 4, borderRadius: 2, backgroundColor: BORDER_STRONG }}
+            className="bg-border-strong"
+            style={{ width: 40, height: 4, borderRadius: 2 }}
             accessibilityElementsHidden
           />
         </Pressable>
@@ -242,11 +236,11 @@ export function BodyMapDetailPanel({
             <View className="flex-row items-center" style={{ gap: 8, flexShrink: 1 }}>
               <Text
                 accessibilityRole="header"
+                className="text-text-primary"
                 style={{
                   fontSize: 16,
                   fontFamily: '"Space Grotesk", sans-serif',
                   fontWeight: '700',
-                  color: TEXT_PRIMARY,
                 }}
                 testID="body-map-detail-panel-title"
               >
@@ -269,13 +263,14 @@ export function BodyMapDetailPanel({
               style={{ padding: 4, margin: -4 }}
               testID="body-map-detail-panel-close"
             >
-              <Text style={{ fontSize: 22, lineHeight: 22, color: TEXT_SECONDARY }}>{'×'}</Text>
+              <Text className="text-text-secondary" style={{ fontSize: 22, lineHeight: 22 }}>{'×'}</Text>
             </Pressable>
           </View>
 
           {lastTrained != null && (
             <Text
-              style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+              className="text-text-secondary"
+              style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}
               testID="body-map-detail-panel-last-trained"
             >
               {`Last trained ${lastTrained}`}
@@ -288,10 +283,10 @@ export function BodyMapDetailPanel({
               style={{ marginBottom: 6 }}
               accessibilityElementsHidden
             >
-              <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', fontWeight: '600', color: TEXT_TERTIARY }}>
+              <Text className="text-text-tertiary" style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', fontWeight: '600' }}>
                 {`MEV ${landmarks.mev}`}
               </Text>
-              <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', fontWeight: '600', color: TEXT_TERTIARY }}>
+              <Text className="text-text-tertiary" style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', fontWeight: '600' }}>
                 {`MRV ${landmarks.mrv}`}
               </Text>
             </View>
@@ -310,6 +305,7 @@ export function BodyMapDetailPanel({
                 accessibilityElementsHidden
               />
               <View
+                className="border-text-primary bg-surface-elevated"
                 style={{
                   position: 'absolute',
                   left: `${markerLeft}%`,
@@ -318,8 +314,6 @@ export function BodyMapDetailPanel({
                   height: 14,
                   borderRadius: 7,
                   borderWidth: 2,
-                  borderColor: TEXT_PRIMARY,
-                  backgroundColor: SURFACE_ELEVATED,
                   boxShadow: '0 0 4px rgba(0,0,0,0.5)',
                 }}
                 accessibilityElementsHidden
@@ -330,18 +324,19 @@ export function BodyMapDetailPanel({
 
           <View className="flex-row items-baseline" style={{ marginTop: 14, gap: 4 }}>
             <Text
+              className="text-text-primary"
               style={{
                 fontSize: 24,
                 fontFamily: '"Space Grotesk", sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
               testID="body-map-detail-panel-set-count"
             >
               {weeklySets}
             </Text>
             <Text
-              style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+              className="text-text-secondary"
+              style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}
               testID="body-map-detail-panel-mrv-suffix"
             >
               {`/ ${landmarks.mrv} MRV`}
@@ -351,11 +346,11 @@ export function BodyMapDetailPanel({
           {weeklyHistory != null && weeklyHistory.length > 0 && (
             <View style={{ marginTop: 14 }} testID="body-map-detail-panel-sparkline">
               <Text
+                className="text-text-tertiary"
                 style={{
                   fontSize: 10,
                   fontFamily: 'Inter, sans-serif',
                   fontWeight: '600',
-                  color: TEXT_TERTIARY,
                   marginBottom: 6,
                 }}
                 accessibilityElementsHidden
@@ -369,11 +364,11 @@ export function BodyMapDetailPanel({
           {hasContributing && (
             <View style={{ marginTop: 16 }} testID="body-map-detail-panel-contributing">
               <Text
+                className="text-text-tertiary"
                 style={{
                   fontSize: 10,
                   fontFamily: 'Inter, sans-serif',
                   fontWeight: '600',
-                  color: TEXT_TERTIARY,
                   marginBottom: 8,
                 }}
               >
@@ -382,27 +377,27 @@ export function BodyMapDetailPanel({
               {contributingExercises!.map((exercise, index) => (
                 <View
                   key={`${exercise.name}-${index}`}
-                  className="flex-row items-center justify-between"
+                  className="flex-row items-center justify-between bg-surface-raised border-border"
                   style={{
                     gap: 10,
                     paddingVertical: 8,
                     paddingHorizontal: 12,
                     marginBottom: 6,
                     borderRadius: 8,
-                    backgroundColor: SURFACE_RAISED,
                     borderWidth: 1,
-                    borderColor: BORDER_DEFAULT,
                   }}
                   testID={`body-map-detail-panel-contributing-${index}`}
                 >
                   <Text
-                    style={{ flex: 1, fontSize: 13, fontFamily: 'Inter, sans-serif', fontWeight: '600', color: TEXT_PRIMARY }}
+                    className="text-text-primary"
+                    style={{ flex: 1, fontSize: 13, fontFamily: 'Inter, sans-serif', fontWeight: '600' }}
                     testID={`body-map-detail-panel-contributing-${index}-name`}
                   >
                     {exercise.name}
                   </Text>
                   <Text
-                    style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+                    className="text-text-secondary"
+                    style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}
                     testID={`body-map-detail-panel-contributing-${index}-detail`}
                   >
                     {`${exercise.sets} sets · ${Math.round(exercise.contributionWeight * 100)}%`}
@@ -415,11 +410,11 @@ export function BodyMapDetailPanel({
           {hasUpcoming && (
             <View style={{ marginTop: 16 }} testID="body-map-detail-panel-upcoming">
               <Text
+                className="text-text-tertiary"
                 style={{
                   fontSize: 10,
                   fontFamily: 'Inter, sans-serif',
                   fontWeight: '600',
-                  color: TEXT_TERTIARY,
                   marginBottom: 8,
                 }}
               >
@@ -433,13 +428,15 @@ export function BodyMapDetailPanel({
                   testID={`body-map-detail-panel-upcoming-${index}`}
                 >
                   <Text
-                    style={{ flex: 1, fontSize: 13, fontFamily: 'Inter, sans-serif', fontWeight: '600', color: TEXT_PRIMARY }}
+                    className="text-text-primary"
+                    style={{ flex: 1, fontSize: 13, fontFamily: 'Inter, sans-serif', fontWeight: '600' }}
                     testID={`body-map-detail-panel-upcoming-${index}-name`}
                   >
                     {exercise.name}
                   </Text>
                   <Text
-                    style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_TERTIARY }}
+                    className="text-text-tertiary"
+                    style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}
                     testID={`body-map-detail-panel-upcoming-${index}-detail`}
                   >
                     {`${exercise.workoutName} · ${exercise.sets} sets`}

--- a/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
+++ b/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
@@ -8,7 +8,6 @@ const STATUS_INFO = '#2196F3'
 /** Dot outline: near-white ring so load dots read on the band fill and any
  *  surface (matches the MesoStatusCard gauge-marker convention). */
 const DOT_BORDER = '#F3F4F6'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
 const BAND_FILL = 'rgba(20,184,166,0.1)'
 const BAND_EDGE = 'rgba(20,184,166,0.45)'
 const PROJECTION_FILL = 'rgba(20,184,166,0.05)'
@@ -398,6 +397,7 @@ export function CapacityBandChart({
 
       {/* Y axis conceptual label (no numbers). */}
       <Text
+        className="text-text-tertiary"
         style={{
           position: 'absolute',
           left: PADDING_LEFT / 2 - 14,
@@ -406,7 +406,6 @@ export function CapacityBandChart({
           textAlign: 'center',
           fontSize: 9,
           fontFamily: 'Inter, sans-serif',
-          color: TEXT_TERTIARY,
           transform: [{ rotate: '-90deg' }],
         }}
         accessibilityElementsHidden
@@ -422,6 +421,7 @@ export function CapacityBandChart({
         return (
           <Text
             key={`x-${point.date}`}
+            className="text-text-tertiary"
             style={{
               position: 'absolute',
               left: toX(point.date) - 14,
@@ -430,7 +430,6 @@ export function CapacityBandChart({
               textAlign: 'center',
               fontSize: 10,
               fontFamily: 'Inter, sans-serif',
-              color: TEXT_TERTIARY,
             }}
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"

--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -8,6 +8,7 @@ import { PrBadge } from './PrBadge'
 import { TempoDisplay } from './TempoDisplay'
 import { SetRow, type SetRowProps } from './SetRow'
 import { roundWeight } from '../../../utils/workout-format'
+import { resolveColor } from '../../../theme/resolve-color'
 
 export type ExerciseCardState = 'collapsed' | 'expanded' | 'upcoming'
 
@@ -32,21 +33,6 @@ export interface ExerciseCardProps {
   previousBest?: string
   supersetPosition?: 'first' | 'last' | 'middle' | null
   supersetColor?: string
-}
-
-const COLORS = {
-  // Theme-aware tokens: text foregrounds and this card's own surfaces/borders
-  // must flip together so text stays readable in both light and dark. The
-  // expanded/pressed surfaces are self-owned here (not from a themed Card), so
-  // hardcoding dark values would leave dark-on-dark once the text flips.
-  // react-native-web passes the CSS var through to the inline style.
-  textPrimary: 'var(--color-text-primary)',
-  textSecondary: 'var(--color-text-secondary)',
-  textTertiary: 'var(--color-text-tertiary)',
-  brandPrimary: '#FF7900',
-  surfaceRaised: 'var(--color-surface-raised)',
-  surfaceElevated: 'var(--color-surface-elevated)',
-  borderDefault: 'var(--color-border-default)',
 }
 
 /** Column headers; the weight column reflects the card's unit (LBS / KG). */
@@ -139,11 +125,11 @@ function CollapsedCard({
       testID="exercise-card"
     >
       <View
+        className={pressed ? 'bg-surface-raised' : undefined}
         style={{
           padding: 12,
           paddingHorizontal: 14,
           cursor: 'pointer',
-          backgroundColor: pressed ? COLORS.surfaceRaised : 'transparent',
           ...borderRadius,
           ...supersetMargin,
         }}
@@ -153,11 +139,11 @@ function CollapsedCard({
           testID="exercise-card-header"
         >
           <Text
+            className="text-text-primary"
             style={{
               fontSize: 14,
               fontFamily: '"Space Grotesk", sans-serif',
               fontWeight: '700',
-              color: COLORS.textPrimary,
             }}
             testID="exercise-card-name"
           >
@@ -166,10 +152,10 @@ function CollapsedCard({
           <View className="flex-1" />
           {summary && (
             <Text
+              className="text-text-secondary"
               style={{
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
-                color: COLORS.textSecondary,
                 marginRight: 8,
               }}
               testID="exercise-card-summary"
@@ -239,10 +225,9 @@ function ExpandedCard({
 
   return (
     <View
+      className="bg-surface-elevated border-border"
       style={{
-        backgroundColor: COLORS.surfaceElevated,
         borderWidth: 1,
-        borderColor: COLORS.borderDefault,
         ...borderRadius,
         ...supersetMargin,
       }}
@@ -262,15 +247,15 @@ function ExpandedCard({
             paddingHorizontal: 14,
             paddingBottom: 10,
             borderBottomWidth: 1,
-            borderBottomColor: COLORS.borderDefault,
+            borderBottomColor: resolveColor('border-default'),
           }}
         >
           <Text
+            className="text-text-primary"
             style={{
               fontSize: 14,
               fontFamily: '"Space Grotesk", sans-serif',
               fontWeight: '700',
-              color: COLORS.textPrimary,
             }}
             testID="exercise-card-name"
           >
@@ -279,10 +264,10 @@ function ExpandedCard({
           <View className="flex-1" />
           {summary && (
             <Text
+              className="text-text-secondary"
               style={{
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
-                color: COLORS.textSecondary,
                 marginRight: 8,
               }}
               testID="exercise-card-summary"
@@ -339,13 +324,13 @@ function ExpandedCard({
               {...(isFlex ? { className: 'flex-1' } : {})}
             >
               <Text
+                className="text-text-tertiary"
                 style={{
                   fontSize: 10,
                   fontWeight: '600',
                   fontFamily: 'Inter, sans-serif',
                   textTransform: 'uppercase',
                   letterSpacing: 0.8,
-                  color: COLORS.textTertiary,
                 }}
               >
                 {header}
@@ -389,11 +374,11 @@ function UpcomingCard({
     >
       <View className="flex-row items-center">
         <Text
+          className="text-text-primary"
           style={{
             fontSize: 14,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: COLORS.textPrimary,
           }}
           testID="exercise-card-name"
         >
@@ -401,10 +386,10 @@ function UpcomingCard({
         </Text>
         {prescription && (
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 12,
               fontFamily: 'Inter, sans-serif',
-              color: COLORS.textSecondary,
               marginLeft: 8,
             }}
             testID="exercise-card-prescription"
@@ -415,10 +400,10 @@ function UpcomingCard({
         <View className="flex-1" />
         {previousBest && (
           <Text
+            className="text-text-tertiary"
             style={{
               fontSize: 11,
               fontFamily: 'Inter, sans-serif',
-              color: COLORS.textTertiary,
             }}
             testID="exercise-card-previous-best"
           >

--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
@@ -16,14 +16,10 @@ import {
 import { ExerciseCard, type ExerciseCardProps } from './ExerciseCard'
 import { type SetRowProps } from './SetRow'
 import { VelocityStrip, calculateMeanVelocity, calculateVelocityLoss } from './VelocityStrip'
+import { resolveColor } from '../../../theme/resolve-color'
+import { cn } from '../../../utils/cn'
 
-const SURFACE_ELEVATED = 'var(--color-surface-elevated)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
-const PAGE_BG = 'var(--color-background-base)'
 
 /** Inner plot width: page width 390 − 16 page padding − 12 card padding on each side. */
 const CHART_WIDTH = 326
@@ -190,7 +186,7 @@ function TabBar({ active, onSelect }: TabBarProps) {
       className="flex-row"
       style={{
         borderBottomWidth: 1,
-        borderBottomColor: BORDER_DEFAULT,
+        borderBottomColor: resolveColor('border-default'),
       }}
       accessibilityRole={'tablist' as ViewProps['accessibilityRole']}
       testID="exercise-detail-page-tabs"
@@ -213,11 +209,11 @@ function TabBar({ active, onSelect }: TabBarProps) {
             testID={`exercise-detail-page-tab-${key}`}
           >
             <Text
+              className={isActive ? 'text-text-primary' : 'text-text-tertiary'}
               style={{
                 fontSize: 13,
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: isActive ? '700' : '500',
-                color: isActive ? TEXT_PRIMARY : TEXT_TERTIARY,
               }}
             >
               {label}
@@ -244,27 +240,27 @@ function StatStrip({ stats, unit }: { stats: ExerciseDetailStats; unit: 'lbs' | 
         return (
           <View
             key={key}
+            className="bg-surface-elevated border-border"
             style={{
               flex: 1,
               padding: 12,
               borderRadius: 10,
-              backgroundColor: SURFACE_ELEVATED,
               borderWidth: 1,
-              borderColor: BORDER_DEFAULT,
             }}
             testID={`exercise-detail-page-stat-${key}`}
           >
             <Text
+              className="text-text-primary"
               style={{
                 fontSize: 18,
                 fontFamily: '"Space Grotesk", sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
             >
               {value}
             </Text>
             <Text
+              className="text-text-tertiary"
               style={{
                 marginTop: 2,
                 fontSize: 10,
@@ -272,7 +268,6 @@ function StatStrip({ stats, unit }: { stats: ExerciseDetailStats; unit: 'lbs' | 
                 fontWeight: '600',
                 letterSpacing: 0.4,
                 textTransform: 'uppercase',
-                color: TEXT_TERTIARY,
               }}
             >
               {label}
@@ -295,10 +290,9 @@ function SectionCard({
 }) {
   return (
     <View
+      className="bg-surface-elevated border-border"
       style={{
-        backgroundColor: SURFACE_ELEVATED,
         borderWidth: 1,
-        borderColor: BORDER_DEFAULT,
         borderRadius: 12,
         padding: 12,
         gap: 10,
@@ -306,13 +300,13 @@ function SectionCard({
       testID={testID}
     >
       <Text
+        className="text-text-tertiary"
         style={{
           fontSize: 11,
           fontFamily: 'Inter, sans-serif',
           fontWeight: '600',
           letterSpacing: 0.6,
           textTransform: 'uppercase',
-          color: TEXT_TERTIARY,
         }}
       >
         {title}
@@ -334,7 +328,8 @@ function EntryList({ entries, expandedId, onToggle, emptyLabel, testID }: EntryL
   if (entries.length === 0) {
     return (
       <Text
-        style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_TERTIARY }}
+        className="text-text-tertiary"
+        style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}
         testID={`${testID}-empty`}
       >
         {emptyLabel}
@@ -367,12 +362,12 @@ function VbtBreakdown({ sets }: { sets: ExerciseVbtSet[] }) {
             testID="exercise-detail-page-vbt-set"
           >
             <Text
+              className="text-text-secondary"
               style={{
                 width: 44,
                 fontSize: 11,
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: '600',
-                color: TEXT_SECONDARY,
               }}
             >
               {set.label}
@@ -381,11 +376,11 @@ function VbtBreakdown({ sets }: { sets: ExerciseVbtSet[] }) {
               <VelocityStrip velocities={set.velocities} variant="mini" />
             </View>
             <Text
+              className="text-text-tertiary"
               style={{
                 fontSize: 11,
                 fontFamily: 'Inter, sans-serif',
                 fontVariant: ['tabular-nums'],
-                color: TEXT_TERTIARY,
               }}
             >
               {`${mean.toFixed(2)} · -${loss}%`}
@@ -407,26 +402,26 @@ function VbtSummaryRow({ summary }: { summary: VbtSummary }) {
       {cells.map((cell) => (
         <View
           key={cell.label}
+          className="bg-surface-elevated border-border"
           style={{
             flex: 1,
             padding: 12,
             borderRadius: 10,
-            backgroundColor: SURFACE_ELEVATED,
             borderWidth: 1,
-            borderColor: BORDER_DEFAULT,
           }}
         >
           <Text
+            className="text-text-primary"
             style={{
               fontSize: 16,
               fontFamily: '"Space Grotesk", sans-serif',
               fontWeight: '700',
-              color: TEXT_PRIMARY,
             }}
           >
             {cell.value}
           </Text>
           <Text
+            className="text-text-tertiary"
             style={{
               marginTop: 2,
               fontSize: 10,
@@ -434,7 +429,6 @@ function VbtSummaryRow({ summary }: { summary: VbtSummary }) {
               fontWeight: '600',
               letterSpacing: 0.4,
               textTransform: 'uppercase',
-              color: TEXT_TERTIARY,
             }}
           >
             {cell.label}
@@ -488,8 +482,8 @@ export function ExerciseDetailPage({
 
   return (
     <View
-      className={className}
-      style={{ width: 390, backgroundColor: PAGE_BG }}
+      className={cn('bg-background-base', className)}
+      style={{ width: 390 }}
       accessibilityRole={'main' as ViewProps['accessibilityRole']}
       aria-label={exercise.name}
       testID="exercise-detail-page"
@@ -504,22 +498,22 @@ export function ExerciseDetailPage({
           <View style={{ flexShrink: 1 }}>
             <Text
               accessibilityRole="header"
+              className="text-text-primary"
               style={{
                 fontSize: 20,
                 fontFamily: '"Space Grotesk", sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
               testID="exercise-detail-page-title"
             >
               {exercise.name}
             </Text>
             <Text
+              className="text-text-secondary"
               style={{
                 marginTop: 2,
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_SECONDARY,
               }}
               testID="exercise-detail-page-subtitle"
             >
@@ -539,13 +533,13 @@ export function ExerciseDetailPage({
               testID="exercise-detail-page-e1rm"
             >
               <Text
+                className="text-text-tertiary"
                 style={{
                   fontSize: 9,
                   fontFamily: 'Inter, sans-serif',
                   fontWeight: '600',
                   letterSpacing: 0.4,
                   textTransform: 'uppercase',
-                  color: TEXT_TERTIARY,
                 }}
               >
                 e1RM

--- a/packages/ui/src/components/custom/Workout/InputBar.tsx
+++ b/packages/ui/src/components/custom/Workout/InputBar.tsx
@@ -1,6 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import React from 'react'
 import { View, Text, Pressable, TextInput } from 'react-native'
+import { resolveColor } from '../../../theme/resolve-color'
 
 export interface InputBarProps {
   exerciseName: string
@@ -17,19 +18,15 @@ export interface InputBarProps {
 }
 
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
+const INPUT_CLASSNAME = 'bg-surface-raised border-border-strong text-text-primary'
 
 const inputStyle = {
   fontSize: 14,
   fontWeight: '600' as const,
   fontFamily: 'Inter, sans-serif',
-  backgroundColor: 'var(--color-surface-raised)',
   borderWidth: 1,
-  borderColor: 'var(--color-border-strong)',
   borderRadius: 6,
   textAlign: 'center' as const,
-  color: TEXT_PRIMARY,
   paddingVertical: 5,
   paddingHorizontal: 2,
 }
@@ -53,11 +50,11 @@ export function InputBar({
 
   return (
     <View
+      className="bg-surface-elevated"
       style={{
         width: '100%',
-        backgroundColor: 'var(--color-surface-elevated)',
         borderTopWidth: 1,
-        borderTopColor: 'var(--color-border-default)',
+        borderTopColor: resolveColor('border-default'),
         paddingTop: 10,
         paddingHorizontal: 16,
         paddingBottom: 12,
@@ -70,11 +67,11 @@ export function InputBar({
     >
       <View style={{ minWidth: 80, flexDirection: 'column' }}>
         <Text
+          className="text-text-primary"
           style={{
             fontSize: 12,
             fontWeight: '700',
             fontFamily: '"Space Grotesk", sans-serif',
-            color: TEXT_PRIMARY,
           }}
           testID="input-bar-exercise-name"
           numberOfLines={1}
@@ -82,10 +79,10 @@ export function InputBar({
           {exerciseName}
         </Text>
         <Text
+          className="text-text-tertiary"
           style={{
             fontSize: 10,
             fontFamily: 'Inter, sans-serif',
-            color: TEXT_TERTIARY,
           }}
           testID="input-bar-set-info"
         >
@@ -97,16 +94,17 @@ export function InputBar({
         <TextInput
           value={reps}
           onChangeText={onRepsChange}
+          className={INPUT_CLASSNAME}
           style={{ ...inputStyle, width: 36 }}
           accessibilityLabel="Reps"
           testID="input-bar-reps"
           keyboardType="numeric"
         />
         <Text
+          className="text-text-tertiary"
           style={{
             fontSize: 12,
             fontFamily: 'Inter, sans-serif',
-            color: TEXT_TERTIARY,
           }}
         >
           {'\u00D7'}
@@ -114,17 +112,18 @@ export function InputBar({
         <TextInput
           value={weight}
           onChangeText={onWeightChange}
+          className={INPUT_CLASSNAME}
           style={{ ...inputStyle, width: 52 }}
           accessibilityLabel={`Weight in ${unit}`}
           testID="input-bar-weight"
           keyboardType="numeric"
         />
         <Text
+          className="text-text-tertiary"
           style={{
             fontSize: 12,
             fontWeight: '500',
             fontFamily: 'Inter, sans-serif',
-            color: TEXT_TERTIARY,
           }}
           testID="input-bar-unit"
         >

--- a/packages/ui/src/components/custom/Workout/MesoCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.tsx
@@ -9,10 +9,6 @@ const BRAND_PRIMARY = '#FF7900'
 const BRAND_PRIMARY_DARK = '#C45E00'
 const BRAND_PRIMARY_LIGHT = '#FFB066'
 const BORDER_DEFAULT = '#1F1F1F'
-// Theme-aware foregrounds: resolve to a readable color in both light and dark
-// (react-native-web passes the CSS var through to the inline style).
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
 
 /** Gradient stops for the 3px top accent: dark -> primary -> light. */
 const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]
@@ -119,11 +115,11 @@ export function MesoCard({
     <View style={{ paddingHorizontal: 14, paddingTop: 12, paddingBottom: 10 }} testID="meso-card-body">
       <View className="flex-row items-center" style={{ gap: 8 }} testID="meso-card-header">
         <Text
+          className="text-text-primary"
           style={{
             fontSize: 15,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: TEXT_PRIMARY,
           }}
           testID="meso-card-name"
         >
@@ -135,11 +131,11 @@ export function MesoCard({
       </View>
 
       <Text
+        className="text-text-secondary"
         style={{
           marginTop: 4,
           fontSize: 12,
           fontFamily: 'Inter, sans-serif',
-          color: TEXT_SECONDARY,
         }}
         testID="meso-card-subheader"
       >

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
@@ -3,13 +3,11 @@ import { Fragment, type ReactNode } from 'react'
 import { View, Text, type ViewProps, type ViewStyle } from 'react-native'
 import { Card } from '../../ui/card'
 import { StatusDot } from './StatusDot'
+import { resolveColor } from '../../../theme/resolve-color'
 
 const BRAND_PRIMARY = '#FF7900'
 const BRAND_PRIMARY_DARK = '#C45E00'
 const BRAND_PRIMARY_LIGHT = '#FFB066'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
 
 const SUCCESS = '#14B8A6'
 const WARNING = '#FFB020'
@@ -18,9 +16,12 @@ const ERROR = '#D14343'
 /** Gradient stops for the 3px top accent: dark -> primary -> light (matches MesoCard). */
 const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]
 
-/** Card surface gradient: elevated -> raised at 135deg (theme-aware). */
-const CARD_GRADIENT =
-  'linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-raised) 100%)'
+/**
+ * Card surface gradient: elevated -> raised at 135deg. Uses resolved dark-theme
+ * hexes (a gradient string can't carry a className token, and var() renders
+ * black on native).
+ */
+const CARD_GRADIENT = `linear-gradient(135deg, ${resolveColor('surface-elevated')} 0%, ${resolveColor('surface-raised')} 100%)`
 
 /** Gauge track gradient (teal -> amber -> red) at 0.25 alpha. */
 const GAUGE_GRADIENT =
@@ -118,7 +119,8 @@ function renderCoachingText(text: string, highlights?: string[]): ReactNode {
     highlights.includes(part) ? (
       <Text
         key={`${part}-${index}`}
-        style={{ fontWeight: '700', color: TEXT_PRIMARY }}
+        className="text-text-primary"
+        style={{ fontWeight: '700' }}
       >
         {part}
       </Text>
@@ -166,24 +168,24 @@ function MetricCell({ metric }: { metric: MesoStatusMetric }) {
   return (
     <View style={{ width: '48%' }} testID="meso-status-card-metric">
       <Text
+        className="text-text-tertiary"
         style={{
           fontSize: 10,
           fontFamily: 'Inter, sans-serif',
           fontWeight: '600',
           letterSpacing: 0.5,
           textTransform: 'uppercase',
-          color: TEXT_TERTIARY,
         }}
       >
         {metric.label}
       </Text>
       <Text
+        className="text-text-primary"
         style={{
           marginTop: 2,
           fontSize: 13,
           fontFamily: 'Inter, sans-serif',
           fontWeight: '600',
-          color: TEXT_PRIMARY,
         }}
       >
         {metric.value}
@@ -212,24 +214,24 @@ function Gauge({ gauge }: { gauge: MesoStatusGauge }) {
         accessibilityElementsHidden
       >
         <Text
+          className="text-text-secondary"
           style={{
             fontSize: 10,
             fontFamily: 'Inter, sans-serif',
             fontWeight: '500',
             letterSpacing: 0.5,
             textTransform: 'uppercase',
-            color: TEXT_SECONDARY,
           }}
         >
           {gauge.label}
         </Text>
         {gauge.sublabel != null && (
           <Text
+            className="text-text-tertiary"
             style={{
               fontSize: 10,
               fontFamily: 'Inter, sans-serif',
               fontWeight: '500',
-              color: TEXT_TERTIARY,
             }}
           >
             {gauge.sublabel}
@@ -261,6 +263,7 @@ function Gauge({ gauge }: { gauge: MesoStatusGauge }) {
           testID="meso-status-card-gauge-center"
         />
         <View
+          className="border-text-primary"
           style={{
             position: 'absolute',
             left: `${percentage}%`,
@@ -270,7 +273,6 @@ function Gauge({ gauge }: { gauge: MesoStatusGauge }) {
             height: 14,
             borderRadius: 9999,
             borderWidth: 2,
-            borderColor: TEXT_PRIMARY,
             backgroundColor: markerColor,
             boxShadow: '0 0 4px rgba(0,0,0,0.5)',
           }}
@@ -349,12 +351,12 @@ export function MesoStatusCard({
             style={{ gap: 8 }}
           >
             <Text
+              className="text-text-primary"
               style={{
                 flexShrink: 1,
                 fontSize: 15,
                 fontFamily: '"Space Grotesk", sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
               testID="meso-status-card-name"
             >
@@ -363,11 +365,11 @@ export function MesoStatusCard({
             <StatusPill badge={statusBadge} />
           </View>
           <Text
+            className="text-text-secondary"
             style={{
               marginTop: 4,
               fontSize: 12,
               fontFamily: 'Inter, sans-serif',
-              color: TEXT_SECONDARY,
             }}
             testID="meso-status-card-subtitle"
           >
@@ -408,11 +410,11 @@ export function MesoStatusCard({
             testID="meso-status-card-coaching"
           >
             <Text
+              className="text-text-secondary"
               style={{
                 fontSize: 12,
                 lineHeight: 17,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_SECONDARY,
               }}
             >
               {renderCoachingText(coaching.text, coaching.highlights)}

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
@@ -34,16 +34,14 @@ export function MuscleGroupChip({
 
   const content = (
     <View
-      className={className}
+      className={['bg-surface-raised border-border', className].filter(Boolean).join(' ')}
       style={{
         flexDirection: 'row',
         alignItems: 'center',
         borderRadius: 9999,
         paddingHorizontal: 9,
         paddingVertical: 3,
-        backgroundColor: 'var(--color-surface-raised)',
         borderWidth: 1,
-        borderColor: 'var(--color-border-default)',
       }}
       accessibilityLabel={onPress ? undefined : `${name}, volume status: ${statusLabel}`}
       testID="muscle-group-chip"
@@ -62,11 +60,11 @@ export function MuscleGroupChip({
         testID="muscle-group-chip-dot"
       />
       <Text
+        className="text-text-secondary"
         style={{
           fontFamily: 'Inter, sans-serif',
           fontWeight: '500',
           fontSize: 11,
-          color: 'var(--color-text-secondary)',
         }}
         accessibilityElementsHidden
       >

--- a/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/PlaceholderStrip.tsx
@@ -18,14 +18,13 @@ function SingleStrip({
 }: Omit<PlaceholderStripProps, 'mode' | 'segments'>) {
   return (
     <View
-      className={cn(className)}
+      className={cn('border-border-strong', className)}
       style={[
         {
           height: 3,
           backgroundColor: 'transparent',
           borderWidth: 1,
           borderStyle: 'dashed',
-          borderColor: 'var(--color-border-strong)',
           borderRadius: 1,
           opacity: 0.5,
         },
@@ -60,13 +59,13 @@ function SegmentedStrip({
       {Array.from({ length: segments }, (_, i) => (
         <View
           key={i}
+          className="border-border-strong"
           style={{
             flex: 1,
             height: 3,
             backgroundColor: 'transparent',
             borderWidth: 1,
             borderStyle: 'dashed',
-            borderColor: 'var(--color-border-strong)',
             borderRadius: 1,
             minWidth: 4,
           }}

--- a/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
+++ b/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
@@ -2,15 +2,14 @@
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { Star } from 'lucide-react'
 import { Drawer, DrawerBody } from '../../ui/drawer'
+import { resolveColor } from '../../../theme/resolve-color'
 
 const BRAND_PRIMARY = '#FF7900'
 const RECENT_BORDER = 'rgba(255,176,32,0.3)'
 const RECENT_GLOW = '0 0 12px rgba(255,176,32,0.06)'
-const SURFACE_RAISED = 'var(--color-surface-raised)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
+// Native-safe fallback for the conditional row border (recent uses a computed
+// rgba, so className can't express both branches).
+const BORDER_DEFAULT = resolveColor('border-default')
 
 export type PrRecordType = 'e1rm' | 'weight' | 'reps' | 'volume' | 'velocity'
 
@@ -72,14 +71,13 @@ function PrRecordRow({ record, index }: { record: PrRecord; index: number }) {
     <View
       accessibilityRole="text"
       accessibilityLabel={a11yLabel}
-      className="flex-row items-center"
+      className="flex-row items-center bg-surface-raised"
       style={{
         gap: 10,
         paddingVertical: 10,
         paddingHorizontal: 12,
         marginBottom: 8,
         borderRadius: 8,
-        backgroundColor: SURFACE_RAISED,
         borderWidth: 1,
         borderColor: record.isRecent ? RECENT_BORDER : BORDER_DEFAULT,
         ...(record.isRecent ? { boxShadow: RECENT_GLOW } : {}),
@@ -88,35 +86,35 @@ function PrRecordRow({ record, index }: { record: PrRecord; index: number }) {
     >
       <Star size={16} color={BRAND_PRIMARY} fill={BRAND_PRIMARY} strokeWidth={2} />
       <Text
+        className="text-text-secondary"
         style={{
           flex: 1,
           fontSize: 13,
           fontFamily: 'Inter, sans-serif',
           fontWeight: '600',
-          color: TEXT_SECONDARY,
         }}
         testID={`pr-history-modal-record-${index}-type`}
       >
         {label}
       </Text>
       <Text
+        className="text-text-primary"
         style={{
           fontSize: 14,
           fontFamily: '"Space Grotesk", sans-serif',
           fontWeight: '700',
-          color: TEXT_PRIMARY,
         }}
         testID={`pr-history-modal-record-${index}-value`}
       >
         {valueText}
       </Text>
       <Text
+        className="text-text-tertiary"
         style={{
           minWidth: 64,
           textAlign: 'right',
           fontSize: 11,
           fontFamily: 'Inter, sans-serif',
-          color: TEXT_TERTIARY,
         }}
         testID={`pr-history-modal-record-${index}-date`}
       >
@@ -173,13 +171,13 @@ export function PrHistoryModal({
     >
       <View
         accessibilityElementsHidden
+        className="bg-border"
         style={{
           alignSelf: 'center',
           width: 40,
           height: 4,
           borderRadius: 2,
           marginTop: 8,
-          backgroundColor: BORDER_DEFAULT,
         }}
         testID="pr-history-modal-handle"
       />
@@ -191,11 +189,11 @@ export function PrHistoryModal({
       >
         <Text
           accessibilityRole="header"
+          className="text-text-primary"
           style={{
             fontSize: 16,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: TEXT_PRIMARY,
           }}
           testID="pr-history-modal-title"
         >
@@ -209,7 +207,7 @@ export function PrHistoryModal({
           style={{ padding: 4, margin: -4 }}
           testID="pr-history-modal-close"
         >
-          <Text style={{ fontSize: 22, lineHeight: 22, color: TEXT_SECONDARY }}>
+          <Text className="text-text-secondary" style={{ fontSize: 22, lineHeight: 22 }}>
             {'×'}
           </Text>
         </Pressable>
@@ -219,11 +217,11 @@ export function PrHistoryModal({
         {records.length === 0 ? (
           <View style={{ paddingVertical: 24 }} testID="pr-history-modal-empty">
             <Text
+              className="text-text-tertiary"
               style={{
                 textAlign: 'center',
                 fontSize: 13,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_TERTIARY,
               }}
             >
               No personal records yet

--- a/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
@@ -7,13 +7,9 @@ import { type WeekRowProps, type WeekRowWorkout } from './WeekRow'
 import { WorkoutCard, type WorkoutStatus, type WorkoutMuscleGroup } from './WorkoutCard'
 import { type WorkoutPillStatus } from './WorkoutPill'
 import { type ExerciseCardProps } from './ExerciseCard'
+import { cn } from '../../../utils/cn'
 
-const SURFACE_ELEVATED = 'var(--color-surface-elevated)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
-const PAGE_BG = 'var(--color-background-base)'
 
 /** A single workout within a planned week, plus its exercise breakdown. */
 export interface PlanWorkout {
@@ -157,7 +153,7 @@ function Breadcrumbs({ crumbs, onNavigate }: BreadcrumbsProps) {
         const isLast = index === crumbs.length - 1
         return (
           <View key={crumb.key} className="flex-row items-center" style={{ gap: 4 }}>
-            {index > 0 && <Text style={{ fontSize: 12, color: TEXT_TERTIARY }}>{'›'}</Text>}
+            {index > 0 && <Text className="text-text-tertiary" style={{ fontSize: 12 }}>{'›'}</Text>}
             <Pressable
               onPress={() => onNavigate(crumb.level)}
               disabled={isLast}
@@ -165,11 +161,12 @@ function Breadcrumbs({ crumbs, onNavigate }: BreadcrumbsProps) {
               testID={`program-planning-page-crumb-${crumb.key}`}
             >
               <Text
+                className={isLast ? 'text-text-primary' : undefined}
                 style={{
                   fontSize: 12,
                   fontFamily: 'Inter, sans-serif',
                   fontWeight: isLast ? '700' : '500',
-                  color: isLast ? TEXT_PRIMARY : BRAND_PRIMARY,
+                  color: isLast ? undefined : BRAND_PRIMARY,
                 }}
               >
                 {crumb.label}
@@ -351,8 +348,8 @@ export function ProgramPlanningPage({
 
   return (
     <View
-      className={className}
-      style={{ width: 390, backgroundColor: PAGE_BG }}
+      className={cn(className, 'bg-background-base')}
+      style={{ width: 390 }}
       accessibilityRole={'main' as ViewProps['accessibilityRole']}
       aria-label={title}
       testID="program-planning-page"
@@ -361,11 +358,11 @@ export function ProgramPlanningPage({
       <View style={{ padding: 16, gap: 14 }} testID="program-planning-page-content">
         <Text
           accessibilityRole="header"
+          className="text-text-primary"
           style={{
             fontSize: 20,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: TEXT_PRIMARY,
           }}
           testID="program-planning-page-title"
         >
@@ -388,10 +385,9 @@ export function ProgramPlanningPage({
         )}
 
         <View
+          className="bg-surface-elevated border-border"
           style={{
-            backgroundColor: SURFACE_ELEVATED,
             borderWidth: 1,
-            borderColor: BORDER_DEFAULT,
             borderRadius: 12,
             padding: 12,
           }}

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
@@ -8,8 +8,6 @@ const BRAND_PRIMARY_SUBTLE = 'rgba(255,121,0,0.12)'
 const STATUS_SUCCESS = '#14B8A6'
 const STATUS_WARNING = '#FFB020'
 const STATUS_ERROR = '#D14343'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
 
 /** Emoji option sets per known factor, keyed by lowercase id/label. */
 const EMOJI_SETS: Record<string, readonly string[]> = {
@@ -91,7 +89,8 @@ function EmojiSlider({ factor }: EmojiSliderProps) {
   return (
     <View style={{ marginTop: 14 }} testID={`readiness-check-factor-${factor.id}`}>
       <Text
-        style={{ fontSize: 12, fontWeight: '500', fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+        className="text-text-secondary"
+        style={{ fontSize: 12, fontWeight: '500', fontFamily: 'Inter, sans-serif' }}
         testID="readiness-check-factor-label"
       >
         {factor.label}
@@ -114,14 +113,15 @@ function EmojiSlider({ factor }: EmojiSliderProps) {
               accessibilityLabel={`${factor.label} level ${level} of 5`}
               aria-checked={selected}
               testID="readiness-check-emoji"
+              className={selected ? undefined : 'border-border bg-surface-raised'}
               style={({ pressed }) => ({
                 flex: 1,
                 alignItems: 'center',
                 paddingVertical: 8,
                 borderRadius: 8,
                 borderWidth: 1,
-                borderColor: selected ? BRAND_PRIMARY : 'var(--color-border-default)',
-                backgroundColor: selected ? BRAND_PRIMARY_SUBTLE : 'var(--color-surface-raised)',
+                borderColor: selected ? BRAND_PRIMARY : undefined,
+                backgroundColor: selected ? BRAND_PRIMARY_SUBTLE : undefined,
                 opacity: selected ? 1 : pressed ? 0.8 : 0.55,
                 transform: [{ scale: selected ? 1.06 : 1 }],
               })}
@@ -143,13 +143,13 @@ function ScoreGauge({ score }: { score: number }) {
       accessibilityRole="image"
       accessibilityLabel={`Readiness score: ${score} out of 100`}
       testID="readiness-check-score"
+      className="bg-surface-raised"
       style={{
         width: 60,
         height: 60,
         borderRadius: 30,
         borderWidth: 4,
         borderColor: color,
-        backgroundColor: 'var(--color-surface-raised)',
         alignItems: 'center',
         justifyContent: 'center',
       }}
@@ -169,19 +169,19 @@ function WarmUpCard({ validation }: { validation: WarmUpValidation }) {
   const badge = WARMUP_BADGE[validation.status]
   return (
     <View
+      className="border-border bg-surface-raised"
       style={{
         marginTop: 16,
         padding: 12,
         borderRadius: 8,
         borderWidth: 1,
-        borderColor: 'var(--color-border-default)',
-        backgroundColor: 'var(--color-surface-raised)',
       }}
       testID="readiness-check-warmup"
     >
       <View className="flex-row items-center justify-between" style={{ gap: 8 }}>
         <Text
-          style={{ fontSize: 12, fontWeight: '600', fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}
+          className="text-text-secondary"
+          style={{ fontSize: 12, fontWeight: '600', fontFamily: 'Inter, sans-serif' }}
           testID="readiness-check-warmup-deficit"
         >
           {velocityDeficitText(validation.velocityDeficit)}
@@ -191,7 +191,8 @@ function WarmUpCard({ validation }: { validation: WarmUpValidation }) {
         </Badge>
       </View>
       <Text
-        style={{ marginTop: 6, fontSize: 13, fontFamily: 'Inter, sans-serif', color: TEXT_PRIMARY }}
+        className="text-text-primary"
+        style={{ marginTop: 6, fontSize: 13, fontFamily: 'Inter, sans-serif' }}
         testID="readiness-check-warmup-recommendation"
       >
         {validation.recommendation}
@@ -226,7 +227,8 @@ export function ReadinessCheck({
       <View style={{ padding: 16 }}>
         <View className="flex-row items-center justify-between" style={{ gap: 12 }}>
           <Text
-            style={{ fontSize: 18, fontWeight: '700', fontFamily: '"Space Grotesk", sans-serif', color: TEXT_PRIMARY }}
+            className="text-text-primary"
+            style={{ fontSize: 18, fontWeight: '700', fontFamily: '"Space Grotesk", sans-serif' }}
             testID="readiness-check-title"
           >
             How are you feeling?

--- a/packages/ui/src/components/custom/Workout/RestTimer.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.tsx
@@ -1,5 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, Pressable } from 'react-native'
+import { resolveColor } from '../../../theme/resolve-color'
 
 const BRAND_PRIMARY = '#FF7900'
 
@@ -34,11 +35,11 @@ export function RestTimer({
 
   return (
     <View
+      className="bg-surface-raised"
       style={{
         width: '100%',
-        backgroundColor: 'var(--color-surface-raised)',
         borderTopWidth: 1,
-        borderTopColor: 'var(--color-border-default)',
+        borderTopColor: resolveColor('border-default'),
         paddingVertical: 12,
         paddingHorizontal: 16,
       }}
@@ -58,13 +59,13 @@ export function RestTimer({
         {/* Left side */}
         <View style={{ flexDirection: 'column' }}>
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 11,
               fontFamily: 'Inter, sans-serif',
               fontWeight: '600',
               textTransform: 'uppercase',
               letterSpacing: 1,
-              color: 'var(--color-text-secondary)',
             }}
             testID="rest-timer-label"
           >
@@ -72,10 +73,10 @@ export function RestTimer({
           </Text>
           {nextSetInfo != null && (
             <Text
+              className="text-text-tertiary"
               style={{
                 fontSize: 11,
                 fontFamily: 'Inter, sans-serif',
-                color: 'var(--color-text-tertiary)',
                 marginTop: 2,
               }}
               testID="rest-timer-next-set"
@@ -87,11 +88,11 @@ export function RestTimer({
 
         {/* Right side - time display */}
         <Text
+          className="text-text-primary"
           style={{
             fontSize: 28,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: 'var(--color-text-primary)',
             fontVariant: ['tabular-nums'],
             letterSpacing: -0.5,
           }}
@@ -103,9 +104,9 @@ export function RestTimer({
 
       {/* Progress bar */}
       <View
+        className="bg-border"
         style={{
           height: 3,
-          backgroundColor: 'var(--color-border-default)',
           borderRadius: 2,
           marginBottom: 12,
         }}
@@ -137,11 +138,11 @@ export function RestTimer({
           testID="rest-timer-add-time"
         >
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 11,
               fontFamily: 'Inter, sans-serif',
               fontWeight: '600',
-              color: 'var(--color-text-secondary)',
             }}
           >
             +30s

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
@@ -2,17 +2,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { resolveColor } from '../../../theme/resolve-color'
 
 const BRAND_PRIMARY = '#FF7900'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
-const BORDER_STRONG = 'var(--color-border-strong)'
+// Line/border color for the dashed projection, used where a className cannot
+// apply (passed as a prop into an inline style, and a per-edge borderTopColor).
+const PROJECTION_LINE_COLOR = resolveColor('text-tertiary')
 const STATUS_SUCCESS = '#14B8A6'
 const STATUS_ERROR = '#D14343'
 const STATUS_WARNING = '#FFB020'
 const GRID_LINE = 'rgba(255,255,255,0.06)'
-const TOOLTIP_BG = 'var(--color-surface-elevated)'
 const SUCCESS_PILL_BG = 'rgba(20,184,166,0.10)'
 const SUCCESS_PILL_BORDER = 'rgba(20,184,166,0.20)'
 const ERROR_PILL_BG = 'rgba(209,67,67,0.10)'
@@ -312,7 +311,7 @@ export function StrengthTrendChart({
             justifyContent: 'center',
           }}
         >
-          <Text style={{ fontSize: 12, fontFamily: 'Inter, sans-serif', color: TEXT_TERTIARY }}>
+          <Text className="text-text-tertiary" style={{ fontSize: 12, fontFamily: 'Inter, sans-serif' }}>
             No strength data yet
           </Text>
         </View>
@@ -358,6 +357,7 @@ export function StrengthTrendChart({
               }}
             >
               <Text
+                className="text-text-tertiary"
                 style={{
                   position: 'absolute',
                   left: -PLOT_LEFT,
@@ -366,7 +366,6 @@ export function StrengthTrendChart({
                   textAlign: 'right',
                   fontSize: 9,
                   fontFamily: 'Inter, sans-serif',
-                  color: TEXT_TERTIARY,
                 }}
               >
                 {line.label}
@@ -406,7 +405,7 @@ export function StrengthTrendChart({
             <View style={{ width, height, position: 'absolute', top: 0, left: 0 }}>
               <ChartLine
                 coords={geometry.projection}
-                color={TEXT_TERTIARY}
+                color={PROJECTION_LINE_COLOR}
                 strokeWidth={2}
                 dashed
                 testID="strength-trend-chart-projection-segment"
@@ -475,6 +474,7 @@ export function StrengthTrendChart({
           <View
             testID="strength-trend-chart-tooltip"
             accessibilityElementsHidden
+            className="bg-surface-elevated border-border-strong"
             style={{
               position: 'absolute',
               left: Math.max(
@@ -483,30 +483,28 @@ export function StrengthTrendChart({
               ),
               top: Math.max(0, selectedCoord.y - 52),
               maxWidth: TOOLTIP_WIDTH,
-              backgroundColor: TOOLTIP_BG,
               borderWidth: 1,
-              borderColor: BORDER_STRONG,
               borderRadius: 8,
               paddingVertical: 8,
               paddingHorizontal: 10,
             }}
           >
             <Text
+              className="text-text-tertiary"
               style={{
                 fontSize: 10,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_TERTIARY,
               }}
             >
               {selectedCoord.point.sessionLabel ?? selectedCoord.point.date}
             </Text>
             <Text
+              className="text-text-primary"
               style={{
                 marginTop: 2,
                 fontSize: 13,
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
             >
               {`${formatValue(selectedCoord.point.e1rm)} ${unit}`}
@@ -547,6 +545,7 @@ export function StrengthTrendChart({
             <Text
               key={`axis-${i}`}
               testID="strength-trend-chart-axis-label"
+              className="text-text-tertiary"
               style={{
                 position: 'absolute',
                 left: boundary.x - 24,
@@ -554,7 +553,6 @@ export function StrengthTrendChart({
                 textAlign: 'center',
                 fontSize: 10,
                 fontFamily: 'Inter, sans-serif',
-                color: TEXT_TERTIARY,
               }}
             >
               {boundary.label}
@@ -598,7 +596,7 @@ export function StrengthTrendChart({
       >
         <View className="flex-row items-center" style={{ gap: 5 }}>
           <View style={{ width: 14, height: 2.5, borderRadius: 1.5, backgroundColor: BRAND_PRIMARY }} />
-          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+          <Text className="text-text-secondary" style={{ fontSize: 10, fontFamily: 'Inter, sans-serif' }}>
             Actual
           </Text>
         </View>
@@ -609,16 +607,16 @@ export function StrengthTrendChart({
               height: 0,
               borderTopWidth: 2,
               borderStyle: 'dashed',
-              borderTopColor: TEXT_TERTIARY,
+              borderTopColor: PROJECTION_LINE_COLOR,
             }}
           />
-          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+          <Text className="text-text-secondary" style={{ fontSize: 10, fontFamily: 'Inter, sans-serif' }}>
             Projected
           </Text>
         </View>
         <View className="flex-row items-center" style={{ gap: 5 }}>
           <Text style={{ fontSize: 12, color: STATUS_WARNING }}>★</Text>
-          <Text style={{ fontSize: 10, fontFamily: 'Inter, sans-serif', color: TEXT_SECONDARY }}>
+          <Text className="text-text-secondary" style={{ fontSize: 10, fontFamily: 'Inter, sans-serif' }}>
             PR
           </Text>
         </View>

--- a/packages/ui/src/components/custom/Workout/TrainingStatusPage.tsx
+++ b/packages/ui/src/components/custom/Workout/TrainingStatusPage.tsx
@@ -16,13 +16,6 @@ import {
   type VolumeStatus,
 } from './muscleTaxonomy'
 
-const SURFACE_ELEVATED = 'var(--color-surface-elevated)'
-const BORDER_DEFAULT = 'var(--color-border-default)'
-const TEXT_PRIMARY = 'var(--color-text-primary)'
-const TEXT_SECONDARY = 'var(--color-text-secondary)'
-const TEXT_TERTIARY = 'var(--color-text-tertiary)'
-const PAGE_BG = 'var(--color-background-base)'
-
 /** Volume statuses in display order for the legend and summary cards. */
 const STATUS_ORDER: VolumeStatus[] = ['under', 'maintenance', 'productive', 'over']
 
@@ -121,28 +114,28 @@ function SummaryCards({ summary }: { summary: TrainingStatusSummary }) {
         return (
           <View
             key={key}
+            className="bg-surface-elevated border-border"
             style={{
               flexGrow: 1,
               flexBasis: '46%',
               padding: 12,
               borderRadius: 10,
-              backgroundColor: SURFACE_ELEVATED,
               borderWidth: 1,
-              borderColor: BORDER_DEFAULT,
             }}
             testID={`training-status-page-summary-${key}`}
           >
             <Text
+              className="text-text-primary"
               style={{
                 fontSize: 22,
                 fontFamily: '"Space Grotesk", sans-serif',
                 fontWeight: '700',
-                color: TEXT_PRIMARY,
               }}
             >
               {value}
             </Text>
             <Text
+              className="text-text-tertiary"
               style={{
                 marginTop: 2,
                 fontSize: 11,
@@ -150,7 +143,6 @@ function SummaryCards({ summary }: { summary: TrainingStatusSummary }) {
                 fontWeight: '600',
                 letterSpacing: 0.4,
                 textTransform: 'uppercase',
-                color: TEXT_TERTIARY,
               }}
             >
               {label}
@@ -186,10 +178,10 @@ function StatusLegend() {
             accessibilityElementsHidden
           />
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 11,
               fontFamily: 'Inter, sans-serif',
-              color: TEXT_SECONDARY,
               textTransform: 'capitalize',
             }}
           >
@@ -247,8 +239,8 @@ export function TrainingStatusPage({
 
   return (
     <View
-      className={className}
-      style={{ position: 'relative', width: 390, backgroundColor: PAGE_BG }}
+      className={['bg-background-base', className].filter(Boolean).join(' ')}
+      style={{ position: 'relative', width: 390 }}
       accessibilityRole={'main' as ViewProps['accessibilityRole']}
       aria-label={title}
       testID="training-status-page"
@@ -257,11 +249,11 @@ export function TrainingStatusPage({
       <View style={{ padding: 16, gap: 16 }} testID="training-status-page-content">
         <Text
           accessibilityRole="header"
+          className="text-text-primary"
           style={{
             fontSize: 20,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: TEXT_PRIMARY,
           }}
           testID="training-status-page-title"
         >
@@ -273,10 +265,9 @@ export function TrainingStatusPage({
         <SummaryCards summary={summary} />
 
         <View
+          className="bg-surface-elevated border-border"
           style={{
-            backgroundColor: SURFACE_ELEVATED,
             borderWidth: 1,
-            borderColor: BORDER_DEFAULT,
             borderRadius: 12,
             padding: 12,
             gap: 12,

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -151,7 +151,9 @@ export function VelocityStrip({
 
   const stripContent = (
     <Animated.View
-      className={className}
+      className={[className, expanded ? 'bg-surface-raised' : 'bg-transparent']
+        .filter(Boolean)
+        .join(' ')}
       style={[
         {
           height: heightAnim,
@@ -162,7 +164,6 @@ export function VelocityStrip({
           paddingBottom: expanded ? 24 : 0,
           paddingHorizontal: expanded ? 6 : 0,
           paddingVertical: expanded ? undefined : 8,
-          backgroundColor: expanded ? 'var(--color-surface-raised)' : 'transparent',
           overflow: expanded ? 'visible' : 'hidden',
         },
       ]}
@@ -189,7 +190,8 @@ export function VelocityStrip({
               {expanded && (
                 <Animated.View style={{ opacity: labelOpacity, alignItems: 'center', position: 'absolute', top: -13, left: 0, right: 0 }} accessibilityElementsHidden>
                   <Text
-                    style={{ fontSize: 8, fontWeight: '600', color: 'var(--color-text-secondary)' }}
+                    className="text-text-secondary"
+                    style={{ fontSize: 8, fontWeight: '600' }}
                     testID={`velocity-label-${i}`}
                   >
                     {formatVelocity(v)}
@@ -248,18 +250,18 @@ export function VelocityStrip({
           testID="velocity-info-row"
         >
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 10,
-              color: 'var(--color-text-secondary)',
               fontFamily: 'Inter, sans-serif',
             }}
           >
             {meanZone} {'\u00B7'} {formatVelocity(meanVelocity)} m/s
           </Text>
           <Text
+            className="text-text-secondary"
             style={{
               fontSize: 10,
-              color: 'var(--color-text-secondary)',
               fontFamily: 'Inter, sans-serif',
               ...getLossStyle(loss),
             }}

--- a/packages/ui/src/components/custom/Workout/WeekRow.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.tsx
@@ -100,11 +100,12 @@ export function WeekRow({
           />
         )}
         <Text
+          className={isCurrent ? undefined : 'text-text-primary'}
           style={{
             fontSize: 13,
             fontWeight: '700',
             fontFamily: 'Inter, sans-serif',
-            color: isCurrent ? BRAND_PRIMARY : 'var(--color-text-primary)',
+            color: isCurrent ? BRAND_PRIMARY : undefined,
           }}
           accessibilityElementsHidden
         >

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
@@ -43,11 +43,6 @@ export interface WorkoutCardProps extends ViewProps {
 }
 
 const COLORS = {
-  // Theme-aware foregrounds: resolve to a readable color in both light and dark
-  // (react-native-web passes the CSS var through to the inline style).
-  textPrimary: 'var(--color-text-primary)',
-  textSecondary: 'var(--color-text-secondary)',
-  textTertiary: 'var(--color-text-tertiary)',
   statusSuccess: '#14B8A6',
   brandPrimary: '#FF7900',
   borderDefault: '#1F1F1F',
@@ -124,11 +119,11 @@ export function WorkoutCard({
     <View style={{ padding: 14 }} testID="workout-card-body">
       <View className="flex-row items-center" testID="workout-card-header">
         <Text
+          className="text-text-primary"
           style={{
             fontSize: 15,
             fontFamily: '"Space Grotesk", sans-serif',
             fontWeight: '700',
-            color: COLORS.textPrimary,
           }}
           testID="workout-card-name"
         >
@@ -136,10 +131,10 @@ export function WorkoutCard({
         </Text>
         <View className="flex-1" />
         <Text
+          className="text-text-tertiary"
           style={{
             fontSize: 11,
             fontFamily: 'Inter, sans-serif',
-            color: COLORS.textTertiary,
           }}
           testID="workout-card-date"
         >
@@ -148,11 +143,11 @@ export function WorkoutCard({
       </View>
 
       <Text
+        className="text-text-secondary"
         style={{
           marginTop: 4,
           fontSize: 12,
           fontFamily: 'Inter, sans-serif',
-          color: COLORS.textSecondary,
         }}
         testID="workout-card-stats"
       >

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -5,6 +5,7 @@ export * from './shadows'
 export * from './elevation'
 export * from './manifest'
 export { ThemeProvider, type ThemeProviderProps, type ThemeProviderMode } from './ThemeProvider'
+export { resolveColor } from './resolve-color'
 
 // Re-export commonly used items
 export { getSemanticColors, type ThemeMode } from './tokens/semantic'

--- a/packages/ui/src/theme/resolve-color.ts
+++ b/packages/ui/src/theme/resolve-color.ts
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native'
+import { getSemanticColors, type ThemeMode } from './tokens/semantic'
+
+type ColorToken = keyof ReturnType<typeof getSemanticColors>
+
+/**
+ * Resolve a semantic color token for an inline style where a nativewind
+ * className can't apply — gradients (`backgroundImage`), per-edge borders
+ * (`borderTopColor`, …), SVG attributes, and conditional hex/token mixes.
+ *
+ * The companion to className color tokens: on **web** it returns the CSS
+ * variable (`var(--color-…)`), so the dashboard's light/dark switching keeps
+ * working exactly as `global.css` intends; on **native** it returns the
+ * resolved hex from `getSemanticColors` (mobile is dark-only). This is why
+ * these spots stay theme-correct on web while also rendering on-device.
+ */
+export function resolveColor(token: ColorToken, mode: ThemeMode = 'dark'): string {
+  return Platform.OS === 'web' ? `var(--color-${token})` : getSemanticColors(mode)[token]
+}


### PR DESCRIPTION
## What

Completes the cross-platform theming migration started in #74 (ThemeProvider + SetRow). Every remaining Workout organism moves its inline `var(--color-*)` colors to **nativewind className tokens** (`text-text-secondary`, `bg-surface-elevated`, `border-border`, …), which resolve against the ThemeProvider's `vars()` on native AND `global.css` on web. Every organism now renders correctly on the mobile app instead of black-on-black.

**20 organisms:** ActiveWorkoutPage, BodyMap, BodyMapDetailPanel, CapacityBandChart, ExerciseCard, ExerciseDetailPage, InputBar, MesoCard, MesoStatusCard, MuscleGroupChip, PlaceholderStrip, PrHistoryModal, ProgramPlanningPage, ReadinessCheck, RestTimer, StrengthTrendChart, TrainingStatusPage, VelocityStrip, WeekRow, WorkoutCard.

## Companion helper — `resolveColor(token)`

For the ~11 spots where a className can't apply — gradients (`backgroundImage`), per-edge borders (`borderTopColor`), SVG attributes, conditional hex/token mixes — `resolveColor` returns `var(--color-…)` on **web** (so the dashboard's light/dark switching is preserved) and resolved hex on **native**. Theme-correct on web, fixed on-device.

## How

Executed as a **6-agent fleet** with distinct file ownership, each following the merged SetRow as the reference; the lead verified centrally.

## Verify (web)

- `type-check` — 0 new errors (11 pre-existing react-hook-form)
- `vitest` — **1439 pass**, no regressions
- `build` — CJS+ESM+DTS green
- `lint` — clean
- **className validator** — 0 `var()` left; every added color class exists in `tailwind.config.js` (`bg-transparent` is a tailwind built-in)
- **Storybook-vet** highest-risk conversions — ExerciseCard, MesoStatusCard (gradient via resolveColor), RestTimer (`bg-border` track + per-edge border): all render correct colors, **0 console errors**

Native is bench-confirmed once mobile mounts `<ThemeProvider>`.

## Unblocks
The mobile `SetLog→SetRow` swap (VLT-09.33a) and the dashboard↔mobile convergence keystone — all titan organisms are now native-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)