### PR TITLE
Consolidate VelocityStrip: zones prop, mean semantics, fromBest loss, live mode (TD-03.48)

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCard.tsx
@@ -1,7 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useState } from 'react'
 import { View, Text, Pressable } from 'react-native'
-import { VelocityStrip } from './VelocityStrip'
+import { VelocityStrip, type VelocityZoneBandProp } from './VelocityStrip'
 import { PlaceholderStrip } from './PlaceholderStrip'
 import { WeightBadge } from './WeightBadge'
 import { PrBadge } from './PrBadge'
@@ -26,6 +26,8 @@ export interface ExerciseCardProps {
   e1rm?: { value: number; unit: 'lbs' | 'kg' }
   isPR?: boolean
   setVelocities?: number[][]
+  /** Optional velocity-zone bands shared across this exercise's sets (WA bands). */
+  velocityZones?: readonly VelocityZoneBandProp[]
   totalPlannedSets?: number
   sets?: SetRowProps[]
   tempo?: [number, number, number, number]
@@ -106,6 +108,7 @@ function CollapsedCard({
   e1rm,
   isPR,
   setVelocities,
+  velocityZones,
   totalPlannedSets,
   supersetPosition,
 }: ExerciseCardProps) {
@@ -189,6 +192,7 @@ function CollapsedCard({
               <VelocityStrip
                 key={i}
                 velocities={velocities}
+                zones={velocityZones}
                 variant="mini"
                 testID={`exercise-card-velocity-strip-${i}`}
               />

--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
@@ -15,7 +15,12 @@ import {
 } from './CapacityBandChart'
 import { ExerciseCard, type ExerciseCardProps } from './ExerciseCard'
 import { type SetRowProps } from './SetRow'
-import { VelocityStrip, calculateMeanVelocity, calculateVelocityLoss } from './VelocityStrip'
+import {
+  VelocityStrip,
+  calculateMeanVelocity,
+  calculateVelocityLoss,
+  type VelocityZoneBandProp,
+} from './VelocityStrip'
 import { resolveColor } from '../../../theme/resolve-color'
 import { cn } from '../../../utils/cn'
 
@@ -97,6 +102,8 @@ export interface ExerciseVbt {
   projection?: CapacityBandProjection
   /** Per-set velocity traces for the most recent session. */
   sets: ExerciseVbtSet[]
+  /** Optional velocity-zone bands for this exercise (WA `VelocityZones.bands`). */
+  zones?: readonly VelocityZoneBandProp[]
 }
 
 /** Page-level roll-up of the logged sessions. */
@@ -348,7 +355,13 @@ function EntryList({ entries, expandedId, onToggle, emptyLabel, testID }: EntryL
   )
 }
 
-function VbtBreakdown({ sets }: { sets: ExerciseVbtSet[] }) {
+function VbtBreakdown({
+  sets,
+  zones,
+}: {
+  sets: ExerciseVbtSet[]
+  zones?: readonly VelocityZoneBandProp[]
+}) {
   return (
     <View style={{ gap: 10 }} testID="exercise-detail-page-vbt-breakdown">
       {sets.map((set) => {
@@ -373,7 +386,7 @@ function VbtBreakdown({ sets }: { sets: ExerciseVbtSet[] }) {
               {set.label}
             </Text>
             <View className="flex-1" style={{ height: 8, justifyContent: 'center' }}>
-              <VelocityStrip velocities={set.velocities} variant="mini" />
+              <VelocityStrip velocities={set.velocities} zones={zones} variant="mini" />
             </View>
             <Text
               className="text-text-tertiary"
@@ -614,7 +627,7 @@ export function ExerciseDetailPage({
             </SectionCard>
             <VbtSummaryRow summary={vbtSummary} />
             <SectionCard title="Velocity Breakdown" testID="exercise-detail-page-velocity">
-              <VbtBreakdown sets={vbt.sets} />
+              <VbtBreakdown sets={vbt.sets} zones={vbt.zones} />
             </SectionCard>
           </View>
         )}

--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -1,6 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text } from 'react-native'
-import { VelocityStrip } from './VelocityStrip'
+import { VelocityStrip, type VelocityZoneBandProp } from './VelocityStrip'
 import { PrBadge, type PRType } from './PrBadge'
 import { roundRpe, rpeColor, roundWeight } from '../../../utils/workout-format'
 
@@ -14,7 +14,12 @@ export interface SetRowProps {
   weight: number | null
   rpe?: number | null
   unit: 'lbs' | 'kg'
+  /** Per-rep MEAN concentric velocities (m/s). */
   velocities?: number[]
+  /** Optional velocity-zone bands (WA `VelocityZones.bands`); default scale when absent. */
+  velocityZones?: readonly VelocityZoneBandProp[]
+  /** Live mode: index of the newest rep bar to animate (pop / new-peak bounce). */
+  velocityLiveRepIndex?: number
   velocityExpanded?: boolean
   onVelocityToggle?: () => void
   setType?: string
@@ -43,6 +48,8 @@ export function SetRow({
   rpe,
   unit,
   velocities,
+  velocityZones,
+  velocityLiveRepIndex,
   velocityExpanded,
   onVelocityToggle,
   setType,
@@ -239,6 +246,8 @@ export function SetRow({
         >
           <VelocityStrip
             velocities={velocities}
+            zones={velocityZones}
+            liveRepIndex={velocityLiveRepIndex}
             expanded={velocityExpanded}
             onToggle={onVelocityToggle}
             variant={onVelocityToggle ? 'full' : 'mini'}

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import {
@@ -210,8 +210,24 @@ describe('getVelocityZoneName', () => {
 })
 
 describe('calculateVelocityLoss', () => {
-  it('calculates percentage loss from first to last rep', () => {
+  it('calculates percentage loss from running-best to last rep', () => {
+    // Best is the first rep here, so best->last matches the legacy result.
     expect(calculateVelocityLoss([1.0, 0.8])).toBe(20)
+  })
+
+  it('uses the best rep (not the first) as the reference for non-monotonic sets', () => {
+    // best = 1.0 (rep 2), last = 0.6 -> (1.0 - 0.6) / 1.0 = 40%.
+    // Legacy first->last would have been (0.8 - 0.6) / 0.8 = 25%.
+    expect(calculateVelocityLoss([0.8, 1.0, 0.6])).toBe(40)
+  })
+
+  it('clamps to 0 when the set ends on its best rep', () => {
+    expect(calculateVelocityLoss([0.6, 0.8, 1.0])).toBe(0)
+  })
+
+  it('clamps to 0 when a later rep exceeds the first rep', () => {
+    // best = 1.2 (last), so loss is negative pre-clamp -> 0.
+    expect(calculateVelocityLoss([1.0, 0.9, 1.2])).toBe(0)
   })
 
   it('returns 0 for single rep', () => {
@@ -220,6 +236,10 @@ describe('calculateVelocityLoss', () => {
 
   it('returns 0 for empty array', () => {
     expect(calculateVelocityLoss([])).toBe(0)
+  })
+
+  it('returns 0 when the best rep is non-positive', () => {
+    expect(calculateVelocityLoss([0, 0])).toBe(0)
   })
 })
 
@@ -230,6 +250,73 @@ describe('calculateMeanVelocity', () => {
 
   it('returns 0 for empty array', () => {
     expect(calculateMeanVelocity([])).toBe(0)
+  })
+})
+
+// WA-shaped 5-band zone set (compound movement-class defaults, mean m/s).
+const compoundBands = [
+  { id: 'grinding', label: 'Grinding', min: 0, max: 0.35 },
+  { id: 'maximalStrength', label: 'Max Strength', min: 0.35, max: 0.5 },
+  { id: 'strengthSpeed', label: 'Strength-Speed', min: 0.5, max: 0.75 },
+  { id: 'power', label: 'Power', min: 0.75, max: 1.0 },
+  { id: 'speed', label: 'Speed', min: 1.0, max: null },
+] as const
+
+describe('VelocityStrip zones prop', () => {
+  it('colors bars from the supplied bands (mini)', () => {
+    render(<VelocityStrip velocities={[1.1, 0.45]} zones={compoundBands} variant="mini" />)
+    // 1.1 -> speed -> green; 0.45 -> maximalStrength -> red (shared with grinding).
+    expect(screen.getByTestId('velocity-bar-0')).toHaveStyle({ backgroundColor: '#2ed573' })
+    expect(screen.getByTestId('velocity-bar-1')).toHaveStyle({ backgroundColor: '#ff4757' })
+  })
+
+  it('labels the summary row with the band containing the mean velocity', () => {
+    // mean of the sample = 0.80 -> power band.
+    render(<VelocityStrip velocities={sampleVelocities} zones={compoundBands} expanded />)
+    expect(screen.getByTestId('velocity-info-row')).toHaveTextContent('Power')
+  })
+
+  it('falls back to the default scale when zones is absent', () => {
+    render(<VelocityStrip velocities={[1.1]} variant="mini" />)
+    expect(screen.getByTestId('velocity-bar-0')).toHaveStyle({ backgroundColor: '#2ed573' })
+  })
+})
+
+describe('VelocityStrip live mode', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    if (originalMatchMedia) window.matchMedia = originalMatchMedia
+    else delete (window as { matchMedia?: unknown }).matchMedia
+  })
+
+  it('marks the latest rep bar in its accessibility label', () => {
+    render(<VelocityStrip velocities={sampleVelocities} liveRepIndex={3} expanded />)
+    expect(
+      screen.getByLabelText(/Rep 4: 0\.68 meters per second, latest rep$/),
+    ).toBeInTheDocument()
+  })
+
+  it('flags a new set peak on the latest bar', () => {
+    render(<VelocityStrip velocities={sampleVelocities} liveRepIndex={0} expanded />)
+    expect(
+      screen.getByLabelText(/Rep 1: 1\.10 meters per second, latest rep, new set peak$/),
+    ).toBeInTheDocument()
+  })
+
+  it('renders without animation when prefers-reduced-motion is set', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as typeof window.matchMedia
+    render(<VelocityStrip velocities={sampleVelocities} liveRepIndex={0} expanded />)
+    expect(screen.getByTestId('velocity-bar-0')).toBeInTheDocument()
+  })
+
+  it('does not apply live marking in the mini variant', () => {
+    render(<VelocityStrip velocities={sampleVelocities} liveRepIndex={0} variant="mini" />)
+    expect(screen.queryByLabelText(/latest rep/)).not.toBeInTheDocument()
   })
 })
 

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -1,11 +1,54 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState } from 'react'
-import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { View, Text, Pressable, Animated, Easing, type ViewProps, type ViewStyle } from 'react-native'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 import { formatVelocity } from '../../../utils/workout-format'
 
+/**
+ * Structural velocity-zone band accepted from an upstream analytics source
+ * (e.g. workout-analytics' `VelocityZones.bands`).
+ *
+ * Deliberately a plain structural shape — titan never imports the analytics
+ * package (same policy as TempoBar's presentational phase key). Any object with
+ * this shape can be passed, so `zones={waVelocityZones.bands}` works directly.
+ * Bands are ordered slow → fast, contiguous, and cover `[0, ∞)` with the top
+ * band's `max === null`. Bands carry NO color — color is a UI concern resolved
+ * here via {@link zoneIdToScaleToken}.
+ */
+export interface VelocityZoneBandProp {
+  /** Stable zone identity (e.g. WA's `VelocityZoneId`). Drives color mapping. */
+  id: string
+  /** Human-readable label shown in the summary row. */
+  label: string
+  /** Inclusive lower bound (m/s mean concentric velocity). */
+  min: number
+  /** Exclusive upper bound (m/s); `null` marks the open top band. */
+  max: number | null
+}
+
 export interface VelocityStripProps extends ViewProps {
+  /**
+   * Per-rep MEAN concentric velocity (m/s), one entry per rep (brain WA-D02).
+   * Drives both bar height and — in the default path — zone color. Callers must
+   * feed mean (not peak) concentric velocity so bar color, height, and the
+   * summary label all describe one metric.
+   */
   velocities: number[]
+  /**
+   * Optional velocity-zone bands (shape-compatible with WA's
+   * `VelocityZones.bands`). When provided, bar color and the summary zone label
+   * come from these bands via {@link zoneIdToScaleToken}. When omitted, the
+   * built-in default scale (≥1.0 / ≥0.75 / ≥0.5) is used — identical to prior
+   * releases. Colors NEVER come from the bands themselves.
+   */
+  zones?: readonly VelocityZoneBandProp[]
+  /**
+   * Live mode: index of the most-recently-completed rep. That bar animates in
+   * with a "pop"; if it is also the current set peak (a new best), it "bounces"
+   * instead. Only the latest bar animates. Honors `prefers-reduced-motion`.
+   * Full variant only.
+   */
+  liveRepIndex?: number
   expanded?: boolean
   onToggle?: () => void
   onRepPress?: (index: number, velocity: number) => void
@@ -14,8 +57,35 @@ export interface VelocityStripProps extends ViewProps {
   className?: string
 }
 
-// Canonical scale shared with SetRow's RPE color (see theme/workout-tokens.ts).
+// Canonical 4-color performance scale shared with SetRow's RPE color
+// (see theme/workout-tokens.ts). green = fastest, red = slowest/grinding.
 const VEL_COLORS = WORKOUT_TOKENS.scale
+
+/**
+ * Map a velocity-zone id (WA's 5-band taxonomy) onto the canonical 4-color
+ * scale. The scale has 4 hues but the taxonomy has 5 bands, so the two slowest
+ * bands — `maximalStrength` and `grinding` — intentionally share `red`: both
+ * read as "heavy / effortful" and there is no distinct 5th data-viz hue. The
+ * top three bands align 1:1 with the legacy default scale so an exercise moving
+ * from default to profile-derived zones never shifts its fast-end colors.
+ *
+ * Legacy default parity: speed=green, power=yellow, strengthSpeed=orange, and
+ * the old sub-0.5 "Strength" band (now split into maximalStrength + grinding)
+ * stays red.
+ *
+ * Unknown ids fall back to `green` (matching the historical default-path
+ * fallback), so a forward-compatible band id never renders an empty bar.
+ */
+const zoneIdToScaleToken: Record<string, keyof typeof VEL_COLORS> = {
+  speed: 'green',
+  power: 'yellow',
+  strengthSpeed: 'orange',
+  maximalStrength: 'red',
+  grinding: 'red',
+}
+
+// --- Default (no-zones) scale ------------------------------------------------
+// Retained as named exports for back-compat; they define the default path.
 
 export function getVelocityZoneColor(velocity: number): string {
   if (velocity >= 1.0) return 'vel-green'
@@ -31,35 +101,47 @@ export function getVelocityZoneName(velocity: number): string {
   return 'Strength'
 }
 
-export function calculateVelocityLoss(velocities: number[]): number {
-  if (velocities.length < 2) return 0
-  const first = velocities[0]
-  const last = velocities[velocities.length - 1]
-  if (first === 0) return 0
-  return Math.round(((first - last) / first) * 100)
+const zoneHexMap: Record<string, string> = {
+  'vel-green': VEL_COLORS.green,
+  'vel-yellow': VEL_COLORS.yellow,
+  'vel-orange': VEL_COLORS.orange,
+  'vel-red': VEL_COLORS.red,
 }
 
+/**
+ * Velocity loss for a set, as a whole percentage. Uses the running-best rep as
+ * the reference (matching WA-02.05 / brain WA-D01): `(vBest − vLast) / vBest`,
+ * clamped to ≥ 0 so a set that ends on its best rep reports 0 loss.
+ */
+export function calculateVelocityLoss(velocities: number[]): number {
+  if (velocities.length < 2) return 0
+  const best = Math.max(...velocities)
+  if (best <= 0) return 0
+  const last = velocities[velocities.length - 1]
+  return Math.max(0, Math.round(((best - last) / best) * 100))
+}
+
+/** Arithmetic mean of the per-rep mean-concentric velocities. */
 export function calculateMeanVelocity(velocities: number[]): number {
   if (velocities.length === 0) return 0
   const sum = velocities.reduce((acc, v) => acc + v, 0)
   return sum / velocities.length
 }
 
-function getBarColor(zone: string): string {
-  switch (zone) {
-    case 'vel-green': return VEL_COLORS.green
-    case 'vel-yellow': return VEL_COLORS.yellow
-    case 'vel-orange': return VEL_COLORS.orange
-    case 'vel-red': return VEL_COLORS.red
-    default: return VEL_COLORS.green
+/** Classify a velocity into its band (slow → fast, min inclusive / max exclusive). */
+function classifyBand(
+  velocity: number,
+  bands: readonly VelocityZoneBandProp[],
+): VelocityZoneBandProp | undefined {
+  for (const band of bands) {
+    if (band.max === null || velocity < band.max) return band
   }
+  return bands[bands.length - 1]
 }
 
-const zoneHexMap: Record<string, string> = {
-  'vel-green': VEL_COLORS.green,
-  'vel-yellow': VEL_COLORS.yellow,
-  'vel-orange': VEL_COLORS.orange,
-  'vel-red': VEL_COLORS.red,
+function bandColor(band: VelocityZoneBandProp): string {
+  const token = zoneIdToScaleToken[band.id]
+  return token ? VEL_COLORS[token] : VEL_COLORS.green
 }
 
 function getLossStyle(loss: number): Record<string, string> | null {
@@ -68,11 +150,33 @@ function getLossStyle(loss: number): Record<string, string> | null {
   return null
 }
 
+function getReducedMotionPreference(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** Track the OS "reduce motion" preference; falls back to `false` (jsdom/SSR). */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(getReducedMotionPreference)
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const handler = () => setReduced(mq.matches)
+    handler()
+    mq.addEventListener?.('change', handler)
+    return () => mq.removeEventListener?.('change', handler)
+  }, [])
+  return reduced
+}
+
 const ANIMATION_DURATION = 400
 const ANIMATION_EASING = Easing.bezier(0.22, 1, 0.36, 1)
+const POP_EASING = Easing.bezier(0.34, 1.56, 0.64, 1)
 
 export function VelocityStrip({
   velocities,
+  zones,
+  liveRepIndex,
   expanded = false,
   onToggle,
   onRepPress,
@@ -84,11 +188,55 @@ export function VelocityStrip({
   const maxVelocity = Math.max(...velocities, 0)
   const meanVelocity = calculateMeanVelocity(velocities)
   const loss = calculateVelocityLoss(velocities)
-  const meanZone = getVelocityZoneName(meanVelocity)
 
+  const hasZones = zones != null && zones.length > 0
+  const barColorFor = (v: number): string =>
+    hasZones ? bandColor(classifyBand(v, zones)!) : zoneHexMap[getVelocityZoneColor(v)]
+  const meanZone = hasZones
+    ? (classifyBand(meanVelocity, zones)?.label ?? '')
+    : getVelocityZoneName(meanVelocity)
+
+  const prefersReducedMotion = usePrefersReducedMotion()
   const [heightAnim] = useState(() => new Animated.Value(expanded ? 60 : 3))
   const [labelOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
   const [infoOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
+  const [liveScale] = useState(() => new Animated.Value(1))
+
+  // Newest-rep animation: pop for a normal rep, bounce when it sets a new peak.
+  const liveVelocity = liveRepIndex != null ? velocities[liveRepIndex] : undefined
+  const isNewPeak = liveVelocity != null && maxVelocity > 0 && liveVelocity === maxVelocity
+  useEffect(() => {
+    if (variant === 'mini' || liveRepIndex == null || liveVelocity == null) return
+    if (prefersReducedMotion) {
+      liveScale.setValue(1)
+      return
+    }
+    if (isNewPeak) {
+      liveScale.setValue(1)
+      Animated.sequence([
+        Animated.timing(liveScale, {
+          toValue: 1.25,
+          duration: 150,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.spring(liveScale, {
+          toValue: 1,
+          friction: 3,
+          tension: 140,
+          useNativeDriver: true,
+        }),
+      ]).start()
+    } else {
+      liveScale.setValue(0.8)
+      Animated.timing(liveScale, {
+        toValue: 1,
+        duration: 300,
+        easing: POP_EASING,
+        useNativeDriver: true,
+      }).start()
+    }
+  }, [variant, liveRepIndex, liveVelocity, isNewPeak, prefersReducedMotion, liveScale])
 
   useEffect(() => {
     if (variant === 'mini') return
@@ -131,7 +279,7 @@ export function VelocityStrip({
             key={i}
             style={{
               flex: 1,
-              backgroundColor: getBarColor(getVelocityZoneColor(v)),
+              backgroundColor: barColorFor(v),
               borderRadius: 1,
               minWidth: 4,
               height: '100%' as unknown as number,
@@ -176,11 +324,44 @@ export function VelocityStrip({
         style={{ flexDirection: 'row', flex: 1, gap: 2, alignItems: 'flex-end' }}
       >
         {velocities.map((v, i) => {
-          const zone = getVelocityZoneColor(v)
+          const barBackground = barColorFor(v)
           // Guard all-zero velocities (idle / pre-rep): maxVelocity === 0 makes
           // this 0 / 0 === NaN and emits height:'NaN%'. Flatten the bars instead.
           const barHeightPct =
             maxVelocity > 0 ? Math.round((v / (maxVelocity * 1.15)) * 100) : 0
+          const isLive = liveRepIndex === i
+          const liveLabelSuffix = isLive
+            ? isNewPeak
+              ? ', latest rep, new set peak'
+              : ', latest rep'
+            : ''
+
+          const barStyle: ViewStyle = expanded
+            ? { height: `${barHeightPct}%`, minHeight: 2, borderTopLeftRadius: 2, borderTopRightRadius: 2, backgroundColor: barBackground }
+            : {
+                minHeight: '100%' as unknown as number,
+                borderTopLeftRadius: 2,
+                borderTopRightRadius: 2,
+                borderBottomLeftRadius: 0,
+                borderBottomRightRadius: 0,
+                backgroundColor: barBackground,
+              }
+
+          const barInner = isLive ? (
+            <Animated.View
+              style={[barStyle, { transform: [{ scale: liveScale }] }]}
+              testID={`velocity-bar-${i}`}
+              accessibilityRole="image"
+              accessibilityLabel={`Rep ${i + 1}: ${formatVelocity(v)} meters per second${liveLabelSuffix}`}
+            />
+          ) : (
+            <View
+              style={barStyle}
+              testID={`velocity-bar-${i}`}
+              accessibilityRole="image"
+              accessibilityLabel={`Rep ${i + 1}: ${formatVelocity(v)} meters per second`}
+            />
+          )
 
           const bar = (
             <View
@@ -198,23 +379,7 @@ export function VelocityStrip({
                   </Text>
                 </Animated.View>
               )}
-              <View
-                style={
-                  expanded
-                    ? { height: `${barHeightPct}%`, minHeight: 2, borderTopLeftRadius: 2, borderTopRightRadius: 2, backgroundColor: zoneHexMap[zone] }
-                    : {
-                        minHeight: '100%' as unknown as number,
-                        borderTopLeftRadius: 2,
-                        borderTopRightRadius: 2,
-                        borderBottomLeftRadius: 0,
-                        borderBottomRightRadius: 0,
-                        backgroundColor: zoneHexMap[zone],
-                      }
-                }
-                testID={`velocity-bar-${i}`}
-                accessibilityRole="image"
-                accessibilityLabel={`Rep ${i + 1}: ${formatVelocity(v)} meters per second`}
-              />
+              {barInner}
             </View>
           )
 
@@ -256,7 +421,7 @@ export function VelocityStrip({
               fontFamily: 'Inter, sans-serif',
             }}
           >
-            {meanZone} {'\u00B7'} {formatVelocity(meanVelocity)} m/s
+            {meanZone} {'·'} {formatVelocity(meanVelocity)} m/s
           </Text>
           <Text
             className="text-text-secondary"

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -29,6 +29,7 @@ export { WorkoutPill, type WorkoutPillProps, type WorkoutPillStatus } from './Wo
 export {
   VelocityStrip,
   type VelocityStripProps,
+  type VelocityZoneBandProp,
   getVelocityZoneColor,
   getVelocityZoneName,
   calculateVelocityLoss,


### PR DESCRIPTION
## TD-03.48 — VelocityStrip consolidation (0.5.0)

Makes `VelocityStrip` the single per-rep velocity component. Rebased on current `main` (post dep-hygiene #82).

### 1. `zones` prop (structural, no WA dependency)
Adds `VelocityZoneBandProp { id, label, min, max: number|null }` — a plain structural type shape-compatible with WA's `VelocityZones.bands`, so consumers pass `zones={waZones.bands}` directly (TempoBar precedent: titan never imports WA). When `zones` is present, bar color + the summary zone label come from the bands; when absent, the legacy default scale renders **identically** to prior releases. The two hardcoded threshold fns are absorbed into that default path (kept as exports for back-compat).

**Zone id → `WORKOUT_TOKENS.scale` token map** (colors NEVER come from WA):

| zone id | token | hex |
|---|---|---|
| `speed` | green | `#2ed573` |
| `power` | yellow | `#ffd43b` |
| `strengthSpeed` | orange | `#ffa502` |
| `maximalStrength` | red | `#ff4757` |
| `grinding` | red | `#ff4757` |

The 4-color scale has no 5th hue, so the two slowest bands (`maximalStrength`, `grinding`) intentionally share **red** — both read as "heavy/effortful". The top three align 1:1 with the legacy default scale, so an exercise switching from default to profile-derived zones never shifts its fast-end colors. Unknown ids fall back to green (matches the historical default fallback).

### 2. Mean semantics (WA-D02)
`velocities` is now documented/typed as **mean concentric velocity**. Bar height, color, and the summary row all describe one metric (fixes the latent mixed-metric labeling). Consumer feeds are their own migration; this is the titan-side contract clarification.

### 3. `calculateVelocityLoss` → running-best (WA-02.05 / WA-D01)
`(vBest − vLast) / vBest`, clamped ≥0. Regression tests added for non-monotonic sets and sets that end on their best rep.

### 4. Live mode
New `liveRepIndex?: number` (minimal API — presence activates live; caller names the newest bar). That bar **pops** in; if it is also the current set peak it **bounces** instead. Only the latest bar animates. Honors `prefers-reduced-motion` (jsdom-safe `matchMedia` guard). Full variant only; default DOM structure is unchanged when `liveRepIndex` is absent.

### 5. Threading
Optional, default-absent: `SetRow.velocityZones` + `velocityLiveRepIndex`, `ExerciseCard.velocityZones`, `ExerciseDetailPage`'s `ExerciseVbt.zones`.

## Gates (worktree, post-rebase)
- `type-check` ✅
- `lint` ✅ 0 errors (0 warnings in modified files)
- `test` ✅ 2050 vitest pass (93 files) — incl. specimen/parity suites
- `build` ✅
- `format:check` — repo-wide advisory only (`continue-on-error: true` in CI; `main` itself is non-conforming across 191 files). Modified files match surrounding style; not reformatted to avoid an out-of-band diff.

## Flagged baselines
Default-path rendering (mini + expanded colors/heights, summary row) is byte-identical, so **no Layer-1 screenshot baselines are expected to change**. The Playwright visual suites (`test:visual:compare`, `test:visual:baseline`) are container-pinned and not run here — lead should confirm in-container. No baseline regeneration flagged.

## Deviations / notes
- No `package.json` version bump (release-cut coordination owns 0.4.0 → 0.5.0).
- Stories not extended (out of scope; stories-smoke suite green).
- Expect a rebase before merge if the sibling branch lands changes to shared barrels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)