### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-design/react-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Cross-platform design system built on Gluestack UI",
   "author": "Henry Jewkes",
   "license": "MIT",


### PR DESCRIPTION
Release **@titan-design/react-ui 0.4.0**.

## Included since 0.3.0
- **#74** — cross-platform `ThemeProvider` (nativewind `vars()`) + native-safe `SetRow`
- **#75** — remaining 20 Workout organisms native-safe (className tokens) + `resolveColor()` helper
- **#73** — `TempoBar` live phase-fill

## Nature
Additive: new `ThemeProvider` / `resolveColor` exports; organism color internals moved from inline `var()` to className tokens. **No breaking changes to the public component API.** Web rendering is preserved (className tokens resolve via `global.css`; the ~11 non-className spots use `resolveColor` → `var()` on web).

## Release mechanic
Merging this bumps `packages/ui` to 0.4.0; pushing tag `v0.4.0` triggers `publish.yml` (validate → npm publish with provenance → GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)