### PR TITLE
IntensityBar rich model + RestTimer display-only + PrBadge compact parity (TD-04.12/S5/TD-04.13)

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -112,8 +112,7 @@ const HTML_CSS = `
   }
   .html-scope .pr-badge-compact {
     display: inline-flex;
-    color: var(--brand-primary);
-    font-size: 13px;
+    align-items: center;
   }
 
   /* 3. StatusDot */
@@ -756,6 +755,11 @@ function SectionHeader({ title }: { title: string }) {
 const dumbbellSvg = (w: number, h: number) =>
   `<svg viewBox="0 0 24 24" width="${w}" height="${h}" style="stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;fill:none;display:block"><path d="M14.4 14.4 9.6 9.6"/><path d="M18.657 21.485a2 2 0 1 1-2.829-2.828l-1.767 1.768a2 2 0 1 1-2.829-2.829l6.364-6.364a2 2 0 1 1 2.829 2.829l-1.768 1.767a2 2 0 1 1 2.828 2.829z"/><path d="m21.5 21.5-1.4-1.4"/><path d="M3.9 3.9 2.5 2.5"/><path d="M6.404 12.768a2 2 0 1 1-2.829-2.829l1.768-1.767a2 2 0 1 1-2.828-2.829l2.828-2.828a2 2 0 1 1 2.829 2.828l1.767-1.768a2 2 0 1 1 2.829 2.829z"/></svg>`
 
+/* Star SVG for the compact PrBadge (mirrors lucide-react's Star rendered by PrBadge:
+   size=14, fill/stroke #FF7900, strokeWidth 2). */
+const starSvg = (w: number, h: number) =>
+  `<svg viewBox="0 0 24 24" width="${w}" height="${h}" style="fill:#FF7900;stroke:#FF7900;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;display:block"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`
+
 /* ─────────────────────────────────────────────
    App
    ───────────────────────────────────────────── */
@@ -856,7 +860,7 @@ function App() {
       <ComparisonPair
         testId="compare-pr-badge-compact"
         label="PrBadge compact"
-        htmlContent={`<span class="pr-badge-compact">\u2605</span>`}
+        htmlContent={`<span class="pr-badge-compact">${starSvg(14, 14)}</span>`}
       >
         <PrBadge compact animate={false} />
       </ComparisonPair>

--- a/packages/ui/specimen/comparison.visual.test.ts
+++ b/packages/ui/specimen/comparison.visual.test.ts
@@ -408,11 +408,9 @@ test.describe('HTML vs React Component Comparison', () => {
     )
   })
 
-  // QUARANTINED (test.fixme) pending TD-04.13: not a component regression — the
-  // compact badge intentionally renders a Lucide SVG <Star> (per PrBadge.test.tsx),
-  // but the GT still emits a text ★ glyph, so the harness measures the SVG
-  // container as text and mismatches. Resolve by rendering an SVG star in the GT.
-  test.fixme('PrBadge compact', async ({ page }) => {
+  // TD-04.13 resolved: the GT now emits an inline orange <Star> SVG (14px, #FF7900)
+  // to match the component's Lucide <Star>, so the compact badge reaches parity.
+  test('PrBadge compact', async ({ page }) => {
     await assertStyleMatch(
       page, 'compare-pr-badge-compact',
       '.pr-badge-compact', '[data-testid="pr-badge-star"]',

--- a/packages/ui/specimen/comparison.visual.test.ts
+++ b/packages/ui/specimen/comparison.visual.test.ts
@@ -705,18 +705,15 @@ test.describe('HTML vs React Component Comparison', () => {
   }
 
   // ── IntensityBar ──
-  // QUARANTINED (test.fixme) pending TD-04.12: these 7 parity failures are a
-  // genuine design fork, not stale ground truth. The frozen-HTML GT encodes a
-  // rich workout-semantic model (numeric %-label, teal→amber→graded-red zones,
-  // at-target blue glow, >100% over-target grading + bulge) that the React
-  // component deliberately does NOT implement — its 0.4/0.7 zone boundaries and
-  // label-less bar are locked by IntensityBar.test.tsx, so reconciling either
-  // way is a product decision (redesign + test rewrites, or GT rebaseline).
+  // TD-04.12 resolved: the React component now implements the rich workout-semantic
+  // model encoded by the frozen-HTML GT — numeric %-label, teal→amber→graded-red
+  // zones, at-target blue glow + target line, and >100% over-target grading + bulge —
+  // so these 7 variants reach parity.
   const intensityBarProps = [
     'alignItems', 'display', 'flexDirection',
   ] as const
 
-  test.fixme('IntensityBar 20% building', async ({ page }) => {
+  test('IntensityBar 20% building', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-20', '.intensity-bar', '[data-testid="intensity-bar"]',
       intensityBarProps,
     )
@@ -725,7 +722,7 @@ test.describe('HTML vs React Component Comparison', () => {
     )
   })
 
-  test.fixme('IntensityBar 75% approaching', async ({ page }) => {
+  test('IntensityBar 75% approaching', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-75', '.intensity-bar', '[data-testid="intensity-bar"]',
       intensityBarProps,
     )
@@ -734,13 +731,13 @@ test.describe('HTML vs React Component Comparison', () => {
     )
   })
 
-  test.fixme('IntensityBar 100% target', async ({ page }) => {
+  test('IntensityBar 100% target', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-100', '.intensity-bar', '[data-testid="intensity-bar"]',
       intensityBarProps,
     )
   })
 
-  test.fixme('IntensityBar 110% over', async ({ page }) => {
+  test('IntensityBar 110% over', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-110', '.intensity-fill', '[data-testid="intensity-fill"]',
       ['backgroundColor'] as const,
     )
@@ -761,7 +758,7 @@ test.describe('HTML vs React Component Comparison', () => {
     }
   })
 
-  test.fixme('IntensityBar 50% at target (blue glow)', async ({ page }) => {
+  test('IntensityBar 50% at target (blue glow)', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-50-target', '.intensity-fill', '[data-testid="intensity-fill"]',
       ['backgroundColor', 'boxShadow'] as const,
     )
@@ -783,7 +780,7 @@ test.describe('HTML vs React Component Comparison', () => {
   })
 
   // Priority 3e: IntensityBar over-2 and over-3
-  test.fixme('IntensityBar 120% over-2', async ({ page }) => {
+  test('IntensityBar 120% over-2', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-120', '.intensity-bar', '[data-testid="intensity-bar"]',
       intensityBarProps,
     )
@@ -807,7 +804,7 @@ test.describe('HTML vs React Component Comparison', () => {
     }
   })
 
-  test.fixme('IntensityBar 130% over-3', async ({ page }) => {
+  test('IntensityBar 130% over-3', async ({ page }) => {
     await assertStyleMatch(page, 'compare-intensity-130', '.intensity-bar', '[data-testid="intensity-bar"]',
       intensityBarProps,
     )

--- a/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { IntensityBar } from './IntensityBar'
 
+const AT_TARGET_GLOW = '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(33, 150, 243, 0.15)'
+
 describe('IntensityBar', () => {
   it('renders the bar', () => {
     render(<IntensityBar level={0.5} />)
@@ -14,98 +16,148 @@ describe('IntensityBar', () => {
     expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
   })
 
-  it('renders threshold line when threshold is provided', () => {
-    render(<IntensityBar level={0.5} threshold={0.85} />)
-    expect(screen.getByTestId('intensity-threshold')).toBeInTheDocument()
-  })
-
-  it('does not render threshold line when threshold is omitted', () => {
-    render(<IntensityBar level={0.5} />)
-    expect(screen.queryByTestId('intensity-threshold')).not.toBeInTheDocument()
-  })
-
-  it('shows MRV label when showThresholdLabel is true and threshold set', () => {
-    render(<IntensityBar level={0.6} threshold={0.85} showThresholdLabel />)
-    expect(screen.getByText('MRV')).toBeInTheDocument()
-  })
-
-  it('hides MRV label when showThresholdLabel is false', () => {
-    render(<IntensityBar level={0.6} threshold={0.85} />)
-    expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
-  })
-
-  it('hides MRV label when threshold is omitted even if showThresholdLabel is true', () => {
-    render(<IntensityBar level={0.6} showThresholdLabel />)
-    expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
-  })
-
   it('has correct accessibility role', () => {
     render(<IntensityBar level={0.5} />)
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
-  it('maps level 0-1 to percentage in accessibility label', () => {
-    render(<IntensityBar level={0.75} />)
-    expect(screen.getByLabelText('Intensity level: 75%')).toBeInTheDocument()
+  describe('numeric percentage label', () => {
+    it('renders the level as a percentage under the bar', () => {
+      render(<IntensityBar level={0.2} />)
+      expect(screen.getByTestId('intensity-label')).toHaveTextContent('20%')
+    })
+
+    it('renders over-target percentages above 100', () => {
+      render(<IntensityBar level={1.3} />)
+      expect(screen.getByTestId('intensity-label')).toHaveTextContent('130%')
+    })
+
+    it('mirrors the label in the accessibility value', () => {
+      render(<IntensityBar level={1.1} />)
+      expect(screen.getByLabelText('Intensity level: 110%')).toBeInTheDocument()
+    })
+
+    it('floors a negative level to 0%', () => {
+      render(<IntensityBar level={-0.5} />)
+      expect(screen.getByTestId('intensity-label')).toHaveTextContent('0%')
+    })
   })
 
-  it('clamps level above 1 to 100%', () => {
-    render(<IntensityBar level={1.5} />)
-    expect(screen.getByLabelText('Intensity level: 100%')).toBeInTheDocument()
-  })
-
-  it('clamps level below 0 to 0%', () => {
-    render(<IntensityBar level={-0.5} />)
-    expect(screen.getByLabelText('Intensity level: 0%')).toBeInTheDocument()
-  })
-
-  it('renders horizontal orientation', () => {
-    render(<IntensityBar level={0.5} orientation="horizontal" />)
-    expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
-  })
-
-  it('accepts custom size and thickness', () => {
-    render(<IntensityBar level={0.5} size={32} thickness={8} />)
-    expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
-  })
-
-  describe('fill zones', () => {
-    it('renders teal fill for low levels (0-0.4)', () => {
-      render(<IntensityBar level={0.3} />)
+  describe('zone colors graded by true percentage', () => {
+    it('renders teal below the target ramp (< 75%)', () => {
+      render(<IntensityBar level={0.2} />)
       expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#14B8A6' })
     })
 
-    it('renders amber fill for moderate levels (0.4-0.7)', () => {
+    it('stays teal just under the amber boundary', () => {
+      render(<IntensityBar level={0.74} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#14B8A6' })
+    })
+
+    it('renders amber approaching the target (75-99%)', () => {
+      render(<IntensityBar level={0.75} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FFB020' })
+    })
+
+    it('renders the brand target color exactly at 100%', () => {
+      render(<IntensityBar level={1} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FF7900' })
+    })
+
+    it('renders over-1 red just past target (110%)', () => {
+      render(<IntensityBar level={1.1} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#D14343' })
+    })
+
+    it('renders over-2 deep red at 120%', () => {
+      render(<IntensityBar level={1.2} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#A62626' })
+    })
+
+    it('renders over-3 darkest red at 130%', () => {
+      render(<IntensityBar level={1.3} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#7A1C1C' })
+    })
+  })
+
+  describe('over-target bulge', () => {
+    it('renders a bulge when the level exceeds target', () => {
+      render(<IntensityBar level={1.1} />)
+      expect(screen.getByTestId('intensity-bulge')).toBeInTheDocument()
+    })
+
+    it('colors the bulge to match the over-target zone', () => {
+      render(<IntensityBar level={1.2} />)
+      expect(screen.getByTestId('intensity-bulge')).toHaveStyle({ backgroundColor: '#A62626' })
+    })
+
+    it('does not render a bulge at or below target', () => {
+      render(<IntensityBar level={1} />)
+      expect(screen.queryByTestId('intensity-bulge')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('target line', () => {
+    it('renders the target line when threshold is provided', () => {
+      render(<IntensityBar level={0.5} threshold={0.5} />)
+      expect(screen.getByTestId('intensity-target')).toBeInTheDocument()
+    })
+
+    it('does not render the target line when threshold is omitted', () => {
       render(<IntensityBar level={0.5} />)
-      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FFB020' })
+      expect(screen.queryByTestId('intensity-target')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('at-target glow', () => {
+    it('applies the blue glow when the level rests on the target', () => {
+      render(<IntensityBar level={0.5} threshold={0.5} />)
+      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ boxShadow: AT_TARGET_GLOW })
     })
 
-    it('renders red fill for high levels (0.7-1.0)', () => {
-      render(<IntensityBar level={0.85} />)
-      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#D14343' })
+    it('does not glow when the level is away from the target', () => {
+      render(<IntensityBar level={0.2} threshold={0.85} />)
+      expect(screen.getByTestId('intensity-fill')).not.toHaveStyle({ boxShadow: AT_TARGET_GLOW })
     })
 
-    it('uses teal at the lower zone boundary', () => {
-      render(<IntensityBar level={0.39} />)
-      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#14B8A6' })
+    it('does not glow when no threshold is provided', () => {
+      render(<IntensityBar level={0.5} />)
+      expect(screen.getByTestId('intensity-fill')).not.toHaveStyle({ boxShadow: AT_TARGET_GLOW })
+    })
+  })
+
+  describe('MRV threshold label', () => {
+    it('shows MRV when showThresholdLabel is true and threshold set', () => {
+      render(<IntensityBar level={0.6} threshold={0.85} showThresholdLabel />)
+      expect(screen.getByText('MRV')).toBeInTheDocument()
     })
 
-    it('uses amber at the 0.4 boundary', () => {
-      render(<IntensityBar level={0.4} />)
-      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#FFB020' })
+    it('hides MRV when showThresholdLabel is false', () => {
+      render(<IntensityBar level={0.6} threshold={0.85} />)
+      expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
     })
 
-    it('uses red at the 0.7 boundary', () => {
-      render(<IntensityBar level={0.7} />)
-      expect(screen.getByTestId('intensity-fill')).toHaveStyle({ backgroundColor: '#D14343' })
+    it('hides MRV when threshold is omitted even if showThresholdLabel is true', () => {
+      render(<IntensityBar level={0.6} showThresholdLabel />)
+      expect(screen.queryByTestId('intensity-threshold-label')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('geometry', () => {
+    it('renders horizontal orientation', () => {
+      render(<IntensityBar level={0.5} orientation="horizontal" />)
+      expect(screen.getByTestId('intensity-fill')).toBeInTheDocument()
+    })
+
+    it('accepts custom size and thickness', () => {
+      render(<IntensityBar level={0.5} size={36} thickness={8} />)
+      expect(screen.getByTestId('intensity-bar')).toBeInTheDocument()
     })
   })
 
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
-      const { container } = render(
-        <IntensityBar level={0.5} threshold={0.85} showThresholdLabel />,
-      )
+      const { container } = render(<IntensityBar level={0.5} threshold={0.85} showThresholdLabel />)
       const results = await axe(container)
       expect(results).toHaveNoViolations()
     })

--- a/packages/ui/src/components/custom/Workout/IntensityBar.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.tsx
@@ -1,13 +1,20 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState } from 'react'
-import { View, Text, Animated, type ViewProps, type ViewStyle } from 'react-native'
+import {
+  View,
+  Text,
+  Animated,
+  type ViewProps,
+  type ViewStyle,
+  type DimensionValue,
+} from 'react-native'
 
 export type IntensityBarOrientation = 'vertical' | 'horizontal'
 
 export interface IntensityBarProps extends ViewProps {
-  /** Current intensity level 0-1 */
+  /** Current intensity level; 1 == 100% of target. Values >1 render as over-target. */
   level: number
-  /** MRV/overexertion threshold position 0-1 */
+  /** Target position 0-1. When the level sits at this target the fill gains an at-target glow. */
   threshold?: number
   /** Orientation */
   orientation?: IntensityBarOrientation
@@ -15,26 +22,55 @@ export interface IntensityBarProps extends ViewProps {
   size?: number
   /** Width for vertical (default 6px) or height for horizontal */
   thickness?: number
-  /** Show threshold label ("MRV") */
+  /** Show the "MRV" threshold label under the bar */
   showThresholdLabel?: boolean
   className?: string
 }
 
-const TRACK_BG = 'rgba(255,255,255,0.06)'
-const THRESHOLD_COLOR = '#FFFFFF'
+const TRACK_BG = '#333333'
 const LABEL_COLOR = '#6B7280'
+const TARGET_LINE_COLOR = 'rgba(33, 150, 243, 0.5)'
+const AT_TARGET_GLOW = '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(33, 150, 243, 0.15)'
 
-/** Fill color by intensity zone: teal 0-0.4, amber 0.4-0.7, red 0.7-1.0. */
-function getZoneColor(level: number): string {
-  if (level >= 0.7) return '#D14343'
-  if (level >= 0.4) return '#FFB020'
-  return '#14B8A6'
+// Zone colors graded by TRUE percentage (level * 100).
+const ZONE = {
+  building: '#14B8A6', // teal   — below target ramp-up
+  approaching: '#FFB020', // amber  — nearing target
+  target: '#FF7900', // brand  — exactly at target
+  over1: '#D14343', // red    — mild over-target
+  over2: '#A62626', // deep red — moderate over-target
+  over3: '#7A1C1C', // darkest red — severe over-target
+} as const
+
+type OverTier = 0 | 1 | 2 | 3
+
+interface Zone {
+  color: string
+  over: OverTier
 }
 
-function clamp01(value: number): number {
+const BULGE_SIZE: Record<Exclude<OverTier, 0>, number> = { 1: 8, 2: 10, 3: 11 }
+
+/** Map a true percentage to its fill color and over-target tier. */
+function zoneForPct(pct: number): Zone {
+  if (pct >= 125) return { color: ZONE.over3, over: 3 }
+  if (pct >= 115) return { color: ZONE.over2, over: 2 }
+  if (pct > 100) return { color: ZONE.over1, over: 1 }
+  if (pct === 100) return { color: ZONE.target, over: 0 }
+  if (pct >= 75) return { color: ZONE.approaching, over: 0 }
+  return { color: ZONE.building, over: 0 }
+}
+
+function clampFill(value: number): number {
   if (value < 0) return 0
   if (value > 1) return 1
   return value
+}
+
+/** True when the level rests on the supplied target (within 5%). */
+function isAtTarget(pct: number, threshold?: number): boolean {
+  if (threshold == null) return false
+  return Math.abs(pct - Math.round(threshold * 100)) <= 5
 }
 
 export function IntensityBar({
@@ -48,21 +84,22 @@ export function IntensityBar({
   ...props
 }: IntensityBarProps) {
   const isVertical = orientation === 'vertical'
-  const clampedLevel = clamp01(level)
-  const percentage = Math.round(clampedLevel * 100)
-  const zoneColor = getZoneColor(clampedLevel)
+  const fillLevel = clampFill(level)
+  const pct = Math.round(Math.max(0, level) * 100)
+  const zone = zoneForPct(pct)
+  const atTarget = isAtTarget(pct, threshold)
 
-  const [fillAnim] = useState(() => new Animated.Value(clampedLevel))
+  const [fillAnim] = useState(() => new Animated.Value(fillLevel))
 
   useEffect(() => {
     const animation = Animated.timing(fillAnim, {
-      toValue: clampedLevel,
+      toValue: fillLevel,
       duration: 250,
       useNativeDriver: false,
     })
     animation.start()
     return () => animation.stop()
-  }, [clampedLevel, fillAnim])
+  }, [fillLevel, fillAnim])
 
   const fillSizePercent = fillAnim.interpolate({
     inputRange: [0, 1],
@@ -74,51 +111,50 @@ export function IntensityBar({
     : { width: size, height: thickness }
 
   const fillStyle = isVertical
+    ? { position: 'absolute' as const, bottom: 0, left: 0, right: 0, height: fillSizePercent }
+    : { position: 'absolute' as const, top: 0, bottom: 0, left: 0, width: fillSizePercent }
+
+  const bulgeSize = zone.over === 0 ? 0 : BULGE_SIZE[zone.over]
+  const bulgeStyle: ViewStyle = {
+    position: 'absolute',
+    width: bulgeSize,
+    height: bulgeSize,
+    borderRadius: bulgeSize / 2,
+    backgroundColor: zone.color,
+    zIndex: 1,
+    ...(isVertical
+      ? { top: 0, left: '50%', transform: [{ translateX: -bulgeSize / 2 }] }
+      : { right: 0, top: '50%', transform: [{ translateY: -bulgeSize / 2 }] }),
+  }
+
+  const targetPct: DimensionValue = `${clampFill(threshold ?? 0) * 100}%`
+  const targetLineStyle: ViewStyle = isVertical
     ? {
-        position: 'absolute' as const,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        height: fillSizePercent,
+        position: 'absolute',
+        bottom: targetPct,
+        left: -3,
+        right: -3,
+        height: 1.5,
+        backgroundColor: TARGET_LINE_COLOR,
+        zIndex: 4,
       }
     : {
-        position: 'absolute' as const,
-        top: 0,
-        bottom: 0,
-        left: 0,
-        width: fillSizePercent,
+        position: 'absolute',
+        left: targetPct,
+        top: -3,
+        bottom: -3,
+        width: 1.5,
+        backgroundColor: TARGET_LINE_COLOR,
+        zIndex: 4,
       }
-
-  const thresholdLineStyle: ViewStyle | undefined =
-    threshold != null
-      ? isVertical
-        ? {
-            position: 'absolute' as const,
-            bottom: `${clamp01(threshold) * 100}%`,
-            left: -2,
-            right: -2,
-            height: 1,
-            backgroundColor: THRESHOLD_COLOR,
-            zIndex: 4,
-          }
-        : {
-            position: 'absolute' as const,
-            left: `${clamp01(threshold) * 100}%`,
-            top: -2,
-            bottom: -2,
-            width: 1,
-            backgroundColor: THRESHOLD_COLOR,
-            zIndex: 4,
-          }
-      : undefined
 
   return (
     <View
       className={className}
       style={{ alignItems: 'center' }}
       accessibilityRole="progressbar"
-      accessibilityValue={{ min: 0, max: 100, now: percentage }}
-      accessibilityLabel={`Intensity level: ${percentage}%`}
+      accessibilityValue={{ min: 0, max: 100, now: pct }}
+      accessibilityLabel={`Intensity level: ${pct}%`}
       testID="intensity-bar"
       {...props}
     >
@@ -136,16 +172,31 @@ export function IntensityBar({
           style={{
             ...fillStyle,
             borderRadius: 3,
-            backgroundColor: zoneColor,
+            backgroundColor: zone.color,
             zIndex: 2,
+            ...(atTarget ? { boxShadow: AT_TARGET_GLOW } : null),
           }}
           testID="intensity-fill"
         />
 
-        {threshold != null && (
-          <View style={thresholdLineStyle} testID="intensity-threshold" />
-        )}
+        {zone.over !== 0 && <View style={bulgeStyle} testID="intensity-bulge" />}
+
+        {threshold != null && <View style={targetLineStyle} testID="intensity-target" />}
       </View>
+
+      <Text
+        style={{
+          fontSize: 8,
+          color: LABEL_COLOR,
+          fontFamily: '"Nunito Sans", sans-serif',
+          marginTop: 6,
+        }}
+        accessibilityElementsHidden
+        testID="intensity-label"
+      >
+        {pct}%
+      </Text>
+
       {showThresholdLabel && threshold != null && (
         <Text
           style={{
@@ -153,7 +204,7 @@ export function IntensityBar({
             fontWeight: '500',
             color: LABEL_COLOR,
             fontFamily: 'Inter, sans-serif',
-            marginTop: 6,
+            marginTop: 2,
           }}
           accessibilityElementsHidden
           testID="intensity-threshold-label"

--- a/packages/ui/src/components/custom/Workout/RestTimer.test.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.test.tsx
@@ -75,16 +75,51 @@ describe('RestTimer', () => {
     })
   })
 
-  describe('next set info', () => {
-    it('displays nextSetInfo when provided', () => {
+  describe('display-only mode', () => {
+    it('renders the Skip and +30s actions by default', () => {
+      render(<RestTimer {...defaultProps} />)
+      expect(screen.getByTestId('rest-timer-skip')).toBeInTheDocument()
+      expect(screen.getByTestId('rest-timer-add-time')).toBeInTheDocument()
+    })
+
+    it('hides the Skip and +30s actions when displayOnly', () => {
+      render(<RestTimer {...defaultProps} displayOnly />)
+      expect(screen.queryByTestId('rest-timer-skip')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('rest-timer-add-time')).not.toBeInTheDocument()
+    })
+
+    it('keeps the countdown, progress bar, and next-set line when displayOnly', () => {
       render(
         <RestTimer
           {...defaultProps}
+          elapsedMs={30000}
+          displayOnly
           nextSetInfo="Bench Press — Set 3 of 4"
-        />,
+        />
       )
+      expect(screen.getByTestId('rest-timer-time')).toHaveTextContent('2:00')
+      expect(screen.getByTestId('rest-timer-progress-fill')).toBeInTheDocument()
       expect(screen.getByTestId('rest-timer-next-set')).toHaveTextContent(
-        'Bench Press — Set 3 of 4',
+        'Bench Press — Set 3 of 4'
+      )
+    })
+
+    it('does not fire callbacks in display-only mode (controls absent)', () => {
+      const onSkip = vi.fn()
+      const onAddTime = vi.fn()
+      render(<RestTimer {...defaultProps} onSkip={onSkip} onAddTime={onAddTime} displayOnly />)
+      expect(screen.queryByLabelText('Skip rest')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Add 30 seconds')).not.toBeInTheDocument()
+      expect(onSkip).not.toHaveBeenCalled()
+      expect(onAddTime).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('next set info', () => {
+    it('displays nextSetInfo when provided', () => {
+      render(<RestTimer {...defaultProps} nextSetInfo="Bench Press — Set 3 of 4" />)
+      expect(screen.getByTestId('rest-timer-next-set')).toHaveTextContent(
+        'Bench Press — Set 3 of 4'
       )
     })
 
@@ -127,9 +162,7 @@ describe('RestTimer', () => {
 
     it('has timer role with remaining seconds in label', () => {
       render(<RestTimer {...defaultProps} totalSeconds={90} elapsedMs={30000} />)
-      expect(
-        screen.getByLabelText('Rest timer, 60 seconds remaining'),
-      ).toBeInTheDocument()
+      expect(screen.getByLabelText('Rest timer, 60 seconds remaining')).toBeInTheDocument()
     })
 
     it('skip button has accessible label', () => {
@@ -146,9 +179,7 @@ describe('RestTimer', () => {
 
 describe('RestTimer zero-duration timer (NaN guard)', () => {
   it('emits a valid 100% width (not NaN) when totalSeconds is 0', () => {
-    const { container } = render(
-      <RestTimer {...defaultProps} totalSeconds={0} elapsedMs={0} />,
-    )
+    const { container } = render(<RestTimer {...defaultProps} totalSeconds={0} elapsedMs={0} />)
     expect(screen.getByTestId('rest-timer-progress-fill')).toHaveStyle({ width: '100%' })
     expect(container.innerHTML).not.toContain('NaN')
   })

--- a/packages/ui/src/components/custom/Workout/RestTimer.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.tsx
@@ -11,6 +11,8 @@ export interface RestTimerProps {
   onAddTime: () => void
   nextSetInfo?: string
   visible: boolean
+  /** Passive/poll-only mode: hides the Skip and +30s controls, keeps the countdown, progress bar, and next-set line. */
+  displayOnly?: boolean
 }
 
 export function RestTimer({
@@ -20,6 +22,7 @@ export function RestTimer({
   onAddTime,
   nextSetInfo,
   visible,
+  displayOnly = false,
 }: RestTimerProps) {
   if (!visible) return null
 
@@ -123,55 +126,57 @@ export function RestTimer({
         />
       </View>
 
-      {/* Actions row */}
-      <View style={{ flexDirection: 'row', gap: 8 }}>
-        <Pressable
-          onPress={onAddTime}
-          style={{
-            backgroundColor: 'rgba(255,255,255,0.06)',
-            paddingVertical: 8,
-            paddingHorizontal: 20,
-            borderRadius: 8,
-          }}
-          accessibilityRole="button"
-          accessibilityLabel="Add 30 seconds"
-          testID="rest-timer-add-time"
-        >
-          <Text
-            className="text-text-secondary"
+      {/* Actions row — hidden in display-only (poll-only) mode */}
+      {!displayOnly && (
+        <View style={{ flexDirection: 'row', gap: 8 }}>
+          <Pressable
+            onPress={onAddTime}
             style={{
-              fontSize: 11,
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: '600',
+              backgroundColor: 'rgba(255,255,255,0.06)',
+              paddingVertical: 8,
+              paddingHorizontal: 20,
+              borderRadius: 8,
             }}
+            accessibilityRole="button"
+            accessibilityLabel="Add 30 seconds"
+            testID="rest-timer-add-time"
           >
-            +30s
-          </Text>
-        </Pressable>
-        <Pressable
-          onPress={onSkip}
-          style={{
-            backgroundColor: 'rgba(255,121,0,0.12)',
-            paddingVertical: 8,
-            paddingHorizontal: 20,
-            borderRadius: 8,
-          }}
-          accessibilityRole="button"
-          accessibilityLabel="Skip rest"
-          testID="rest-timer-skip"
-        >
-          <Text
+            <Text
+              className="text-text-secondary"
+              style={{
+                fontSize: 11,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '600',
+              }}
+            >
+              +30s
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={onSkip}
             style={{
-              fontSize: 11,
-              fontFamily: 'Inter, sans-serif',
-              fontWeight: '600',
-              color: BRAND_PRIMARY,
+              backgroundColor: 'rgba(255,121,0,0.12)',
+              paddingVertical: 8,
+              paddingHorizontal: 20,
+              borderRadius: 8,
             }}
+            accessibilityRole="button"
+            accessibilityLabel="Skip rest"
+            testID="rest-timer-skip"
           >
-            Skip
-          </Text>
-        </Pressable>
-      </View>
+            <Text
+              style={{
+                fontSize: 11,
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: '600',
+                color: BRAND_PRIMARY,
+              }}
+            >
+              Skip
+            </Text>
+          </Pressable>
+        </View>
+      )}
     </View>
   )
 }

--- a/packages/ui/src/components/custom/Workout/WeekRow.test.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.test.tsx
@@ -37,12 +37,12 @@ describe('WeekRow', () => {
 
     it('passes the threshold through to the intensity bar', () => {
       render(<WeekRow {...baseProps} intensityThreshold={0.8} />)
-      expect(screen.getByTestId('intensity-threshold')).toBeInTheDocument()
+      expect(screen.getByTestId('intensity-target')).toBeInTheDocument()
     })
 
     it('omits the threshold line when not provided', () => {
       render(<WeekRow {...baseProps} />)
-      expect(screen.queryByTestId('intensity-threshold')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('intensity-target')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
Three independent Workout-component / parity changes, one commit each.

### TD-04.12 — IntensityBar rich over-target model
Rewrites `IntensityBar` to match the frozen-HTML ground truth:
- Numeric `%`-label under the bar (`intensity-label`).
- Zones graded by **true** percentage: `<75%` teal `#14B8A6`, `75–99%` amber `#FFB020`, exactly `100%` brand `#FF7900`, then graded over-target reds `#D14343` (`>100%`), `#A62626` (`≥115%`), `#7A1C1C` (`≥125%`).
- Over-target **bulge** (`intensity-bulge`, 8/10/11px) colored to the zone.
- **At-target blue glow** on the fill + a blue **target line** (`intensity-target`) when the level rests on `threshold`.
- Bar geometry bounded to 100% while color grades by the true (>100%) percentage, so overexertion renders.
- Threshold-line testID renamed `intensity-threshold` → `intensity-target` (the parity harness's contract); `WeekRow` consumer test updated.
- `IntensityBar.test.tsx` rewritten to lock the new behavior; the 7 IntensityBar parity tests un-fixmed and passing.

### S5 — RestTimer display-only mode
Adds `displayOnly?: boolean` (default `false`) that hides the Skip / +30s controls for passive poll-only consumers, keeping the countdown, progress bar, and next-set line. Public API unchanged / backward-compatible.

### TD-04.13 — PrBadge compact parity
GT `.pr-badge-compact` now emits an inline orange `<Star>` SVG (14px, `#FF7900`) mirroring the component's Lucide `<Star>`, and inherits color/font-size to match the bare RNW View. The 1 PrBadge-compact parity test is un-fixmed and passing. **Component unchanged.**

## Verification
- `pnpm type-check`: 0 errors
- `eslint` (all touched files): 0 errors
- `pnpm test` (vitest): **2039 passed** / 93 files
- `test:visual:compare` (playwright): **84 passed**, incl. the 8 newly un-fixmed (7 IntensityBar + 1 PrBadge-compact). Teeth-checked: all 8 fail against the pre-change component/GT, pass after.
- `pnpm build`: clean

Only 7 files touched; no `package.json` / CI / config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)