### PR TITLE
TempoDisplay: opt-in live phase-fill mode (VW-18 S2 / TD)

### DIFF
--- a/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useEffect, useState } from 'react'
 import { View } from 'react-native'
-import { TempoDisplay } from './TempoDisplay'
+import { TempoDisplay, type TempoLivePhase, type TempoLiveState } from './TempoDisplay'
 
 // tempo = [eccentric, pauseBottom, concentric, pauseTop]
 const meta: Meta<typeof TempoDisplay> = {
@@ -8,10 +9,17 @@ const meta: Meta<typeof TempoDisplay> = {
   component: TempoDisplay,
   tags: ['autodocs'],
   argTypes: {
-    tempo: { control: 'object', description: 'Tempo values [eccentric, pauseBottom, concentric, pauseTop] in seconds' },
+    tempo: {
+      control: 'object',
+      description: 'Tempo values [eccentric, pauseBottom, concentric, pauseTop] in seconds',
+    },
     size: { control: 'select', options: ['sm', 'md'], description: 'Size variant' },
     colored: { control: 'boolean', description: 'Colored vs mono display' },
     showInfo: { control: 'boolean', description: 'Show info tooltip on press' },
+    live: {
+      control: 'object',
+      description: 'Live phase-fill state (opt-in); omit for static prescription',
+    },
   },
 }
 
@@ -61,6 +69,65 @@ export const AllVariants: Story = {
         <TempoDisplay tempo={[3, 1, 1, 0]} size="sm" colored />
         <TempoDisplay tempo={[3, 1, 1, 0]} size="sm" colored={false} />
       </View>
+    </View>
+  ),
+}
+
+// --- Live phase-fill (opt-in) ----------------------------------------------
+
+// Deterministic mid-rep frames — the active phase digit fills against its target.
+export const LiveEccentricInProgress: Story = {
+  args: { tempo: [3, 1, 1, 0], live: { activePhase: 'eccentric', phaseElapsedMs: 1500 } },
+}
+
+// Concentric target is 1s; 1.6s elapsed is behind pace, so the digit turns red.
+export const LiveBehindPace: Story = {
+  args: { tempo: [3, 1, 1, 0], live: { activePhase: 'concentric', phaseElapsedMs: 1600 } },
+}
+
+const LIVE_CYCLE: { phase: TempoLivePhase; ms: number }[] = [
+  { phase: 'eccentric', ms: 3000 },
+  { phase: 'pauseBottom', ms: 1000 },
+  { phase: 'concentric', ms: 1000 },
+]
+
+function LiveTempoDemo() {
+  const [live, setLive] = useState<TempoLiveState>({ activePhase: 'eccentric', phaseElapsedMs: 0 })
+  useEffect(() => {
+    let idx = 0
+    let start = Date.now()
+    const id = setInterval(() => {
+      const step = LIVE_CYCLE[idx]
+      const elapsed = Date.now() - start
+      if (elapsed >= step.ms + 400) {
+        idx = (idx + 1) % LIVE_CYCLE.length
+        start = Date.now()
+      }
+      setLive({
+        activePhase: LIVE_CYCLE[idx].phase,
+        phaseElapsedMs: Math.min(elapsed, step.ms + 400),
+      })
+    }, 50)
+    return () => clearInterval(id)
+  }, [])
+  return <TempoDisplay tempo={[3, 1, 1, 0]} live={live} />
+}
+
+// Self-driving demo cycling Ecc → Pause → Con to show the fill animating.
+export const LiveAnimated: Story = {
+  render: () => <LiveTempoDemo />,
+}
+
+// Static and live side by side — the same prescription, two modes.
+export const StaticVsLive: Story = {
+  render: () => (
+    <View style={{ gap: 12 }}>
+      <TempoDisplay tempo={[3, 1, 1, 0]} />
+      <TempoDisplay
+        tempo={[3, 1, 1, 0]}
+        live={{ activePhase: 'eccentric', phaseElapsedMs: 1500 }}
+      />
+      <LiveTempoDemo />
     </View>
   ),
 }

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.test.tsx
@@ -80,6 +80,41 @@ describe('TempoDisplay', () => {
     })
   })
 
+  describe('live phase-fill', () => {
+    it('is inert by default (no active fill) for backward-compatible static use', () => {
+      render(<TempoDisplay tempo={[3, 1, 1, 0]} />)
+      expect(screen.queryByTestId('tempo-live-active')).not.toBeInTheDocument()
+    })
+
+    it('renders an active fill overlay for the in-progress phase when live', () => {
+      render(
+        <TempoDisplay
+          tempo={[3, 1, 1, 0]}
+          live={{ activePhase: 'eccentric', phaseElapsedMs: 1500 }}
+        />
+      )
+      expect(screen.getByTestId('tempo-live-active')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    it('marks no phase active when idle (activePhase null)', () => {
+      render(<TempoDisplay tempo={[3, 1, 1, 0]} live={{ activePhase: null, phaseElapsedMs: 0 }} />)
+      expect(screen.queryByTestId('tempo-live-active')).not.toBeInTheDocument()
+    })
+
+    it('still renders all four phase digits in live mode', () => {
+      render(
+        <TempoDisplay
+          tempo={[4, 3, 2, 1]}
+          live={{ activePhase: 'concentric', phaseElapsedMs: 500 }}
+        />
+      )
+      for (const digit of ['4', '3', '2', '1']) {
+        expect(screen.getByText(digit)).toBeInTheDocument()
+      }
+    })
+  })
+
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
       const { container } = render(<TempoDisplay tempo={[3, 1, 1, 0]} />)

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -2,6 +2,23 @@
 import { useState, useCallback } from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { roundTempo } from '../../../utils/workout-format'
+import { alpha } from '../../../utils/colors'
+import { getTempoFillPct, getTempoPacingState } from './TempoBar'
+
+/** The four tempo phases, in the order the display renders them. */
+export type TempoLivePhase = 'eccentric' | 'pauseBottom' | 'concentric' | 'pauseTop'
+
+/**
+ * Live rep state driving the phase-fill overlay. Controlled by the consumer
+ * (matching titan's `elapsedMs`-in convention) so the same real timer feeds
+ * both web dashboard and native app — TempoDisplay owns rendering only.
+ */
+export interface TempoLiveState {
+  /** Phase currently in progress, or null when idle/at rest. */
+  activePhase: TempoLivePhase | null
+  /** Elapsed time (ms) within the active phase. */
+  phaseElapsedMs: number
+}
 
 export interface TempoDisplayProps extends ViewProps {
   /** Tempo values: [eccentric, pauseBottom, concentric, pauseTop] in seconds */
@@ -11,12 +28,19 @@ export interface TempoDisplayProps extends ViewProps {
   colored?: boolean
   /** Show info tooltip on press */
   showInfo?: boolean
+  /**
+   * When set, renders a live phase-fill: the active phase digit fills against
+   * its prescribed duration and inactive phases dim. Omit for the static
+   * prescription string (default, backward compatible).
+   */
+  live?: TempoLiveState
   onPress?: () => void
   className?: string
 }
 
 const INTER = 'Inter, sans-serif'
 const TEXT_TERTIARY = '#6B7280'
+const STATUS_ERROR = '#D14343' // status-error (red), shown when a phase runs behind pace
 
 // Phase colors: [eccentric, pauseBottom, concentric, pauseTop]
 const phaseColors = {
@@ -67,11 +91,84 @@ function TempoSeparator({ color, fontSize }: { color: string; fontSize: number }
   )
 }
 
+// Phase order + color matching the tempo tuple, for the live phase-fill row.
+const LIVE_PHASES: { key: TempoLivePhase; color: string }[] = [
+  { key: 'eccentric', color: phaseColors.eccentric },
+  { key: 'pauseBottom', color: phaseColors.pauseBottom },
+  { key: 'concentric', color: phaseColors.concentric },
+  { key: 'pauseTop', color: phaseColors.pauseTop },
+]
+
+function LiveTempoCell({
+  value,
+  color,
+  isActive,
+  phaseElapsedMs,
+  fontSize,
+}: {
+  value: number
+  color: string
+  isActive: boolean
+  phaseElapsedMs: number
+  fontSize: number
+}) {
+  if (!isActive) {
+    return <TempoValue value={value} color={alpha(color, 0.35)} fontSize={fontSize} />
+  }
+  const targetMs = value > 0 ? value * 1000 : null
+  const barColor = getTempoPacingState(phaseElapsedMs, targetMs) === 'behind' ? STATUS_ERROR : color
+  const fillPct = getTempoFillPct(phaseElapsedMs, targetMs)
+  return (
+    <View style={{ position: 'relative' }} testID="tempo-live-active">
+      <View
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: `${fillPct}%`,
+          backgroundColor: alpha(barColor, 0.3),
+          borderRadius: 2,
+        }}
+      />
+      <TempoValue value={value} color={barColor} fontSize={fontSize} />
+    </View>
+  )
+}
+
+function LiveTempoRow({
+  values,
+  live,
+  fontSize,
+}: {
+  values: [number, number, number, number]
+  live: TempoLiveState
+  fontSize: number
+}) {
+  return (
+    <>
+      {LIVE_PHASES.map((phase, i) => (
+        <View key={phase.key} style={{ flexDirection: 'row' }}>
+          {i > 0 && <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />}
+          <LiveTempoCell
+            value={values[i]}
+            color={phase.color}
+            isActive={live.activePhase === phase.key}
+            phaseElapsedMs={live.phaseElapsedMs}
+            fontSize={fontSize}
+          />
+        </View>
+      ))}
+    </>
+  )
+}
+
 export function TempoDisplay({
   tempo,
   size = 'md',
   colored = true,
   showInfo = true,
+  live,
   onPress,
   className,
   ...props
@@ -119,7 +216,13 @@ export function TempoDisplay({
         TEMPO
       </Text>
       <View style={{ flexDirection: 'row' }} testID="tempo-value">
-        {colored ? (
+        {live ? (
+          <LiveTempoRow
+            values={[eccentric, pauseBottom, concentric, pauseTop]}
+            live={live}
+            fontSize={fontSize}
+          />
+        ) : colored ? (
           <>
             <TempoValue value={eccentric} color={phaseColors.eccentric} fontSize={fontSize} />
             <TempoSeparator color={phaseColors.dash} fontSize={fontSize} />

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -8,7 +8,12 @@ export { WeightBadge, type WeightBadgeProps, type WeightBadgeSize } from './Weig
 export { PrBadge, type PrBadgeProps, type PRType } from './PrBadge'
 export { StatusDot, type StatusDotVariant, type StatusDotProps } from './StatusDot'
 export { PlaceholderStrip, type PlaceholderStripProps } from './PlaceholderStrip'
-export { TempoDisplay, type TempoDisplayProps } from './TempoDisplay'
+export {
+  TempoDisplay,
+  type TempoDisplayProps,
+  type TempoLivePhase,
+  type TempoLiveState,
+} from './TempoDisplay'
 export {
   TempoBar,
   type TempoBarProps,


### PR DESCRIPTION
## What

Adds an opt-in **live phase-fill** mode to `TempoDisplay`, promoting the live-tempo capability that previously only existed in the mobile `TempoBar` up into the shared titan component (VW-18 convergence slice S2 — bidirectional reuse: the dashboard gains live tempo now, mobile consumes it back later).

## Design

- **Backward compatible.** New optional `live?: TempoLiveState` prop. Omit it → the existing static prescription string renders exactly as before (default path unchanged).
- **Controlled component.** The consumer owns the timer and passes `{ activePhase, phaseElapsedMs }` in — matching titan's existing `elapsedMs`-in convention. No internal animation loop, so it works uniformly on web (react-native-web) and native.
- **Reuses existing titan helpers.** Fill % and pacing state come from the already-shipped `getTempoFillPct` / `getTempoPacingState` in sibling `TempoBar` — no duplicated timing logic. Active phase fills against its prescribed duration; inactive phases dim (`alpha(color, 0.35)`); a phase running behind pace turns status-error red.

## Verification (no hardware)

- `type-check` ✓
- `lint` — 0 errors (changed files clean)
- full ui test suite — **1446 passed** (17 in TempoDisplay incl. new live-mode cases)
- `build` (tsup) ✓ — DTS generated
- Storybook story extended to demo both static and live modes

New exports: `TempoLivePhase`, `TempoLiveState`.