### PR TITLE
TD-05.09: color-system foundations — 7-hue ramps + categorical + dataviz scales (no-op)

### DIFF
--- a/packages/ui/src/components/custom/Gauge/Gauge.tsx
+++ b/packages/ui/src/components/custom/Gauge/Gauge.tsx
@@ -1,5 +1,8 @@
 import { View, Text, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const sem = getSemanticColors('dark')
 
 export interface GaugeThreshold {
   /** Band start, in the gauge's value units. */
@@ -30,9 +33,9 @@ export interface GaugeProps extends Omit<ViewProps, 'children'> {
   className?: string
 }
 
-const STATUS_SUCCESS = '#14B8A6'
-const STATUS_WARNING = '#FFB020'
-const STATUS_ERROR = '#D14343'
+const STATUS_SUCCESS = sem['status-success']
+const STATUS_WARNING = sem['status-warning']
+const STATUS_ERROR = sem['status-error']
 const TRACK = 'rgba(255,255,255,0.08)'
 
 /** Titan status-token bands for a 0–100 score. */

--- a/packages/ui/src/components/custom/Scatter/Scatter.tsx
+++ b/packages/ui/src/components/custom/Scatter/Scatter.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { DATAVIZ_CATEGORICAL_PALETTE } from '../../../theme/extracted-colors-dataviz'
 
 export interface ScatterDatum {
   /** Stable identity — returned by onPress and used as the React key. */
@@ -45,11 +46,8 @@ export interface ScatterProps extends Omit<ViewProps, 'children'> {
   className?: string
 }
 
-/** Titan categorical fallback palette (data-1..data-8). */
-const PALETTE = [
-  '#5B9BD5', '#14B8A6', '#F4A736', '#F83030',
-  '#823CA0', '#D4A520', '#406D87', '#43C6B7',
-]
+/** Titan categorical fallback palette (see extracted-colors-dataviz). */
+const PALETTE = DATAVIZ_CATEGORICAL_PALETTE
 
 const GRID_LINE = 'rgba(255,255,255,0.07)'
 const AXIS_LINE = 'rgba(255,255,255,0.18)'

--- a/packages/ui/src/components/custom/Treemap/Treemap.tsx
+++ b/packages/ui/src/components/custom/Treemap/Treemap.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { DATAVIZ_CATEGORICAL_PALETTE } from '../../../theme/extracted-colors-dataviz'
 
 export interface TreemapDatum {
   /** Stable identity — returned by onPress and used as the React key. */
@@ -35,11 +36,8 @@ export interface TreemapProps extends Omit<ViewProps, 'children'> {
   className?: string
 }
 
-/** Titan categorical fallback palette (data-1..data-8). */
-const PALETTE = [
-  '#5B9BD5', '#14B8A6', '#F4A736', '#F83030',
-  '#823CA0', '#D4A520', '#406D87', '#43C6B7',
-]
+/** Titan categorical fallback palette (see extracted-colors-dataviz). */
+const PALETTE = DATAVIZ_CATEGORICAL_PALETTE
 
 interface Rect {
   x: number

--- a/packages/ui/src/components/custom/Workout/ActiveWorkoutPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ActiveWorkoutPage.tsx
@@ -7,8 +7,9 @@ import { RestTimer } from './RestTimer'
 import { SupersetWrapper } from './SupersetWrapper'
 import { type SetRowProps } from './SetRow'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 /** Where an exercise sits in the during-workout flow. */
 export type ActiveExerciseStatus = 'completed' | 'active' | 'upcoming'

--- a/packages/ui/src/components/custom/Workout/BodyMap.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMap.tsx
@@ -4,6 +4,7 @@ import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-n
 import BodyHighlighter, { type ExtendedBodyPart, type Slug } from 'react-native-body-highlighter'
 import { cn } from '../../../utils/cn'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 import {
   MuscleGroup,
   SimpleMuscleGroup,
@@ -24,6 +25,8 @@ import {
  */
 const Body = ((BodyHighlighter as unknown as { default?: typeof BodyHighlighter }).default ??
   BodyHighlighter) as typeof BodyHighlighter
+
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 const OUTLINE_FILL = 'rgba(255,255,255,0.08)'
 const OUTLINE_BORDER = 'rgba(255,255,255,0.12)'
@@ -275,7 +278,7 @@ function ViewToggle({ view, onViewChange }: ViewToggleProps) {
               borderRadius: 9999,
               backgroundColor: active ? 'rgba(255,121,0,0.16)' : 'transparent',
               borderWidth: 1,
-              borderColor: active ? '#FF7900' : resolveColor('border-strong'),
+              borderColor: active ? BRAND_PRIMARY : resolveColor('border-strong'),
             }}
             testID={`body-map-toggle-${side}`}
           >
@@ -284,7 +287,7 @@ function ViewToggle({ view, onViewChange }: ViewToggleProps) {
                 fontSize: 12,
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: active ? '700' : '500',
-                color: active ? '#FF7900' : resolveColor('text-secondary'),
+                color: active ? BRAND_PRIMARY : resolveColor('text-secondary'),
                 textTransform: 'capitalize',
               }}
             >
@@ -321,7 +324,7 @@ function MuscleButton({ entry, highlighted, onMusclePress }: MuscleButtonProps) 
         paddingVertical: 3,
         borderRadius: 9999,
         borderWidth: 1,
-        borderColor: highlighted ? '#FF7900' : resolveColor('border-default'),
+        borderColor: highlighted ? BRAND_PRIMARY : resolveColor('border-default'),
       }}
       testID={`body-map-muscle-${entry.key}`}
     >

--- a/packages/ui/src/components/custom/Workout/BodyMapDetailPanel.tsx
+++ b/packages/ui/src/components/custom/Workout/BodyMapDetailPanel.tsx
@@ -18,11 +18,14 @@ import {
   type VolumeLandmarks,
   type VolumeStatus,
 } from './muscleTaxonomy'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const t = getSemanticColors('dark')
 
-/** Volume track gradient: status-info (blue) -> result-improve (teal) -> status-error (red). */
-const VOLUME_GRADIENT = 'linear-gradient(90deg, #2196F3 0%, #14B8A6 50%, #D14343 100%)'
+const BRAND_PRIMARY = t['brand-primary']
+
+/** Volume track gradient: status-info (blue) -> status-success (teal) -> status-error (red). */
+const VOLUME_GRADIENT = `linear-gradient(90deg, ${t['status-info']} 0%, ${t['status-success']} 50%, ${t['status-error']} 100%)`
 
 /** Sheet slides up from this offset (px) and the backdrop fades to this opacity. */
 const SLIDE_OFFSET = 400

--- a/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
+++ b/packages/ui/src/components/custom/Workout/CapacityBandChart.tsx
@@ -1,10 +1,13 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState, useMemo } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const STATUS_SUCCESS = '#14B8A6'
-const STATUS_WARNING = '#FFB020'
-const STATUS_INFO = '#2196F3'
+const t = getSemanticColors('dark')
+
+const STATUS_SUCCESS = t['status-success']
+const STATUS_WARNING = t['status-warning']
+const STATUS_INFO = t['status-info']
 /** Dot outline: near-white ring so load dots read on the band fill and any
  *  surface (matches the MesoStatusCard gauge-marker convention). */
 const DOT_BORDER = '#F3F4F6'

--- a/packages/ui/src/components/custom/Workout/DeviationBar.tsx
+++ b/packages/ui/src/components/custom/Workout/DeviationBar.tsx
@@ -1,5 +1,8 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, type ViewProps, type ViewStyle } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 export interface DeviationBarProps extends ViewProps {
   deviation: number
@@ -9,10 +12,10 @@ export interface DeviationBarProps extends ViewProps {
 
 function getDotColor(deviation: number): string {
   const abs = Math.abs(deviation)
-  if (deviation < -0.3) return '#14B8A6'
+  if (deviation < -0.3) return t['status-success']
   if (abs <= 0.3) return '#6B7280'
-  if (abs <= 0.7) return '#FFB020'
-  return '#D14343'
+  if (abs <= 0.7) return t['status-warning']
+  return t['status-error']
 }
 
 function getDeviationDescription(deviation: number): string {

--- a/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseDetailPage.tsx
@@ -22,9 +22,10 @@ import {
   type VelocityZoneBandProp,
 } from './VelocityStrip'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { cn } from '../../../utils/cn'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 /** Inner plot width: page width 390 − 16 page padding − 12 card padding on each side. */
 const CHART_WIDTH = 326

--- a/packages/ui/src/components/custom/Workout/InputBar.tsx
+++ b/packages/ui/src/components/custom/Workout/InputBar.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { View, Text, Pressable, TextInput } from 'react-native'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
 export interface InputBarProps {
   exerciseName: string
@@ -17,7 +18,7 @@ export interface InputBarProps {
   visible: boolean
 }
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 const INPUT_CLASSNAME = 'bg-surface-raised border-border-strong text-text-primary'
 
 const inputStyle = {

--- a/packages/ui/src/components/custom/Workout/IntensityBar.tsx
+++ b/packages/ui/src/components/custom/Workout/IntensityBar.tsx
@@ -8,6 +8,10 @@ import {
   type ViewStyle,
   type DimensionValue,
 } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const t = getSemanticColors('dark')
 
 export type IntensityBarOrientation = 'vertical' | 'horizontal'
 
@@ -34,12 +38,12 @@ const AT_TARGET_GLOW = '0 0 5px 1px rgba(33, 150, 243, 0.35), 0 0 10px 3px rgba(
 
 // Zone colors graded by TRUE percentage (level * 100).
 const ZONE = {
-  building: '#14B8A6', // teal   — below target ramp-up
-  approaching: '#FFB020', // amber  — nearing target
-  target: '#FF7900', // brand  — exactly at target
-  over1: '#D14343', // red    — mild over-target
-  over2: '#A62626', // deep red — moderate over-target
-  over3: '#7A1C1C', // darkest red — severe over-target
+  building: t['status-success'], // teal   — below target ramp-up
+  approaching: t['status-warning'], // amber  — nearing target
+  target: t['brand-primary'], // brand  — exactly at target
+  over1: t['status-error'], // red    — mild over-target
+  over2: WORKOUT_TOKENS.intensity.over2, // deep red — moderate over-target
+  over3: WORKOUT_TOKENS.intensity.over3, // darkest red — severe over-target
 } as const
 
 type OverTier = 0 | 1 | 2 | 3

--- a/packages/ui/src/components/custom/Workout/MesoCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoCard.tsx
@@ -4,10 +4,15 @@ import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-n
 import { Card } from '../../ui/card'
 import { Badge } from '../../ui/badge'
 import { WeekRow, type WeekRowProps } from './WeekRow'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import {
+  MESO_ACCENT_GRADIENT_DARK,
+  MESO_ACCENT_GRADIENT_LIGHT,
+} from '../../../theme/extracted-colors-dataviz'
 
-const BRAND_PRIMARY = '#FF7900'
-const BRAND_PRIMARY_DARK = '#C45E00'
-const BRAND_PRIMARY_LIGHT = '#FFB066'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
+const BRAND_PRIMARY_DARK = MESO_ACCENT_GRADIENT_DARK
+const BRAND_PRIMARY_LIGHT = MESO_ACCENT_GRADIENT_LIGHT
 const BORDER_DEFAULT = '#1F1F1F'
 
 /** Gradient stops for the 3px top accent: dark -> primary -> light. */

--- a/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoProgressBar.tsx
@@ -1,8 +1,9 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useState } from 'react'
 import { View, Pressable, Animated, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 export type MesoStatus = 'completed' | 'current' | 'upcoming'
 

--- a/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
+++ b/packages/ui/src/components/custom/Workout/MesoStatusCard.tsx
@@ -4,14 +4,21 @@ import { View, Text, type ViewProps, type ViewStyle } from 'react-native'
 import { Card } from '../../ui/card'
 import { StatusDot } from './StatusDot'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import {
+  MESO_ACCENT_GRADIENT_DARK,
+  MESO_ACCENT_GRADIENT_LIGHT,
+} from '../../../theme/extracted-colors-dataviz'
 
-const BRAND_PRIMARY = '#FF7900'
-const BRAND_PRIMARY_DARK = '#C45E00'
-const BRAND_PRIMARY_LIGHT = '#FFB066'
+const t = getSemanticColors('dark')
 
-const SUCCESS = '#14B8A6'
-const WARNING = '#FFB020'
-const ERROR = '#D14343'
+const BRAND_PRIMARY = t['brand-primary']
+const BRAND_PRIMARY_DARK = MESO_ACCENT_GRADIENT_DARK
+const BRAND_PRIMARY_LIGHT = MESO_ACCENT_GRADIENT_LIGHT
+
+const SUCCESS = t['status-success']
+const WARNING = t['status-warning']
+const ERROR = t['status-error']
 
 /** Gradient stops for the 3px top accent: dark -> primary -> light (matches MesoCard). */
 const ACCENT_STOPS = [BRAND_PRIMARY_DARK, BRAND_PRIMARY, BRAND_PRIMARY_LIGHT]

--- a/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
+++ b/packages/ui/src/components/custom/Workout/MuscleGroupChip.tsx
@@ -1,5 +1,8 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, Pressable, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 // Aliases for spec compatibility: under=behind, maintenance=ontrack, productive=target
 export type VolumeStatus = 'untrained' | 'behind' | 'ontrack' | 'target' | 'over'
@@ -13,10 +16,10 @@ export interface MuscleGroupChipProps extends ViewProps {
 
 const dotColorMap: Record<VolumeStatus, string> = {
   untrained: '#2C2C2C',
-  behind: '#406D87',
-  ontrack: '#14B8A6',
-  target: '#FF7900',
-  over: '#D14343',
+  behind: t['brand-secondary'],
+  ontrack: t['status-success'],
+  target: t['brand-primary'],
+  over: t['status-error'],
 }
 
 export function MuscleGroupChip({

--- a/packages/ui/src/components/custom/Workout/PrBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/PrBadge.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from 'react'
 import { View, Text, Animated, Easing, type ViewProps } from 'react-native'
 import { StarIcon } from './icons'
 import { BaseBadge } from './BaseBadge'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 export type PRType = 'e1rm' | 'weight' | 'reps' | 'volume' | 'velocity'
 
@@ -66,7 +69,7 @@ export function PrBadge({
       testID="pr-badge-star"
       {...props}
     >
-      <StarIcon size={14} color="#FF7900" fill="#FF7900" strokeWidth={2} />
+      <StarIcon size={14} color={BRAND_PRIMARY} fill={BRAND_PRIMARY} strokeWidth={2} />
     </View>
   ) : (
     <BaseBadge
@@ -78,7 +81,7 @@ export function PrBadge({
       <Text
         style={{
           fontSize: 12,
-          color: '#FF7900',
+          color: BRAND_PRIMARY,
           fontWeight: '700',
           fontFamily: 'Inter, sans-serif',
         }}

--- a/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
+++ b/packages/ui/src/components/custom/Workout/PrHistoryModal.tsx
@@ -3,8 +3,9 @@ import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { StarIcon } from './icons'
 import { Drawer, DrawerBody } from '../../ui/drawer'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 const RECENT_BORDER = 'rgba(255,176,32,0.3)'
 const RECENT_GLOW = '0 0 12px rgba(255,176,32,0.06)'
 // Native-safe fallback for the conditional row border (recent uses a computed

--- a/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
+++ b/packages/ui/src/components/custom/Workout/ProgramPlanningPage.tsx
@@ -8,8 +8,9 @@ import { WorkoutCard, type WorkoutStatus, type WorkoutMuscleGroup } from './Work
 import { type WorkoutPillStatus } from './WorkoutPill'
 import { type ExerciseCardProps } from './ExerciseCard'
 import { cn } from '../../../utils/cn'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 /** A single workout within a planned week, plus its exercise breakdown. */
 export interface PlanWorkout {

--- a/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
+++ b/packages/ui/src/components/custom/Workout/ReadinessCheck.tsx
@@ -2,12 +2,15 @@
 import { View, Text, Pressable } from 'react-native'
 import { Card } from '../../ui/card'
 import { Badge, type BadgeColor } from '../../ui/badge'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const t = getSemanticColors('dark')
+
+const BRAND_PRIMARY = t['brand-primary']
 const BRAND_PRIMARY_SUBTLE = 'rgba(255,121,0,0.12)'
-const STATUS_SUCCESS = '#14B8A6'
-const STATUS_WARNING = '#FFB020'
-const STATUS_ERROR = '#D14343'
+const STATUS_SUCCESS = t['status-success']
+const STATUS_WARNING = t['status-warning']
+const STATUS_ERROR = t['status-error']
 
 /** Emoji option sets per known factor, keyed by lowercase id/label. */
 const EMOJI_SETS: Record<string, readonly string[]> = {

--- a/packages/ui/src/components/custom/Workout/RestTimer.tsx
+++ b/packages/ui/src/components/custom/Workout/RestTimer.tsx
@@ -1,8 +1,9 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, Pressable } from 'react-native'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 export interface RestTimerProps {
   totalSeconds: number

--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -3,6 +3,7 @@ import { View, Text } from 'react-native'
 import { VelocityStrip, type VelocityZoneBandProp } from './VelocityStrip'
 import { PrBadge, type PRType } from './PrBadge'
 import { roundRpe, rpeColor, roundWeight } from '../../../utils/workout-format'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 
 export type SetRowMode = 'active' | 'completed' | 'history'
 
@@ -100,7 +101,7 @@ export function SetRow({
               fontSize: 10,
               fontWeight: '700',
               fontFamily: 'Inter, sans-serif',
-              color: '#ffa502',
+              color: WORKOUT_TOKENS.scale.orange,
               backgroundColor: 'rgba(255,165,2,0.12)',
               paddingVertical: 1,
               paddingHorizontal: 5,

--- a/packages/ui/src/components/custom/Workout/Sparkline.tsx
+++ b/packages/ui/src/components/custom/Workout/Sparkline.tsx
@@ -2,8 +2,9 @@
 import React from 'react'
 import { View, Text, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 export interface SparklineProps extends ViewProps {
   data: number[]

--- a/packages/ui/src/components/custom/Workout/StatusDot.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusDot.tsx
@@ -1,5 +1,8 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 export type StatusDotVariant =
   | 'success'
@@ -22,9 +25,9 @@ export interface StatusDotProps extends ViewProps {
 }
 
 const solidVariantColors: Record<string, string> = {
-  success: '#14B8A6',
-  warning: '#FFB020',
-  error: '#D14343',
+  success: t['status-success'],
+  warning: t['status-warning'],
+  error: t['status-error'],
   neutral: '#6B7280',
 }
 
@@ -69,8 +72,8 @@ const iconColors: Record<StatusDotVariant, string> = {
   warning: '#6B4000',
   error: '#5C1A1A',
   neutral: '#D1D5DB',
-  'on-track': '#14B8A6',
-  deviation: '#FFB020',
+  'on-track': t['status-success'],
+  deviation: t['status-warning'],
   future: '#6B7280',
 }
 

--- a/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
+++ b/packages/ui/src/components/custom/Workout/StrengthTrendChart.tsx
@@ -3,14 +3,17 @@ import { useEffect, useMemo, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
 import { resolveColor } from '../../../theme/resolve-color'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const sem = getSemanticColors('dark')
+
+const BRAND_PRIMARY = sem['brand-primary']
 // Line/border color for the dashed projection, used where a className cannot
 // apply (passed as a prop into an inline style, and a per-edge borderTopColor).
 const PROJECTION_LINE_COLOR = resolveColor('text-tertiary')
-const STATUS_SUCCESS = '#14B8A6'
-const STATUS_ERROR = '#D14343'
-const STATUS_WARNING = '#FFB020'
+const STATUS_SUCCESS = sem['status-success']
+const STATUS_ERROR = sem['status-error']
+const STATUS_WARNING = sem['status-warning']
 const GRID_LINE = 'rgba(255,255,255,0.06)'
 const SUCCESS_PILL_BG = 'rgba(20,184,166,0.10)'
 const SUCCESS_PILL_BORDER = 'rgba(20,184,166,0.20)'

--- a/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
+++ b/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
@@ -1,6 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import React from 'react'
 import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
 export interface SupersetWrapperProps {
   label?: string
@@ -10,7 +11,7 @@ export interface SupersetWrapperProps {
 
 const DEFAULTS = {
   label: 'SS',
-  color: '#FF7900',
+  color: getSemanticColors('dark')['brand-primary'],
   bgBase: '#101010',
 } as const
 

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -3,7 +3,10 @@ import { useState, useCallback } from 'react'
 import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { roundTempo } from '../../../utils/workout-format'
 import { alpha } from '../../../utils/colors'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { getTempoFillPct, getTempoPacingState } from './TempoBar'
+
+const t = getSemanticColors('dark')
 
 /** The four tempo phases, in the order the display renders them. */
 export type TempoLivePhase = 'eccentric' | 'pauseBottom' | 'concentric' | 'pauseTop'
@@ -40,13 +43,13 @@ export interface TempoDisplayProps extends ViewProps {
 
 const INTER = 'Inter, sans-serif'
 const TEXT_TERTIARY = '#6B7280'
-const STATUS_ERROR = '#D14343' // status-error (red), shown when a phase runs behind pace
+const STATUS_ERROR = t['status-error'] // status-error (red), shown when a phase runs behind pace
 
 // Phase colors: [eccentric, pauseBottom, concentric, pauseTop]
 const phaseColors = {
-  eccentric: '#FFB020', // status-warning (amber)
+  eccentric: t['status-warning'], // status-warning (amber)
   pauseBottom: TEXT_TERTIARY,
-  concentric: '#14B8A6', // status-success (teal)
+  concentric: t['status-success'], // status-success (teal)
   pauseTop: TEXT_TERTIARY,
   dash: TEXT_TERTIARY,
 }

--- a/packages/ui/src/components/custom/Workout/WeekRow.tsx
+++ b/packages/ui/src/components/custom/Workout/WeekRow.tsx
@@ -2,8 +2,9 @@
 import { View, Text, type ViewProps } from 'react-native'
 import { WorkoutPill, type WorkoutPillStatus } from './WorkoutPill'
 import { IntensityBar } from './IntensityBar'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
-const BRAND_PRIMARY = '#FF7900'
+const BRAND_PRIMARY = getSemanticColors('dark')['brand-primary']
 
 export interface WeekRowWorkout {
   name: string

--- a/packages/ui/src/components/custom/Workout/WeightBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/WeightBadge.tsx
@@ -7,6 +7,7 @@ import {
   type BaseBadgeSize,
   type BaseBadgeProps,
 } from './BaseBadge'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
 export type WeightBadgeSize = BaseBadgeSize
 
@@ -42,7 +43,7 @@ export function WeightBadge({
   ...props
 }: WeightBadgeProps) {
   const config = baseBadgeSizeConfig[size]
-  const textColor = isPr ? '#FF7900' : '#9CA3AF'
+  const textColor = isPr ? getSemanticColors('dark')['brand-primary'] : '#9CA3AF'
   // Dumbbell reads clearly as a weight/strength metric and is unit-agnostic
   // across estimated-1RM and N-rep-max contexts (vs. TrendingUp which implies
   // change/trend rather than a load value).
@@ -100,7 +101,10 @@ export function WeightBadge({
             fontFamily: '"Space Grotesk", sans-serif',
             fontSize: config.fontSize,
             marginLeft: 4,
-            color: delta >= 0 ? '#4caf50' : '#ef5350',
+            color:
+              delta >= 0
+                ? getSemanticColors('dark')['result-improve']
+                : getSemanticColors('dark')['result-degrade'],
           }}
           testID="weight-badge-delta"
         >

--- a/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutCard.tsx
@@ -6,6 +6,9 @@ import {
   MuscleGroupChip,
   type VolumeStatus,
 } from './MuscleGroupChip'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 export type WorkoutStatus = 'completed' | 'today' | 'upcoming'
 
@@ -43,8 +46,8 @@ export interface WorkoutCardProps extends ViewProps {
 }
 
 const COLORS = {
-  statusSuccess: '#14B8A6',
-  brandPrimary: '#FF7900',
+  statusSuccess: t['status-success'],
+  brandPrimary: t['brand-primary'],
   borderDefault: '#1F1F1F',
   brandPrimarySubtle: 'rgba(255,121,0,0.06)',
 }

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
@@ -1,6 +1,10 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useEffect, useState } from 'react'
 import { View, Text, Pressable, Animated, Easing, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { WORKOUT_PILL_DELOAD } from '../../../theme/extracted-colors-dataviz'
+
+const t = getSemanticColors('dark')
 
 /**
  * Spec statuses: completed | current | upcoming | deload.
@@ -37,12 +41,12 @@ const statusBorderStyles: Record<WorkoutPillStatus, Record<string, unknown>> = {
 }
 
 const textColors: Record<WorkoutPillStatus, string> = {
-  completed: '#14B8A6',
-  current: '#FF7900',
-  next: '#FF7900',
+  completed: t['status-success'],
+  current: t['brand-primary'],
+  next: t['brand-primary'],
   upcoming: '#6B7280',
   missed: 'rgba(209,67,67,0.7)',
-  deload: '#9333ea',
+  deload: WORKOUT_PILL_DELOAD,
 }
 
 function usePulse(enabled: boolean) {

--- a/packages/ui/src/components/ui/spinner/Spinner.tsx
+++ b/packages/ui/src/components/ui/spinner/Spinner.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ActivityIndicator, View, type ViewProps } from 'react-native'
 import { cn } from '../../../utils/cn'
+import { SPINNER_PRIMARY, SPINNER_SECONDARY } from '../../../theme/extracted-colors-ui'
 
 export type SpinnerSize = 'sm' | 'md' | 'lg' | 'xl'
 export type SpinnerColor = 'primary' | 'secondary' | 'white' | 'default'
@@ -24,8 +25,8 @@ const sizeMap: Record<SpinnerSize, 'small' | 'large'> = {
 }
 
 const colorMap: Record<SpinnerColor, string> = {
-  primary: '#5048E5',
-  secondary: '#10B981',
+  primary: SPINNER_PRIMARY,
+  secondary: SPINNER_SECONDARY,
   white: '#FFFFFF',
   default: '#6B7280',
 }

--- a/packages/ui/src/components/ui/toolbar-button/ToolbarButton.tsx
+++ b/packages/ui/src/components/ui/toolbar-button/ToolbarButton.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, createContext, useContext } from 'react'
 import { View, Text, Pressable, type ViewProps, StyleSheet, Platform } from 'react-native'
 import { cn } from '../../../utils/cn'
 import { neumorphicShadows, getHoverColors } from '../../../theme'
+import { resolveColor } from '../../../theme/resolve-color'
 
 export type ToolbarButtonVariant = 'default' | 'neumorphic'
 export type ToolbarButtonSize = 'sm' | 'md' | 'lg'
@@ -129,7 +130,7 @@ export function ToolbarButton({
 
   // Determine icon color based on state
   const getIconColor = () => {
-    if (isActive === true) return '#FF7900' // brand-primary
+    if (isActive === true) return resolveColor('brand-primary') // #FF7900
     return showActive ? '#FFFFFF' : '#D1D1D1'
   }
 

--- a/packages/ui/src/theme/ColorSystem.stories.tsx
+++ b/packages/ui/src/theme/ColorSystem.stories.tsx
@@ -1,0 +1,345 @@
+import type { ReactNode } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import {
+  primitiveColors,
+  primitiveRamps,
+  categoricalPalette,
+  getCategoricalColor,
+  CATEGORICAL_CVD_SAFE_MAX,
+  divergingScale,
+  sequentialEffort,
+  bestTextColor,
+} from './tokens/primitives'
+
+const meta: Meta = {
+  title: 'Design Tokens/Color System',
+  tags: ['autodocs'],
+}
+export default meta
+
+// ---- color math (self-contained; drives the accessibility panel) ----
+const hexToRgb = (hex: string): [number, number, number] => {
+  const h = hex.replace('#', '')
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255) as [number, number, number]
+}
+const toHex = (v: number) => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0')
+const lin = (c: number) => (c >= 0.04045 ? ((c + 0.055) / 1.055) ** 2.4 : c / 12.92)
+const gamma = (c: number) => (c >= 0.0031308 ? 1.055 * Math.max(0, c) ** (1 / 2.4) - 0.055 : 12.92 * c)
+const relLum = (hex: string) => {
+  const [r, g, b] = hexToRgb(hex).map(lin)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+const contrast = (a: string, b: string) => {
+  const [l1, l2] = [relLum(a), relLum(b)].sort((x, y) => y - x)
+  return (l1 + 0.05) / (l2 + 0.05)
+}
+const bestText = (hex: string) => (contrast(hex, '#000000') >= contrast(hex, '#FFFFFF') ? '#000000' : '#FFFFFF')
+// Machado-2009 dichromacy simulation (severity 1.0)
+const CVD = {
+  deuteranopia: [0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881],
+  protanopia: [0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998],
+} as const
+const simulate = (M: readonly number[], hex: string) => {
+  const [r, g, b] = hexToRgb(hex).map(lin)
+  const out = [
+    M[0] * r + M[1] * g + M[2] * b,
+    M[3] * r + M[4] * g + M[5] * b,
+    M[6] * r + M[7] * g + M[8] * b,
+  ].map(gamma)
+  return '#' + out.map(toHex).join('')
+}
+
+const STEPS = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950] as const
+
+function SectionTitle({ children }: { children: string }) {
+  return <Text className="text-lg font-bold text-text-primary mb-3 mt-2">{children}</Text>
+}
+
+function Ramp({ name, ramp }: { name: string; ramp: Record<number, string> }) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 6 }}>
+      <Text className="text-text-secondary text-xs" style={{ width: 150 }}>
+        {name}
+      </Text>
+      <View style={{ flexDirection: 'row', flex: 1, borderRadius: 6, overflow: 'hidden', borderWidth: 1, borderColor: '#2C2C2C' }}>
+        {STEPS.map((s) => (
+          <View key={s} style={{ flex: 1, height: 30, backgroundColor: ramp[s] }} />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+function Chip({ hex, label, sub }: { hex: string; label?: string; sub?: string }) {
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <View
+        style={{
+          width: 58,
+          height: 44,
+          borderRadius: 8,
+          backgroundColor: hex,
+          borderWidth: 1,
+          borderColor: '#2C2C2C',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {label ? <Text style={{ color: bestText(hex), fontSize: 11, fontWeight: '700' }}>{label}</Text> : null}
+      </View>
+      {sub ? <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>{sub}</Text> : null}
+    </View>
+  )
+}
+
+const RAMP_NAMES: Array<[keyof typeof primitiveRamps, string]> = [
+  ['red', 'Red'],
+  ['orange', 'Orange'],
+  ['amber', 'Amber · yellow-merged'],
+  ['green', 'Green'],
+  ['cyan', 'Cyan · steel-merged'],
+  ['blue', 'Blue'],
+  ['magenta', 'Magenta'],
+]
+
+// Final semantic mappings (token -> new ramp step). These are the values the
+// PR-2 repoint will apply; shown here as the design target.
+const SEM = {
+  success: primitiveRamps.green[300], // teal folds into green; unified (no separate vivid)
+  warning: primitiveRamps.amber[300],
+  error: primitiveRamps.red[600],
+  info: primitiveRamps.blue[500],
+  deload: primitiveRamps.magenta[600], // violet folds into magenta
+  brand: primitiveRamps.orange[400],
+  brandDark: primitiveRamps.orange[600],
+  brandSecondary: primitiveRamps.cyan[600], // steel folds into cyan
+  spinner: primitiveRamps.cyan[600],
+  neutral: primitiveColors.neutral[500],
+} as const
+
+// BodyMap training-status diverging scale (from the divergingScale token).
+const D3_STATUS = divergingScale
+
+// Semantic token: current value -> new mapping, for the migration section.
+const SEM_MIGRATION: Array<{ label: string; old: string; next: string; flag?: boolean }> = [
+  { label: 'brand', old: primitiveColors.accent[400], next: SEM.brand },
+  { label: 'brand-secondary', old: primitiveColors.steel[500], next: SEM.brandSecondary, flag: true },
+  { label: 'info', old: primitiveColors.sky[500], next: SEM.info },
+  { label: 'error', old: primitiveColors.red[600], next: SEM.error },
+  { label: 'warning', old: primitiveColors.amber[500], next: SEM.warning, flag: true },
+  { label: 'success (unified)', old: primitiveColors.teal[500], next: SEM.success, flag: true },
+  { label: 'deload', old: '#9333EA', next: SEM.deload, flag: true },
+  { label: 'spinner', old: '#5048E5', next: SEM.spinner, flag: true },
+]
+
+export const Overview: StoryObj = {
+  render: () => (
+    <View style={{ padding: 24, gap: 6 }}>
+      <Text className="text-2xl font-bold text-text-primary mb-1">Color System</Text>
+      <Text className="text-text-secondary mb-4">
+        Seven OKLCH tonal ramps (amber absorbs yellow, cyan absorbs steel) and an ordered, colorblind-safe
+        categorical palette. Ramps are the single source of truth; the categorical references ramp steps.
+      </Text>
+
+      <SectionTitle>Tonal ramps</SectionTitle>
+      {RAMP_NAMES.map(([key, name]) => (
+        <Ramp key={key} name={name} ramp={primitiveRamps[key]} />
+      ))}
+
+      <SectionTitle>Semantic tokens — current → new</SectionTitle>
+      <Text className="text-text-secondary text-xs mb-3">
+        ⚑ marks a deliberate hue change (teal-success → green, warning warms, deload violet → magenta,
+        brand-secondary/spinner steel+indigo → cyan). The rest re-home onto the nearest ramp step.
+      </Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 18 }}>
+        {SEM_MIGRATION.map((m) => (
+          <View key={m.label} style={{ alignItems: 'center' }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <Chip hex={m.old} />
+              <Text className="text-text-secondary">→</Text>
+              <Chip hex={m.next} />
+            </View>
+            <Text className="text-text-secondary" style={{ fontSize: 9, marginTop: 3 }}>
+              {m.flag ? '⚑ ' : ''}{m.label}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      <SectionTitle>Categorical — ordered, nested, CVD-safe to 6</SectionTitle>
+      {(['default', 'dark'] as const).map((variant) => (
+        <View key={variant} style={{ marginBottom: 10 }}>
+          <Text className="text-text-secondary text-xs mb-1" style={{ textTransform: 'capitalize' }}>
+            {variant}
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 6 }}>
+            {categoricalPalette[variant].map((hex, i) => (
+              <Chip key={i} hex={hex} label={`${i + 1}`} sub={i < CATEGORICAL_CVD_SAFE_MAX ? undefined : 'ext'} />
+            ))}
+          </View>
+        </View>
+      ))}
+
+      <SectionTitle>Data-viz scales</SectionTitle>
+      <Text className="text-text-secondary text-xs mb-2">
+        Diverging (BodyMap training-status) — light-centered so it reads in lightness and stays
+        colorblind-stable; direction is the blue↔red axis. Labels use per-cell best-contrast text.
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 6, marginBottom: 12 }}>
+        {['under', 'maint', 'optimal', 'approach', 'over'].map((l, i) => (
+          <View key={l} style={{ flex: 1, height: 40, borderRadius: 6, backgroundColor: divergingScale[i], alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ color: bestTextColor(divergingScale[i]), fontSize: 10, fontWeight: '700' }}>{l}</Text>
+          </View>
+        ))}
+      </View>
+      <Text className="text-text-secondary text-xs mb-2">
+        Sequential effort (low → high) — an ordinal green→yellow→orange→red scale that IntensityBar uses
+        in full and VelocityStrip/RPE sub-samples.
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 4, marginBottom: 4 }}>
+        {sequentialEffort.map((hex, i) => (
+          <View key={i} style={{ flex: 1, height: 34, borderRadius: 5, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ color: bestTextColor(hex), fontSize: 10, fontWeight: '700' }}>{i + 1}</Text>
+          </View>
+        ))}
+      </View>
+
+      <SectionTitle>Component examples — correct color roles</SectionTitle>
+      <View style={{ flexDirection: 'row', gap: 20, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        {/* BodyMap muscle heatmap — training-status diverging (D3) */}
+        <Demo label="BodyMap · training status">
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 132, gap: 4 }}>
+            {[
+              ['Chest', 4], ['Quads', 2], ['Back', 3],
+              ['Delts', 0], ['Biceps', 4], ['Calves', 1],
+            ].map(([m, idx]) => (
+              <View key={m as string} style={{ width: 40, backgroundColor: D3_STATUS[idx as number], borderRadius: 5, paddingVertical: 6 }}>
+                <Text style={{ color: bestTextColor(D3_STATUS[idx as number]), fontSize: 8, fontWeight: '700', textAlign: 'center' }}>{m as string}</Text>
+              </View>
+            ))}
+          </View>
+        </Demo>
+        {/* StatusDot — semantic */}
+        <Demo label="StatusDot · semantic">
+          <View style={{ gap: 6 }}>
+            {[['ok', SEM.success], ['warn', SEM.warning], ['err', SEM.error], ['neutral', SEM.neutral]].map(([l, c]) => (
+              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                <View style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: c as string }} />
+                <Text className="text-text-secondary" style={{ fontSize: 11 }}>{l as string}</Text>
+              </View>
+            ))}
+          </View>
+        </Demo>
+        {/* WorkoutPill — status */}
+        <Demo label="WorkoutPill">
+          <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap', maxWidth: 220 }}>
+            {[['Done', SEM.success], ['Now', SEM.brand], ['Next', SEM.neutral], ['Deload', SEM.deload]].map(([t, c]) => (
+              <View key={t as string} style={{ borderRadius: 99, borderWidth: 1, borderColor: c as string, paddingHorizontal: 10, paddingVertical: 3 }}>
+                <Text style={{ color: c as string, fontSize: 11, fontWeight: '700' }}>{t as string}</Text>
+              </View>
+            ))}
+          </View>
+        </Demo>
+        {/* StrengthTrend legend — series → semantic */}
+        <Demo label="StrengthTrend · series">
+          <View style={{ flexDirection: 'row', gap: 12, flexWrap: 'wrap' }}>
+            {[['1RM', SEM.brand], ['vel', SEM.success], ['miss', SEM.error], ['RPE', SEM.warning]].map(([l, c]) => (
+              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                <View style={{ width: 14, height: 3, backgroundColor: c as string, borderRadius: 2 }} />
+                <Text className="text-text-secondary" style={{ fontSize: 10 }}>{l as string}</Text>
+              </View>
+            ))}
+          </View>
+        </Demo>
+        {/* Treemap — ordered categorical */}
+        <Demo label="Treemap · categorical">
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 140, gap: 2 }}>
+            {[46, 30, 30, 24, 24, 24, 20].map((h, i) => (
+              <View key={i} style={{ height: h, flexGrow: 1, flexBasis: h > 40 ? 60 : 40, backgroundColor: getCategoricalColor(i), borderRadius: 3 }} />
+            ))}
+          </View>
+        </Demo>
+        {/* Spinner */}
+        <Demo label="Spinner">
+          <View style={{ width: 24, height: 24, borderRadius: 12, borderWidth: 3, borderColor: '#2C2C2C', borderTopColor: SEM.spinner }} />
+        </Demo>
+        {/* IntensityBar — full effort scale */}
+        <Demo label="IntensityBar · effort">
+          <View style={{ flexDirection: 'row', gap: 2, width: 132 }}>
+            {sequentialEffort.map((hex, i) => (
+              <View key={i} style={{ flex: 1, height: 20, backgroundColor: hex, borderRadius: 2 }} />
+            ))}
+          </View>
+        </Demo>
+        {/* VelocityStrip / RPE — effort sub-sample */}
+        <Demo label="VelocityStrip · RPE">
+          <View style={{ flexDirection: 'row', gap: 3 }}>
+            {[sequentialEffort[0], sequentialEffort[2], sequentialEffort[3], sequentialEffort[5]].map((hex, i) => (
+              <View key={i} style={{ width: 30, height: 26, borderRadius: 4, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
+                <Text style={{ color: bestTextColor(hex), fontSize: 9, fontWeight: '700' }}>{['S', 'M', 'F', 'X'][i]}</Text>
+              </View>
+            ))}
+          </View>
+        </Demo>
+      </View>
+    </View>
+  ),
+}
+
+function Demo({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <View style={{ padding: 10, backgroundColor: '#1A1A1A', borderRadius: 8 }}>
+      <Text className="text-text-secondary" style={{ fontSize: 9, marginBottom: 6 }}>{label}</Text>
+      {children}
+    </View>
+  )
+}
+
+export const Accessibility: StoryObj = {
+  render: () => (
+    <View style={{ padding: 24 }}>
+      <Text className="text-2xl font-bold text-text-primary mb-1">Categorical Accessibility</Text>
+      <Text className="text-text-secondary mb-5">
+        In-place text contrast and colorblind simulation for the categorical series. Converging strips across
+        two swatches signal a collision for that viewer; all pairs hold ΔE ≥ 8 through the first {CATEGORICAL_CVD_SAFE_MAX}.
+      </Text>
+
+      {(['default', 'dark'] as const).map((variant) => {
+        const colors = categoricalPalette[variant]
+        const textColor = variant === 'dark' ? '#FFFFFF' : '#000000'
+        return (
+          <View key={variant} style={{ marginBottom: 22 }}>
+            <Text className="text-lg font-bold text-text-primary mb-2" style={{ textTransform: 'capitalize' }}>
+              {variant}
+            </Text>
+            {/* swatches with in-place text + contrast ratio */}
+            <View style={{ flexDirection: 'row', gap: 6, marginBottom: 6 }}>
+              {colors.map((hex, i) => (
+                <View key={i} style={{ alignItems: 'center' }}>
+                  <View style={{ width: 56, height: 40, borderRadius: 6, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
+                    <Text style={{ color: textColor, fontSize: 11, fontWeight: '700' }}>Aa</Text>
+                  </View>
+                  <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>
+                    {contrast(hex, textColor).toFixed(1)}:1
+                  </Text>
+                </View>
+              ))}
+            </View>
+            {/* CVD simulation strips */}
+            {(['deuteranopia', 'protanopia'] as const).map((mode) => (
+              <View key={mode} style={{ flexDirection: 'row', alignItems: 'center', marginTop: 3 }}>
+                <Text className="text-text-secondary" style={{ fontSize: 9, width: 96 }}>{mode}</Text>
+                <View style={{ flexDirection: 'row', gap: 6 }}>
+                  {colors.map((hex, i) => (
+                    <View key={i} style={{ width: 56, height: 14, borderRadius: 3, backgroundColor: simulate(CVD[mode], hex) }} />
+                  ))}
+                </View>
+              </View>
+            ))}
+          </View>
+        )
+      })}
+    </View>
+  ),
+}

--- a/packages/ui/src/theme/Colors.stories.tsx
+++ b/packages/ui/src/theme/Colors.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
-import { primitiveColors, discreteRainbow } from './tokens/primitives'
+import { primitiveColors, discreteRainbow, primitiveRamps, categoricalPalette } from './tokens/primitives'
 import { semanticColorsLight, semanticColorsDark } from './tokens/semantic'
 
 const meta: Meta = {
@@ -232,6 +232,74 @@ export const DataVisualizationColors: StoryObj = {
           />
         ))}
       </View>
+    </View>
+  ),
+}
+
+function CategoricalRow({ name, colors }: { name: string; colors: readonly string[] }) {
+  return (
+    <View style={{ marginBottom: 24 }}>
+      <Text className="text-lg font-bold text-text-primary mb-3">
+        {name} <Text className="text-text-secondary text-sm">({colors.length})</Text>
+      </Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        {colors.map((color, index) => (
+          <View key={index} style={{ alignItems: 'center' }}>
+            <View
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 8,
+                backgroundColor: color,
+                borderWidth: 1,
+                borderColor: '#374151',
+              }}
+            />
+            <Text className="text-text-secondary text-xs mt-1">{color.toUpperCase()}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+export const TonalRamps: StoryObj = {
+  render: () => (
+    <View style={{ padding: 24 }}>
+      <Text className="text-2xl font-bold text-text-primary mb-6">
+        Tonal Ramps (Foundations)
+      </Text>
+      <Text className="text-text-secondary mb-6">
+        Seven OKLCH-generated hue ramps, 11 perceptual steps each (50 → 950). Built with hue-torsion and a
+        chroma arc; amber absorbs the former yellow (lemon → warm body) and cyan absorbs the former steel.
+      </Text>
+
+      <ColorScale name="Red" colors={primitiveRamps.red} />
+      <ColorScale name="Orange" colors={primitiveRamps.orange} />
+      <ColorScale name="Amber (yellow-merged)" colors={primitiveRamps.amber} />
+      <ColorScale name="Green" colors={primitiveRamps.green} />
+      <ColorScale name="Cyan (steel-merged)" colors={primitiveRamps.cyan} />
+      <ColorScale name="Blue" colors={primitiveRamps.blue} />
+      <ColorScale name="Magenta" colors={primitiveRamps.magenta} />
+    </View>
+  ),
+}
+
+export const CategoricalPalette: StoryObj = {
+  render: () => (
+    <View style={{ padding: 24 }}>
+      <Text className="text-2xl font-bold text-text-primary mb-6">
+        Categorical Palette
+      </Text>
+      <Text className="text-text-secondary mb-6">
+        Ordered, colorblind-safe qualitative series (worst-case deut/protanopia floor 8 through the first
+        six colors; the 7th is extended — pair it with a legend). Series index is stable. Use{' '}
+        <Text className="font-semibold">default</Text> on neutral/light surfaces (also legible under black
+        text) and <Text className="font-semibold">dark</Text> where white text sits on the swatch.
+      </Text>
+
+      <CategoricalRow name="Default" colors={categoricalPalette.default} />
+      <CategoricalRow name="Dark (white text)" colors={categoricalPalette.dark} />
     </View>
   ),
 }

--- a/packages/ui/src/theme/extracted-colors-dataviz.ts
+++ b/packages/ui/src/theme/extracted-colors-dataviz.ts
@@ -1,0 +1,52 @@
+/**
+ * Extracted data-viz / status / brand colors (Phase 1 audit staging).
+ *
+ * These are chromatic fills that were previously inlined as raw hex literals
+ * inside custom Workout / Treemap / Scatter / Gauge components and do NOT map
+ * to an existing semantic token. They are captured here at their EXACT current
+ * values (a provable no-op) so the color-foundations redesign can audit and
+ * re-home them next. Values that DO map to a semantic token were referenced
+ * directly (via `getSemanticColors('dark')[…]`) instead of duplicated here, and
+ * values already centralized in `workout-tokens.ts` (scale / intensity /
+ * heatmap) continue to be referenced from `WORKOUT_TOKENS`.
+ *
+ * Do not redesign these values here — extraction only.
+ */
+
+/**
+ * Titan categorical fallback palette shared verbatim by Treemap and Scatter.
+ * NOTE: the components labelled this "data-1..data-8", but the values are a
+ * private palette that does NOT match the `data-*` semantic tokens
+ * (data-1 = #1965B0, etc.). Three entries coincide with existing tokens
+ * (#14B8A6 = status-success, #406D87 = brand-secondary, #43C6B7 =
+ * status-success-light); they are kept inline so the categorical scale stays a
+ * single cohesive unit. Future candidate: promote to a canonical `dataviz-cat-*`
+ * scale (or reconcile with `data-*`).
+ */
+export const DATAVIZ_CATEGORICAL_PALETTE = [
+  '#5B9BD5', // blue
+  '#14B8A6', // teal  (== status-success)
+  '#F4A736', // amber-orange (== data-6 token value)
+  '#F83030', // red
+  '#823CA0', // purple
+  '#D4A520', // gold
+  '#406D87', // steel (== brand-secondary)
+  '#43C6B7', // light teal (== status-success-light)
+] as const
+
+/**
+ * MesoCard / MesoStatusCard 3px top-accent gradient stops (dark -> primary ->
+ * light). The dark and light stops are bespoke orange shades that do NOT match
+ * the brand-primary-dark (#D0620C) or brand-primary-light (#FF9630) tokens; the
+ * middle stop is brand-primary (#FF7900) and is referenced from the token.
+ * Future candidate: a `brand-primary-gradient-{dark,light}` token pair.
+ */
+export const MESO_ACCENT_GRADIENT_DARK = '#C45E00'
+export const MESO_ACCENT_GRADIENT_LIGHT = '#FFB066'
+
+/**
+ * WorkoutPill "deload" status color — a purple with no semantic equivalent.
+ * Also appears as rgba(147,51,234,…) tints for the pill bg/border (left inline).
+ * Future candidate: a `status-deload` (or `result-deload`) token.
+ */
+export const WORKOUT_PILL_DELOAD = '#9333ea'

--- a/packages/ui/src/theme/extracted-colors-ui.ts
+++ b/packages/ui/src/theme/extracted-colors-ui.ts
@@ -1,0 +1,50 @@
+/**
+ * Extracted UI-atom colors (color-foundations audit — Phase 1)
+ *
+ * Chromatic data/status/brand/accent fills that were hardcoded inside atom
+ * components in `components/ui/**` and had NO clean semantic-token equivalent
+ * at their current rendered value. They are centralized here VERBATIM (no
+ * value change) so a later phase can decide their canonical tokens.
+ *
+ * These are intentionally NOT theme-switching: each atom currently renders a
+ * fixed hex regardless of light/dark, so referencing a theme-aware semantic
+ * token (via `resolveColor`) would change behavior on web. Keep them as static
+ * hex until the redesign phase reassigns them.
+ *
+ * Chromatic values that DID match a stable semantic token were referenced via
+ * `resolveColor(...)` in-place instead and do not appear here.
+ */
+
+/**
+ * Spinner `color="primary"` fill.
+ * Provenance: `components/ui/spinner/Spinner.tsx` colorMap.primary.
+ * Equals primitive `blue.600` (#5048E5). Used in semantic tokens only in LIGHT
+ * mode (text-link / border-focus); dark mode maps those to #828DF8, so no
+ * dark-default token reproduces this static value.
+ */
+export const SPINNER_PRIMARY = '#5048E5'
+
+/**
+ * Spinner `color="secondary"` fill.
+ * Provenance: `components/ui/spinner/Spinner.tsx` colorMap.secondary.
+ * Equals primitive `green.500` (#10B981, emerald). No semantic token resolves
+ * to this — the vivid/teal success tokens are different greens.
+ */
+export const SPINNER_SECONDARY = '#10B981'
+
+/**
+ * Categorical avatar palette — deterministic per-name fill.
+ * Provenance: `utils/avatar-color.ts` AVATAR_COLORS.
+ * A 7-color qualitative set (order preserved for stable hashing). None of these
+ * map to existing semantic/data tokens; centralized as a candidate canonical
+ * categorical set for the redesign phase.
+ */
+export const AVATAR_CATEGORICAL_COLORS = [
+  '#FF6B6B', // coral / red
+  '#4ECDC4', // turquoise
+  '#45B7D1', // sky blue
+  '#96CEB4', // sage green
+  '#FFEAA7', // pale yellow
+  '#DDA0DD', // plum
+  '#98D8C8', // mint
+] as const

--- a/packages/ui/src/theme/tokens/primitives.test.ts
+++ b/packages/ui/src/theme/tokens/primitives.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import {
+  primitiveRamps,
+  categoricalPalette,
+  getCategoricalColor,
+  CATEGORICAL_CVD_SAFE_MAX,
+  divergingScale,
+  sequentialEffort,
+  bestTextColor,
+} from './primitives'
+
+// --- Minimal OKLab + Machado-2009 dichromacy math (ported from the color-system
+// derivation tools) so the categorical CVD floor is a real, checked property. ---
+const hexToRgb = (hex: string): [number, number, number] => {
+  const h = hex.replace('#', '')
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255) as [number, number, number]
+}
+const lin = (c: number) => (c >= 0.04045 ? ((c + 0.055) / 1.055) ** 2.4 : c / 12.92)
+const toOklab = ([r, g, b]: number[]): [number, number, number] => {
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ]
+}
+const mul = (M: number[], v: number[]) => [
+  M[0] * v[0] + M[1] * v[1] + M[2] * v[2],
+  M[3] * v[0] + M[4] * v[1] + M[5] * v[2],
+  M[6] * v[0] + M[7] * v[1] + M[8] * v[2],
+]
+// Machado-2009 dichromacy simulation matrices, severity 1.0. The palette solver
+// optimizes worst-case deuteranopia/protanopia (red-green is the binding case) —
+// match that 2-way metric here, not a stricter 3-way including tritan.
+const DEUT = [0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881]
+const PROT = [0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998]
+const dist = (a: number[], b: number[]) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]) * 100
+// worst-case perceived ΔE across deuteranopia and protanopia
+const cvdDelta = (x: string, y: string) => {
+  const sim = (M: number[], hex: string) => toOklab(mul(M, hexToRgb(hex).map(lin)))
+  return Math.min(
+    ...[DEUT, PROT].map((M) => dist(sim(M, x), sim(M, y))),
+  )
+}
+
+const HEX6 = /^#[0-9A-F]{6}$/
+const STEPS = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950] as const
+const HUES = ['red', 'orange', 'amber', 'green', 'cyan', 'blue', 'magenta'] as const
+
+describe('primitiveRamps', () => {
+  it('has all seven consolidated hues', () => {
+    expect(Object.keys(primitiveRamps).sort()).toEqual([...HUES].sort())
+  })
+
+  it('gives every hue all eleven perceptual steps as uppercase 6-digit hex', () => {
+    for (const hue of HUES) {
+      const ramp = primitiveRamps[hue] as Record<number, string>
+      for (const step of STEPS) {
+        expect(ramp[step], `${hue}-${step}`).toMatch(HEX6)
+      }
+    }
+  })
+
+  it('flows through each pinned anchor color at its step', () => {
+    // The step each ramp is pinned to its brand/semantic anchor hex.
+    const anchors: Record<string, string> = {
+      'red-600': '#D14343', // status-error
+      'orange-400': '#FF7900', // brand-primary
+      'amber-300': '#F9B415', // status-warning (yellow-merged, nudged toward the lemon top)
+      'green-300': '#2ED573', // status-success
+      'cyan-300': '#22D3EE', // vivid cyan identity
+      'blue-500': '#2196F3', // status-info
+      'magenta-700': '#9C0D7A',
+    }
+    for (const [key, hex] of Object.entries(anchors)) {
+      const [hue, step] = key.split('-')
+      expect((primitiveRamps as never)[hue][Number(step)]).toBe(hex)
+    }
+  })
+
+  it('increases in darkness monotonically (OKLab L descends 50 -> 950)', () => {
+    for (const hue of HUES) {
+      const ramp = primitiveRamps[hue] as Record<number, string>
+      const lightness = STEPS.map((s) => toOklab(hexToRgb(ramp[s]).map(lin))[0])
+      for (let i = 1; i < lightness.length; i++) {
+        expect(lightness[i], `${hue} ${STEPS[i - 1]}->${STEPS[i]}`).toBeLessThan(lightness[i - 1])
+      }
+    }
+  })
+})
+
+describe('categoricalPalette', () => {
+  it('has two ordered variants of seven colors', () => {
+    expect(categoricalPalette.default).toHaveLength(7)
+    expect(categoricalPalette.dark).toHaveLength(7)
+  })
+
+  it('is all uppercase 6-digit hex', () => {
+    for (const variant of ['default', 'dark'] as const) {
+      for (const hex of categoricalPalette[variant]) {
+        expect(hex).toMatch(HEX6)
+      }
+    }
+  })
+
+  it('holds the deut/protanopia dichromacy floor (deltaE >= 8) through the CVD-safe max', () => {
+    // The first CATEGORICAL_CVD_SAFE_MAX colors are legend-free CVD-safe; the 7th is extended.
+    for (const variant of ['default', 'dark'] as const) {
+      const colors = categoricalPalette[variant].slice(0, CATEGORICAL_CVD_SAFE_MAX)
+      let worst = Infinity
+      for (let i = 0; i < colors.length; i++) {
+        for (let j = i + 1; j < colors.length; j++) {
+          worst = Math.min(worst, cvdDelta(colors[i], colors[j]))
+        }
+      }
+      expect(worst, `${variant} min CVD deltaE (first ${CATEGORICAL_CVD_SAFE_MAX})`).toBeGreaterThanOrEqual(8)
+    }
+  })
+
+  it('is nested-stable: no color repeats within a variant', () => {
+    for (const variant of ['default', 'dark'] as const) {
+      expect(new Set(categoricalPalette[variant]).size).toBe(categoricalPalette[variant].length)
+    }
+  })
+
+  it('carries readable in-place text: default on black (>=4.5), dark on white (>=3.5)', () => {
+    const relLum = (hex: string) => {
+      const [r, g, b] = hexToRgb(hex).map(lin)
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    }
+    const onBlack = (hex: string) => (relLum(hex) + 0.05) / 0.05
+    const onWhite = (hex: string) => 1.05 / (relLum(hex) + 0.05)
+    // The in-place text guarantee covers the CVD-safe range; the 7th extended
+    // color trades contrast for separation and is meant to be legend-paired.
+    for (const hex of categoricalPalette.default.slice(0, CATEGORICAL_CVD_SAFE_MAX)) {
+      expect(onBlack(hex), `default ${hex} black-text contrast`).toBeGreaterThanOrEqual(4.5)
+    }
+    for (const hex of categoricalPalette.dark.slice(0, CATEGORICAL_CVD_SAFE_MAX)) {
+      expect(onWhite(hex), `dark ${hex} white-text contrast`).toBeGreaterThanOrEqual(3.5)
+    }
+  })
+})
+
+describe('getCategoricalColor', () => {
+  it('returns default-variant colors by index', () => {
+    expect(getCategoricalColor(0)).toBe(categoricalPalette.default[0])
+    expect(getCategoricalColor(4)).toBe(categoricalPalette.default[4])
+  })
+
+  it('selects the requested variant', () => {
+    expect(getCategoricalColor(2, 'dark')).toBe(categoricalPalette.dark[2])
+    expect(getCategoricalColor(1, 'dark')).toBe(categoricalPalette.dark[1])
+  })
+
+  it('wraps past the end of the palette', () => {
+    expect(getCategoricalColor(7)).toBe(categoricalPalette.default[0])
+    expect(getCategoricalColor(9)).toBe(categoricalPalette.default[2])
+  })
+
+  it('clamps negative and fractional indices', () => {
+    expect(getCategoricalColor(-3)).toBe(categoricalPalette.default[0])
+    expect(getCategoricalColor(2.9)).toBe(categoricalPalette.default[2])
+  })
+})
+
+const relLum = (hex: string) => {
+  const [r, g, b] = hexToRgb(hex).map(lin)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+const bestContrast = (hex: string) => {
+  const l = relLum(hex)
+  return Math.max((l + 0.05) / 0.05, 1.05 / (l + 0.05))
+}
+
+describe('divergingScale', () => {
+  it('is a five-stop diverging scale of uppercase hex', () => {
+    expect(divergingScale).toHaveLength(5)
+    for (const hex of divergingScale) expect(hex).toMatch(HEX6)
+  })
+
+  it('has a light center and dark extremes (diverging shape)', () => {
+    const L = divergingScale.map((h) => toOklab(hexToRgb(h).map(lin))[0])
+    expect(L[2], 'optimal is the lightest').toBeGreaterThan(Math.max(L[0], L[4]))
+    expect(L[0], 'under is dark').toBeLessThan(L[1])
+    expect(L[4], 'over is dark').toBeLessThan(L[3])
+  })
+
+  it('holds a strong CVD floor (deltaE >= 10)', () => {
+    let worst = Infinity
+    for (let i = 0; i < divergingScale.length; i++) {
+      for (let j = i + 1; j < divergingScale.length; j++) {
+        worst = Math.min(worst, cvdDelta(divergingScale[i], divergingScale[j]))
+      }
+    }
+    expect(worst).toBeGreaterThanOrEqual(10)
+  })
+
+  it('every cell carries a legible label via best-contrast text (>=4.5)', () => {
+    for (const hex of divergingScale) {
+      expect(bestContrast(hex), `${hex}`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+})
+
+describe('sequentialEffort', () => {
+  it('is a six-stop ordinal scale of uppercase hex', () => {
+    expect(sequentialEffort).toHaveLength(6)
+    for (const hex of sequentialEffort) expect(hex).toMatch(HEX6)
+  })
+
+  it('keeps adjacent stops distinguishable', () => {
+    for (let i = 0; i < sequentialEffort.length - 1; i++) {
+      expect(cvdDelta(sequentialEffort[i], sequentialEffort[i + 1]), `stop ${i}->${i + 1}`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('every stop carries a legible label via best-contrast text (>=4.5)', () => {
+    for (const hex of sequentialEffort) {
+      expect(bestContrast(hex), `${hex}`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+})
+
+describe('bestTextColor', () => {
+  it('picks black on light fills and white on dark fills', () => {
+    expect(bestTextColor(primitiveRamps.green[300])).toBe('#000000')
+    expect(bestTextColor(primitiveRamps.red[700])).toBe('#FFFFFF')
+    expect(bestTextColor(primitiveRamps.blue[700])).toBe('#FFFFFF')
+  })
+})

--- a/packages/ui/src/theme/tokens/primitives.ts
+++ b/packages/ui/src/theme/tokens/primitives.ts
@@ -181,6 +181,225 @@ export const primitiveColors = {
 } as const
 
 /**
+ * Derived tonal ramps (TD-05.09 color foundations)
+ *
+ * Seven OKLCH-generated hue ramps, 11 perceptual lightness steps each (50 -> 950).
+ * Built with hue-torsion + a chroma arc, anchored through existing brand/semantic
+ * hexes. Two hues were consolidated where their used colors never collided along
+ * the lightness axis: `amber` absorbs the former yellow (lemon light end -> warm
+ * amber body), `cyan` absorbs the former steel (vivid cyan -> muted steel dark,
+ * brand-secondary at 600). `pin` marks the step each ramp flows through its anchor.
+ * This is the single source of truth for chromatic hexes — the categorical palette
+ * below references these steps rather than duplicating values.
+ * See coordination/design-explorations/foundations.
+ */
+export const primitiveRamps = {
+  red: {
+    50: '#FFF4F4',
+    100: '#FFE3E5',
+    200: '#FFC2C5',
+    300: '#FF9A9D',
+    400: '#F77175',
+    500: '#E05254',
+    600: '#D14343', // pin
+    700: '#A4221C',
+    800: '#7E1002',
+    900: '#5A0900',
+    950: '#3D0400',
+  },
+  orange: {
+    50: '#FFF5ED',
+    100: '#FFE6D4',
+    200: '#FFC7A2',
+    300: '#FFA063',
+    400: '#FF7900', // pin
+    500: '#DA5F00',
+    600: '#B94A00',
+    700: '#983804',
+    800: '#6F290F',
+    900: '#4E1C0C',
+    950: '#331107',
+  },
+  amber: { // yellow-merged: lemon top, warm-rich body
+    50: '#FFF7DD',
+    100: '#FFEAA9',
+    200: '#FFD352',
+    300: '#F9B415', // pin
+    400: '#E08C00',
+    500: '#C27400',
+    600: '#A45E00',
+    700: '#814D14',
+    800: '#5B3A1A',
+    900: '#442503',
+    950: '#301500',
+  },
+  green: {
+    50: '#E3FFEE',
+    100: '#B5FFD2',
+    200: '#58F69E',
+    300: '#2ED573', // pin
+    400: '#21C05D',
+    500: '#22A444',
+    600: '#298732',
+    700: '#2B6B25',
+    800: '#264D1C',
+    900: '#1B3515',
+    950: '#11220D',
+  },
+  cyan: { // steel-merged: brand-secondary at 600
+    50: '#E6FBFF',
+    100: '#C2F6FF',
+    200: '#62EAFF',
+    300: '#22D3EE', // pin
+    400: '#01B5D1',
+    500: '#2697B7',
+    600: '#307B9B',
+    700: '#2A617F',
+    800: '#22465F',
+    900: '#0B3149',
+    950: '#001F36',
+  },
+  blue: {
+    50: '#EFF8FF',
+    100: '#D9EFFF',
+    200: '#ACDBFF',
+    300: '#78C2FF',
+    400: '#3CA8FF',
+    500: '#2196F3', // pin
+    600: '#1072CB',
+    700: '#135AA8',
+    800: '#14407E',
+    900: '#112C5A',
+    950: '#091B3C',
+  },
+  magenta: {
+    50: '#FFF3F9',
+    100: '#FFE2F1',
+    200: '#FFBDE2',
+    300: '#FF8FD5',
+    400: '#ED69C3',
+    500: '#D548AF',
+    600: '#BA2996',
+    700: '#9C0D7A', // pin
+    800: '#77005A',
+    900: '#56003F',
+    950: '#3B0029',
+  },
+} as const
+
+/**
+ * Categorical (qualitative) palette — an ordered, CVD-safe series expressed as
+ * references into {@link primitiveRamps} (one source of truth; the palette moves
+ * with the ramps).
+ *
+ * Design: a single canonical hue order (blue, magenta, red, orange, green, cyan,
+ * amber), with steps chosen vivid-midtone-first and fanned lighter/darker as the
+ * series grows to preserve separation. The sequence is nested-stable — a chart
+ * with N series uses the first N colors, and the series index is stable as N
+ * changes. Colorblind-safe worst-case deuteranopia/protanopia floor 8 holds
+ * through {@link CATEGORICAL_CVD_SAFE_MAX} colors; the 7th is an extended color
+ * that should be paired with a legend or other secondary encoding.
+ *
+ * Two variants: `default` (vivid, sits on neutral/light surfaces, legible under
+ * black text) and `dark` (deeper shades legible under white text on a fill). A
+ * separate "light" variant was dropped — the vivid `default` picks already clear
+ * black-text contrast, so it doubles as the light-context palette.
+ */
+export const categoricalPalette = {
+  default: [
+    primitiveRamps.blue[500],
+    primitiveRamps.magenta[500],
+    primitiveRamps.red[500],
+    primitiveRamps.orange[400],
+    primitiveRamps.green[300],
+    primitiveRamps.cyan[300],
+    primitiveRamps.amber[600], // extended (7th) — pair with a legend
+  ],
+  dark: [
+    primitiveRamps.blue[600],
+    primitiveRamps.magenta[600],
+    primitiveRamps.red[500],
+    primitiveRamps.orange[600],
+    primitiveRamps.green[800],
+    primitiveRamps.cyan[800],
+    primitiveRamps.amber[500], // extended (7th) — pair with a legend
+  ],
+} as const
+
+/** Largest series count that holds the CVD floor without a legend. */
+export const CATEGORICAL_CVD_SAFE_MAX = 6
+
+/**
+ * Categorical palette variant.
+ * - `default` : vivid; neutral/light surfaces, legible under black text
+ * - `dark`    : deeper shades, legible under white text on a filled swatch
+ */
+export type CategoricalVariant = keyof typeof categoricalPalette
+
+/**
+ * Get a color from the ordered categorical palette by series index.
+ * The palette is nested-stable, so the color for a given index does not change
+ * with the total series count; `index` simply wraps past the end.
+ *
+ * @param index - 0-based series index (wraps past the end)
+ * @param variant - `default` (black-text / light surfaces) or `dark` (white text)
+ * @returns The hex color string
+ */
+export function getCategoricalColor(index: number, variant: CategoricalVariant = 'default'): string {
+  const palette = categoricalPalette[variant]
+  index = Math.max(0, Math.floor(index))
+  return palette[index % palette.length]
+}
+
+/**
+ * Diverging status scale (BodyMap training-status: under → optimal → over) as
+ * references into {@link primitiveRamps}. A true diverging shape — `optimal` is
+ * the lightest center, the extremes (`under`/`over`) go dark — so the signal
+ * reads in lightness (colorblind-robust; worst-case deut/protanopia min ΔE ~13.7)
+ * and the direction reads in the blue↔red axis (the CVD-safe hue pair).
+ *
+ * Fills carry labels: use per-cell best-contrast text — white on the dark
+ * extremes (under/over), black on the lighter middle three (see {@link bestTextColor}).
+ */
+export const divergingScale = [
+  primitiveRamps.blue[700], // under
+  primitiveRamps.cyan[400], // maintenance
+  primitiveRamps.green[300], // optimal (light center)
+  primitiveRamps.orange[500], // approaching
+  primitiveRamps.red[700], // over
+] as const
+
+/**
+ * Sequential "effort" scale (low → high intensity: green → yellow → orange → red)
+ * as references into {@link primitiveRamps}. An ordinal palette that components
+ * sub-sample — IntensityBar uses the full 6 stops; VelocityStrip/RPE takes a
+ * 4-stop subsample. Order encodes magnitude, so it tolerates the green↔red CVD
+ * pair; the light-yellow stop is the visual pivot. Stops 1–5 take black text,
+ * the dark red-700 max takes white.
+ */
+export const sequentialEffort = [
+  primitiveRamps.green[400],
+  primitiveRamps.amber[200],
+  primitiveRamps.amber[400],
+  primitiveRamps.orange[500],
+  primitiveRamps.red[500],
+  primitiveRamps.red[700],
+] as const
+
+/**
+ * Best-contrast text color (black or white) for a solid fill — for labels sitting
+ * on categorical/diverging/effort swatches. Uses the WCAG relative-luminance ratio.
+ */
+export function bestTextColor(hex: string): '#000000' | '#FFFFFF' {
+  const [r, g, b] = [0, 2, 4].map((i) => {
+    const c = parseInt(hex.replace('#', '').slice(i, i + 2), 16) / 255
+    return c >= 0.04045 ? ((c + 0.055) / 1.055) ** 2.4 : c / 12.92
+  })
+  const l = 0.2126 * r + 0.7152 * g + 0.0722 * b
+  return (l + 0.05) / 0.05 >= 1.05 / (l + 0.05) ? '#000000' : '#FFFFFF'
+}
+
+/**
  * Discrete rainbow palette for data visualization
  * Based on Paul Tol's color schemes: https://personal.sron.nl/~pault/#fig:scheme_rainbow_discrete
  */

--- a/packages/ui/src/utils/avatar-color.ts
+++ b/packages/ui/src/utils/avatar-color.ts
@@ -1,6 +1,6 @@
-const AVATAR_COLORS = [
-  '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#98D8C8'
-]
+import { AVATAR_CATEGORICAL_COLORS } from '../theme/extracted-colors-ui'
+
+const AVATAR_COLORS = AVATAR_CATEGORICAL_COLORS
 
 export function avatarColor(name: string): string {
   let hash = 0


### PR DESCRIPTION
## What

Foundation layer for the color-system redesign (TD-05.09 / VW-22). **Provable no-op** — adds derived tokens and docs that nothing consumes yet. The semantic repoint that makes these visible lands in a follow-up PR.

Two commits:
1. **Extraction** — moves the last hardcoded data/status/brand hex literals out of custom components into `extracted-colors-{dataviz,ui}.ts`, captured verbatim.
2. **Foundations** — adds the derived token API to `primitives.ts`.

## New token API (`packages/ui/src/theme/tokens/primitives.ts`)

All chromatic hexes live in the ramps; everything else references them (single source of truth).

- **`primitiveRamps`** — 7 OKLCH-generated hue ramps (red, orange, amber, green, cyan, blue, magenta), 11 perceptual steps each. Yellow folded into amber; steel into cyan (their used colors never collided along the lightness axis).
- **`categoricalPalette`** + `getCategoricalColor(i, variant)` — ordered, nested-stable qualitative palette, 2 variants (`default` + `dark`), as ramp-step refs. CVD floor 8 holds through `CATEGORICAL_CVD_SAFE_MAX = 6`; 7th is extended.
- **`divergingScale`** — 5-stop BodyMap training-status (light-centered, worst-case deut/protan ΔE ~13.7).
- **`sequentialEffort`** — 6-stop ordinal effort scale (IntensityBar full / VelocityStrip-RPE subsample).
- **`bestTextColor(hex)`** — per-cell WCAG-luminance label contrast.

## Docs / story

- `Design Tokens / Color System` Storybook story (Overview + Accessibility).
- Standalone before/after gallery + method/determinism/index notes in the workspace coordination dir.

## Verification

- `tsc` clean · eslint 0 errors · **vitest 2123/2123 passed**.
- Nothing imports the new tokens yet → rendered output is byte-identical to `main`.

## Next

PR 2 — the semantic repoint: `semantic.ts` / `global.css` / `extracted-colors-*` onto ramp steps, component adoption, visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
