### PR TITLE
Breaking (0.5.0): drop lucide-react, ThemeProvider + pages off the root barrel

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,12 @@
       "import": "./dist/bodymap.mjs",
       "require": "./dist/bodymap.js"
     },
+    "./pages": {
+      "react-native": "./src/pages.ts",
+      "types": "./dist/pages.d.ts",
+      "import": "./dist/pages.mjs",
+      "require": "./dist/pages.js"
+    },
     "./theme": {
       "react-native": "./src/theme/index.ts",
       "types": "./dist/theme/index.d.ts",
@@ -67,8 +73,6 @@
     "prepublishOnly": "tsup && vitest --run"
   },
   "peerDependencies": {
-    "lucide-react": ">=0.400.0",
-    "lucide-react-native": ">=0.400.0",
     "nativewind": "^4.2.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
@@ -78,9 +82,6 @@
     "react-native-web": ">=0.19.0"
   },
   "peerDependenciesMeta": {
-    "lucide-react-native": {
-      "optional": true
-    },
     "nativewind": {
       "optional": true
     },
@@ -125,7 +126,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "jest-axe": "^9.0.0",
     "jsdom": "^25.0.0",
-    "lucide-react": "^0.469.0",
     "nativewind": "^4.2.1",
     "prettier": "^3.8.1",
     "react": "^18.3.0",

--- a/packages/ui/src/components/custom/Workout/BaseBadge.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/BaseBadge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
-import { Dumbbell } from 'lucide-react'
+import { DumbbellIcon } from './icons'
 import { BaseBadge } from './BaseBadge'
 
 const meta: Meta<typeof BaseBadge> = {
@@ -47,7 +47,7 @@ export const Pr: Story = {
 export const WithIcon: Story = {
   args: {
     variant: 'plain',
-    icon: <Dumbbell size={12} color="#9CA3AF" strokeWidth={2} />,
+    icon: <DumbbellIcon size={12} color="#9CA3AF" strokeWidth={2} />,
     children: <Label>225 lbs</Label>,
   },
 }
@@ -66,7 +66,7 @@ export const AllVariants: Story = {
         <BaseBadge variant="pr" size="lg"><Label color="#FF7900">PR</Label></BaseBadge>
       </View>
       <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-        <BaseBadge icon={<Dumbbell size={12} color="#9CA3AF" strokeWidth={2} />}>
+        <BaseBadge icon={<DumbbellIcon size={12} color="#9CA3AF" strokeWidth={2} />}>
           <Label>225 lbs</Label>
         </BaseBadge>
       </View>

--- a/packages/ui/src/components/custom/Workout/PrBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.tsx
@@ -1,7 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState } from 'react'
 import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
-import { Star } from 'lucide-react'
+import { StarIcon } from './icons'
 import { BaseBadge } from './BaseBadge'
 
 export type PRType = 'e1rm' | 'weight' | 'reps' | 'volume' | 'velocity'
@@ -66,7 +66,7 @@ export function PrBadge({
       testID="pr-badge-star"
       {...props}
     >
-      <Star size={14} color="#FF7900" fill="#FF7900" strokeWidth={2} />
+      <StarIcon size={14} color="#FF7900" fill="#FF7900" strokeWidth={2} />
     </View>
   ) : (
     <BaseBadge

--- a/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
+++ b/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
@@ -1,6 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, Pressable, type ViewProps } from 'react-native'
-import { Star } from 'lucide-react'
+import { StarIcon } from './icons'
 import { Drawer, DrawerBody } from '../../ui/drawer'
 import { resolveColor } from '../../../theme/resolve-color'
 
@@ -84,7 +84,7 @@ function PrRecordRow({ record, index }: { record: PrRecord; index: number }) {
       }}
       testID={`pr-history-modal-record-${index}`}
     >
-      <Star size={16} color={BRAND_PRIMARY} fill={BRAND_PRIMARY} strokeWidth={2} />
+      <StarIcon size={16} color={BRAND_PRIMARY} fill={BRAND_PRIMARY} strokeWidth={2} />
       <Text
         className="text-text-secondary"
         style={{

--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -1,0 +1,50 @@
+# Workout component family
+
+Training-specific components (badges, bars, timers, cards, charts, and page-level
+screens) built on titan's atoms. They live flat on disk — the tiering below is a
+documentation contract, not a directory layout, so promoting or composing a
+component is pure import churn with no file moves.
+
+## Tier map
+
+**Atoms** — single-purpose, no cross-component state:
+BaseBadge · WeightBadge · PrBadge · StatusDot · PlaceholderStrip · TempoBar ·
+DeviationBar · IntensityBar · WorkoutPill · MuscleGroupChip · Sparkline ·
+SupersetWrapper · InputBar
+
+**Molecules** — compose atoms, own a little local state:
+VelocityStrip · SetRow · TempoDisplay · RestTimer · MesoProgressBar · WeekRow ·
+WorkoutCard
+
+**Organisms** — full features, often with their own data contract:
+ExerciseCard · MesoCard · MesoStatusCard · PrHistoryModal · ReadinessCheck ·
+StrengthTrendChart · CapacityBandChart · BodyMap · BodyMapDetailPanel
+
+**Pages** — phone-shaped reference screens (whole-screen compositions):
+ActiveWorkoutPage · ExerciseDetailPage · ProgramPlanningPage · TrainingStatusPage
+
+## Subpaths
+
+Two families are kept off the root barrel so `@titan-design/react-ui` stays free
+of their heavy runtime dependencies. In both cases the value exports move to the
+subpath while type-only re-exports remain on the root, so consumers can still
+type props without pulling the dependency.
+
+- **`@titan-design/react-ui/bodymap`** — isolates
+  `react-native-body-highlighter` (a native SVG dep). BodyMap, BodyMapDetailPanel,
+  TrainingStatusPage, and the muscle taxonomy live here.
+- **`@titan-design/react-ui/pages`** — isolates the page-level organisms
+  (ActiveWorkoutPage, ExerciseDetailPage, ProgramPlanningPage). They are full app
+  screens orphaned by both consumers, kept as reference implementations while their
+  successors (the responsive level views) are built. TrainingStatusPage is the
+  exception — it stays under `/bodymap` because of the body-highlighter dep.
+
+## Notes
+
+- **BaseBadge is an internal composition primitive** — the shared shell that
+  WeightBadge and PrBadge build on. It is exempt from orphan accounting; it is not
+  meant to be consumed directly even though it is exported for composition.
+- Badge icons (WeightBadge's dumbbell, PrBadge / PrHistoryModal's star) are inline
+  SVGs (`./icons.tsx`), not `lucide-react` — that dependency was dropped in 0.5.0
+  to keep the root barrel light. The SVG paths mirror lucide's glyphs so rendering
+  is unchanged.

--- a/packages/ui/src/components/custom/Workout/WeightBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/WeightBadge.tsx
@@ -1,6 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { Text } from 'react-native'
-import { Dumbbell } from 'lucide-react'
+import { DumbbellIcon } from './icons'
 import {
   BaseBadge,
   baseBadgeSizeConfig,
@@ -61,7 +61,7 @@ export function WeightBadge({
       className={className}
       icon={
         showIcon ? (
-          <Dumbbell size={config.iconSize} color={iconColor} strokeWidth={2} />
+          <DumbbellIcon size={config.iconSize} color={iconColor} strokeWidth={2} />
         ) : undefined
       }
       accessibilityLabel={fullLabel}

--- a/packages/ui/src/components/custom/Workout/icons.tsx
+++ b/packages/ui/src/components/custom/Workout/icons.tsx
@@ -1,0 +1,68 @@
+// Inline SVG icons for the Workout badges — replaces the `lucide-react`
+// dependency (dep hygiene, titan 0.5.0). The paths mirror lucide-react's
+// `Dumbbell` and `Star` glyphs verbatim so rendering is pixel-identical to the
+// previous `<Dumbbell>` / `<Star>` output (same viewBox, stroke, fill, and
+// round line caps). Rendered as raw `<svg>` DOM elements — the same web-SVG
+// mechanism `Progress.tsx` uses, and the same surface `lucide-react` produced
+// (both are web-only SVG; native icon rendering was never wired here).
+
+export interface WorkoutIconProps {
+  /** Rendered width/height in px (viewBox is fixed 24×24). */
+  size?: number
+  /** Stroke color. */
+  color?: string
+  /** Fill color; defaults to `none` (outline only). */
+  fill?: string
+  /** Stroke width. */
+  strokeWidth?: number
+}
+
+/** Dumbbell glyph (mirrors lucide-react `Dumbbell`). Outline-only by default. */
+export function DumbbellIcon({
+  size = 24,
+  color = 'currentColor',
+  fill = 'none',
+  strokeWidth = 2,
+}: WorkoutIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M14.4 14.4 9.6 9.6" />
+      <path d="M18.657 21.485a2 2 0 1 1-2.829-2.828l-1.767 1.768a2 2 0 1 1-2.829-2.829l6.364-6.364a2 2 0 1 1 2.829 2.829l-1.768 1.767a2 2 0 1 1 2.828 2.829z" />
+      <path d="m21.5 21.5-1.4-1.4" />
+      <path d="M3.9 3.9 2.5 2.5" />
+      <path d="M6.404 12.768a2 2 0 1 1-2.829-2.829l1.768-1.767a2 2 0 1 1-2.828-2.829l2.828-2.828a2 2 0 1 1 2.829 2.828l1.767-1.768a2 2 0 1 1 2.829 2.829z" />
+    </svg>
+  )
+}
+
+/** Star glyph (mirrors lucide-react `Star`). Pass `fill` for a solid star. */
+export function StarIcon({
+  size = 24,
+  color = 'currentColor',
+  fill = 'none',
+  strokeWidth = 2,
+}: WorkoutIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" />
+    </svg>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -108,37 +108,29 @@ export type {
   TrainingStatusMuscle,
   TrainingStatusSummary,
 } from './TrainingStatusPage'
-export {
-  ProgramPlanningPage,
-  deriveNavLevel,
-  toProgressBarMesos,
-  findMeso,
-  findWeek,
-  findWorkout,
-  buildBreadcrumbs,
-  type ProgramPlanningPageProps,
-  type PlanMeso,
-  type PlanWeek,
-  type PlanWorkout,
-  type ProgramNavLevel,
-  type ProgramSelection,
-  type ProgramBreadcrumb,
+// ActiveWorkoutPage / ExerciseDetailPage / ProgramPlanningPage are page-level
+// organisms demoted to the `@titan-design/react-ui/pages` subpath (titan 0.5.0).
+// Their VALUE exports (components + derivation helpers) live there; only
+// type-only re-exports stay on this barrel (erased at build, no runtime pull).
+export type {
+  ProgramPlanningPageProps,
+  PlanMeso,
+  PlanWeek,
+  PlanWorkout,
+  ProgramNavLevel,
+  ProgramSelection,
+  ProgramBreadcrumb,
 } from './ProgramPlanningPage'
-export {
-  ExerciseDetailPage,
-  deriveExerciseStats,
-  toExerciseCardProps,
-  summarizeVbt,
-  EXERCISE_DETAIL_TABS,
-  type ExerciseDetailPageProps,
-  type ExerciseDetailTab,
-  type ExerciseDetailHeader,
-  type ExerciseDetailEntry,
-  type ExerciseTrend,
-  type ExerciseVbtSet,
-  type ExerciseVbt,
-  type ExerciseDetailStats,
-  type VbtSummary,
+export type {
+  ExerciseDetailPageProps,
+  ExerciseDetailTab,
+  ExerciseDetailHeader,
+  ExerciseDetailEntry,
+  ExerciseTrend,
+  ExerciseVbtSet,
+  ExerciseVbt,
+  ExerciseDetailStats,
+  VbtSummary,
 } from './ExerciseDetailPage'
 // muscleTaxonomy imports `react-native-body-highlighter` at runtime. Its value
 // exports (incl. the MuscleGroup / SimpleMuscleGroup enums) live behind the
@@ -149,20 +141,13 @@ export type {
   MovementCategory,
   VolumeLandmarks,
 } from './muscleTaxonomy'
-export {
-  ActiveWorkoutPage,
-  countCompletedSets,
-  deriveWorkoutProgress,
-  findActiveExercise,
-  statusToCardState,
-  toActiveCardProps,
-  groupExercises,
-  type ActiveWorkoutPageProps,
-  type ActiveWorkoutExercise,
-  type ActiveWorkoutSuperset,
-  type ActiveWorkoutInput,
-  type ActiveWorkoutRest,
-  type ActiveExerciseStatus,
-  type WorkoutProgress,
-  type WorkoutGroup,
+export type {
+  ActiveWorkoutPageProps,
+  ActiveWorkoutExercise,
+  ActiveWorkoutSuperset,
+  ActiveWorkoutInput,
+  ActiveWorkoutRest,
+  ActiveExerciseStatus,
+  WorkoutProgress,
+  WorkoutGroup,
 } from './ActiveWorkoutPage'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,8 +3,9 @@
 // Components
 export * from './components'
 
-// Theme
-export * from './theme'
+// Theme (nativewind-free surface; ThemeProvider value lives on the /theme
+// subpath so the root barrel does not pull the nativewind import chain)
+export * from './theme/barrel'
 
 // Utilities
 export * from './utils'

--- a/packages/ui/src/pages.ts
+++ b/packages/ui/src/pages.ts
@@ -1,0 +1,61 @@
+// Subpath entry: @titan-design/react-ui/pages
+//
+// Page-level organisms — phone-shaped reference screens (ActiveWorkoutPage,
+// ExerciseDetailPage, ProgramPlanningPage). Demoted out of the root barrel for
+// titan 0.5.0: they are full app screens, orphaned by both consumers, and their
+// successors are the form-factor-responsive level views (plan B2). Their VALUE
+// exports (components + derivation helpers) live HERE; type-only re-exports
+// stay on the root barrel so consumers can still type props without importing
+// the screens. Mirrors the `/bodymap` isolation pattern.
+//
+// TrainingStatusPage is NOT here — it depends on react-native-body-highlighter
+// and lives under `@titan-design/react-ui/bodymap`.
+export {
+  ActiveWorkoutPage,
+  countCompletedSets,
+  deriveWorkoutProgress,
+  findActiveExercise,
+  statusToCardState,
+  toActiveCardProps,
+  groupExercises,
+  type ActiveWorkoutPageProps,
+  type ActiveWorkoutExercise,
+  type ActiveWorkoutSuperset,
+  type ActiveWorkoutInput,
+  type ActiveWorkoutRest,
+  type ActiveExerciseStatus,
+  type WorkoutProgress,
+  type WorkoutGroup,
+} from './components/custom/Workout/ActiveWorkoutPage'
+export {
+  ExerciseDetailPage,
+  deriveExerciseStats,
+  toExerciseCardProps,
+  summarizeVbt,
+  EXERCISE_DETAIL_TABS,
+  type ExerciseDetailPageProps,
+  type ExerciseDetailTab,
+  type ExerciseDetailHeader,
+  type ExerciseDetailEntry,
+  type ExerciseTrend,
+  type ExerciseVbtSet,
+  type ExerciseVbt,
+  type ExerciseDetailStats,
+  type VbtSummary,
+} from './components/custom/Workout/ExerciseDetailPage'
+export {
+  ProgramPlanningPage,
+  deriveNavLevel,
+  toProgressBarMesos,
+  findMeso,
+  findWeek,
+  findWorkout,
+  buildBreadcrumbs,
+  type ProgramPlanningPageProps,
+  type PlanMeso,
+  type PlanWeek,
+  type PlanWorkout,
+  type ProgramNavLevel,
+  type ProgramSelection,
+  type ProgramBreadcrumb,
+} from './components/custom/Workout/ProgramPlanningPage'

--- a/packages/ui/src/theme/barrel.ts
+++ b/packages/ui/src/theme/barrel.ts
@@ -1,0 +1,53 @@
+// Theme surface WITHOUT the ThemeProvider value (dep hygiene, titan 0.5.0).
+//
+// `ThemeProvider` imports `nativewind` (`vars()`). Re-exporting it from the root
+// barrel dragged the whole nativewind import chain into every consumer of
+// `@titan-design/react-ui` — the web SPA paid for a native-only provider. This
+// file is the nativewind-free theme surface: the root barrel re-exports THIS,
+// and the `/theme` subpath (`./index.ts`) layers the `ThemeProvider` value on
+// top for the native consumers that deliberately import it.
+export * from './tokens'
+export * from './config'
+export * from './shadows'
+export * from './elevation'
+export * from './manifest'
+export { resolveColor } from './resolve-color'
+
+// ThemeProvider TYPES may stay on the root (erased at build — no nativewind
+// pull). Only the ThemeProvider VALUE moves to the `/theme` subpath.
+export type { ThemeProviderProps, ThemeProviderMode } from './ThemeProvider'
+
+// Re-export commonly used items
+export { getSemanticColors, type ThemeMode } from './tokens/semantic'
+export { getThemeCSSVars, gluestackConfig } from './config'
+export {
+  neumorphicShadows,
+  // Color math utilities (HSV-based)
+  lighten,
+  darken,
+  getHoverColors,
+  isDark,
+  hexToRgb,
+  rgbToHsv,
+  // Shadow creation functions
+  createRaisedShadow,
+  createRaisedHoverShadow,
+  createPressedShadow,
+  createPressedHoverShadow,
+  createFlatShadow,
+  shadowColors,
+  type ShadowIntensity,
+  type ShadowSurface,
+} from './shadows'
+export {
+  getElevationConfig,
+  getElevationSurface,
+  getElevationShadow,
+  getBaseSurfaceColor,
+  getValidatedElevation,
+  componentElevationRanges,
+  type ElevationLevel,
+  type ElevationConfig,
+  type ComponentType,
+} from './elevation'
+export * from './presets'

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -1,43 +1,8 @@
-// Theme exports
-export * from './tokens'
-export * from './config'
-export * from './shadows'
-export * from './elevation'
-export * from './manifest'
-export { ThemeProvider, type ThemeProviderProps, type ThemeProviderMode } from './ThemeProvider'
-export { resolveColor } from './resolve-color'
-
-// Re-export commonly used items
-export { getSemanticColors, type ThemeMode } from './tokens/semantic'
-export { getThemeCSSVars, gluestackConfig } from './config'
-export {
-  neumorphicShadows,
-  // Color math utilities (HSV-based)
-  lighten,
-  darken,
-  getHoverColors,
-  isDark,
-  hexToRgb,
-  rgbToHsv,
-  // Shadow creation functions
-  createRaisedShadow,
-  createRaisedHoverShadow,
-  createPressedShadow,
-  createPressedHoverShadow,
-  createFlatShadow,
-  shadowColors,
-  type ShadowIntensity,
-  type ShadowSurface,
-} from './shadows'
-export {
-  getElevationConfig,
-  getElevationSurface,
-  getElevationShadow,
-  getBaseSurfaceColor,
-  getValidatedElevation,
-  componentElevationRanges,
-  type ElevationLevel,
-  type ElevationConfig,
-  type ComponentType,
-} from './elevation'
-export * from './presets'
+// Theme subpath entry: @titan-design/react-ui/theme
+//
+// The full theme surface. This is the nativewind-free `./barrel` PLUS the
+// `ThemeProvider` value — which imports `nativewind` and therefore does NOT
+// belong on the root barrel (that split happened in titan 0.5.0). Native
+// consumers wrap their app root in `<ThemeProvider>` and import it from HERE.
+export * from './barrel'
+export { ThemeProvider } from './ThemeProvider'

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     bodymap: 'src/bodymap.ts',
+    pages: 'src/pages.ts',
     'theme/index': 'src/theme/index.ts',
     'theme/tokens-css': 'src/theme/tokens-css.ts',
   },
@@ -15,13 +16,18 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
+  // Self-contained entries (no shared ESM chunks). Code-splitting merged the
+  // nativewind-importing ThemeProvider into a theme-utils chunk that the root
+  // entry also pulled, re-leaking nativewind into `@titan-design/react-ui` even
+  // after ThemeProvider left the root barrel. Without splitting, each entry only
+  // bundles what it imports, so the root stays nativewind-free (as CJS already
+  // was) and ThemeProvider's nativewind chain is confined to the /theme entry.
+  splitting: false,
   external: [
     'react',
     'react-dom',
     'react-native',
     'react-native-web',
-    'lucide-react',
-    'lucide-react-native',
   ],
   treeshake: true,
   esbuildOptions(options) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
-      lucide-react-native:
-        specifier: '>=0.400.0'
-        version: 0.563.0(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
       react-native:
         specifier: '>=0.72.0'
         version: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
@@ -96,9 +93,6 @@ importers:
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
-      lucide-react:
-        specifier: ^0.469.0
-        version: 0.469.0(react@18.3.1)
       nativewind:
         specifier: ^4.2.1
         version: 4.2.1(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.28.6)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(yaml@2.8.2))
@@ -3751,18 +3745,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lucide-react-native@0.563.0:
-    resolution: {integrity: sha512-q4tYoAMorTqv+UXRYc0MyiEAOF+4Bu73zxD63EDrnGCFL+xuj+imBm3E2rIKRmME0heVHlK+98fsi8wbL92LNQ==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-native: '*'
-      react-native-svg: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
-
-  lucide-react@0.469.0:
-    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9512,16 +9494,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react-native@0.563.0(react-native-svg@15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-native: 0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1)
-      react-native-svg: 15.15.5(react-native@0.83.1(@babel/core@7.28.6)(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
-
-  lucide-react@0.469.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
Dep-hygiene + page-demotion half of the titan **0.5.0** release (plan Part A2). These are **breaking** consumer-facing changes, so they ship together in 0.5.0. Version is left at 0.4.0 here — documented, not bumped, per the release plan. The VelocityStrip half is a separate later task (waits on a WA release).

## Breaking changes (0.5.0 migration notes)

1. **`lucide-react` dropped as a dependency.** No consumer API change — the three Workout icon uses are now inline SVGs mirroring lucide's glyphs. Consumers no longer need `lucide-react` (or `lucide-react-native`) installed for titan. Removed from `peerDependencies`, `peerDependenciesMeta`, and `devDependencies`.
2. **`ThemeProvider` is no longer exported from the root barrel.** Import it from the `/theme` subpath instead:
   ```diff
   - import { ThemeProvider } from '@titan-design/react-ui'
   + import { ThemeProvider } from '@titan-design/react-ui/theme'
   ```
   Mobile switches to this at its 0.5.0 bump. All other theme utilities (`getSemanticColors`, `resolveColor`, `alpha`, shadows, elevation, presets, …) **remain on the root** — unchanged. `ThemeProvider` *types* also remain on root.
3. **Page-level organisms demoted to a `/pages` subpath.** `ActiveWorkoutPage`, `ExerciseDetailPage`, `ProgramPlanningPage` (and their derivation helpers) move off the root barrel:
   ```diff
   - import { ActiveWorkoutPage } from '@titan-design/react-ui'
   + import { ActiveWorkoutPage } from '@titan-design/react-ui/pages'
   ```
   Type-only re-exports stay on the root barrel (mirrors `/bodymap`). `TrainingStatusPage` stays under `/bodymap` (body-highlighter dep).

## What changed

- New `src/components/custom/Workout/icons.tsx` — inline `DumbbellIcon` / `StarIcon` (exact lucide paths, viewBox, stroke/fill, round caps; raw `<svg>`, the same web-SVG path `Progress.tsx` uses). `WeightBadge`, `PrBadge`, `PrHistoryModal`, and `BaseBadge.stories` repointed onto them.
- New `src/theme/barrel.ts` — the nativewind-free theme surface the root re-exports; `src/theme/index.ts` (the `/theme` entry) layers `ThemeProvider` on top.
- New `src/pages.ts` — `/pages` subpath entry; `package.json` `exports` + `tsup` entry added.
- `Workout/index.ts` — the three pages become type-only re-exports.
- `tsup.config.ts` — `splitting: false` (see verification below) and dropped lucide externals.
- New `Workout/README.md` — tier map (atoms/molecules/organisms/pages), `/bodymap` + `/pages` rationale, BaseBadge internal-primitive exemption.

## Verification

Built the package and inspected the dist import graph:
- **Root** (`dist/index.mjs`, `dist/index.js`), **`/pages`**, and **`/bodymap`** bundles: **0** occurrences of `nativewind` and **0** of `lucide`.
- `nativewind` appears **only** in `dist/theme/index.*` (where `ThemeProvider` lives) — as intended.
- Root cause of a subtle re-leak found and fixed: tsup code-splitting had merged the nativewind-importing `ThemeProvider` into a shared theme-utils chunk that the root ESM entry also imported (a top-level `import { vars } from 'nativewind'` rode along even though root never referenced `ThemeProvider`). `splitting: false` makes each entry self-contained, matching the CJS output which was already clean.

## Gates (worktree, all green)

- `pnpm type-check` — clean (exit 0)
- `pnpm lint` — 0 errors (92 pre-existing warnings in untouched files; 0 in modified files)
- `pnpm test` (vitest) — **2039 passed** across 93 files, incl. the **578** stories-smoke mounts (pages remain mountable via source-path imports)
- `pnpm build` — success (one benign rollup "Fragment imported but never used" note in the /theme entry, a tree-shake artifact of disabling splitting)

## CI-only visual gate — flag for the merge decision

The **Visual Regression** workflow (`.github/workflows/visual.yml`) runs two Playwright suites on PRs in a pinned `mcr.microsoft.com/playwright:v1.58.2-noble` container for byte-for-byte baseline matching, so it can't be meaningfully run locally on macOS:
- **Layer 3 — HTML-vs-React parity**: the `PrBadge compact` case compares the specimen ground-truth (already an inline SVG star since #81) against the component; the component now renders that same inline star, so parity should hold or improve.
- **Layer 1 — component screenshot baselines**: the three badges (WeightBadge dumbbell, PrBadge / PrHistoryModal star) appear here. The inline SVGs mirror lucide's exact paths/attributes so pixels should match, but **if the Layer-1 check flags any of the three badges**, the SVG markup legitimately changed (lucide `<svg class="lucide">` → equivalent inline `<svg>`) and baselines should be regenerated with `pnpm --filter @titan-design/react-ui test:visual:baseline:update`. The theme/pages changes are export-graph-only and have no visual impact.

Do not merge — for the lead's review + merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)