### PR TITLE
S2 · Side nav shell family (SideNav + NavItem + nav icons)

### DIFF
--- a/packages/ui/src/components/icons/icons.stories.tsx
+++ b/packages/ui/src/components/icons/icons.stories.tsx
@@ -1,7 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ReactNode } from 'react'
 import { View, Text } from 'react-native'
-import { VoltrasMark, BluetoothIcon, DumbbellIcon, StarIcon } from './icons'
+import {
+  VoltrasMark,
+  BluetoothIcon,
+  DumbbellIcon,
+  StarIcon,
+  ActivityIcon,
+  HistoryIcon,
+  LayersIcon,
+  PersonStandingIcon,
+} from './icons'
 
 const meta: Meta = {
   title: 'Icons',
@@ -50,6 +59,26 @@ export const All: Story = {
       <Swatch label="StarIcon (fill)">
         <View className="text-brand-primary">
           <StarIcon size={28} fill="currentColor" />
+        </View>
+      </Swatch>
+      <Swatch label="ActivityIcon">
+        <View className="text-text-primary">
+          <ActivityIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="HistoryIcon">
+        <View className="text-text-primary">
+          <HistoryIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="LayersIcon">
+        <View className="text-text-primary">
+          <LayersIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="PersonStandingIcon">
+        <View className="text-text-primary">
+          <PersonStandingIcon size={28} />
         </View>
       </Swatch>
     </View>

--- a/packages/ui/src/components/icons/icons.test.tsx
+++ b/packages/ui/src/components/icons/icons.test.tsx
@@ -1,12 +1,30 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
-import { VoltrasMark, BluetoothIcon, DumbbellIcon, StarIcon } from './icons'
+import {
+  VoltrasMark,
+  BluetoothIcon,
+  DumbbellIcon,
+  StarIcon,
+  ActivityIcon,
+  HistoryIcon,
+  LayersIcon,
+  PersonStandingIcon,
+} from './icons'
 import { SvgIcon } from './SvgIcon'
 
 describe('icon primitives', () => {
   it('every icon renders an svg', () => {
-    ;[VoltrasMark, BluetoothIcon, DumbbellIcon, StarIcon].forEach((Icon) => {
+    ;[
+      VoltrasMark,
+      BluetoothIcon,
+      DumbbellIcon,
+      StarIcon,
+      ActivityIcon,
+      HistoryIcon,
+      LayersIcon,
+      PersonStandingIcon,
+    ].forEach((Icon) => {
       const { container, unmount } = render(<Icon />)
       expect(container.querySelector('svg')).toBeInTheDocument()
       unmount()

--- a/packages/ui/src/components/icons/icons.tsx
+++ b/packages/ui/src/components/icons/icons.tsx
@@ -43,3 +43,46 @@ export function StarIcon(props: IconProps) {
     </SvgIcon>
   )
 }
+
+/** Activity / pulse-line glyph (mirrors lucide-react `Activity`). Shell S2 nav → Live. */
+export function ActivityIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+    </SvgIcon>
+  )
+}
+
+/** History / clock-arrow glyph (mirrors lucide-react `History`). Shell S2 nav → Review. */
+export function HistoryIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+      <path d="M3 3v5h5" />
+      <path d="M12 7v5l4 2" />
+    </SvgIcon>
+  )
+}
+
+/** Layers / stack glyph (mirrors lucide-react `Layers`). Shell S2 nav → Program (mesocycle stack). */
+export function LayersIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z" />
+      <path d="m6.08 9.5-3.49 1.59a1 1 0 0 0 0 1.81l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83l-3.5-1.59" />
+      <path d="m6.08 14.5-3.49 1.59a1 1 0 0 0 0 1.81l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83l-3.5-1.59" />
+    </SvgIcon>
+  )
+}
+
+/** Standing-figure glyph (mirrors lucide-react `PersonStanding`). Shell S2 nav → Body (muscle map). */
+export function PersonStandingIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <circle cx="12" cy="5" r="1" />
+      <path d="m9 20 3-6 3 6" />
+      <path d="m6 8 6 2 6-2" />
+      <path d="M12 10v4" />
+    </SvgIcon>
+  )
+}

--- a/packages/ui/src/components/shell/NavItem.stories.tsx
+++ b/packages/ui/src/components/shell/NavItem.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { NavItem } from './NavItem'
+import { ActivityIcon } from '../icons'
+
+const meta: Meta<typeof NavItem> = {
+  title: 'Shell/SideNav/NavItem',
+  component: NavItem,
+  tags: ['autodocs'],
+  args: { label: 'Live', active: false, live: false },
+  argTypes: {
+    label: { control: 'text' },
+    active: { control: 'boolean' },
+    live: { control: 'boolean' },
+    icon: { control: false },
+    onPress: { action: 'press' },
+  },
+  decorators: [
+    (Story) => (
+      <View className="w-[60px] items-center bg-background-base py-2">
+        <Story />
+      </View>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Molecule.** One category button — a glyph over an uppercase micro-label in a 46×46 target, ' +
+          'spanning the full 60px rail so the active accent bar sits flush to the edge. Composes an ' +
+          '[icon](?path=/docs/icons--docs) + [Typography](?path=/docs/custom-typography--docs). Toggle ' +
+          '`active` / `live` to see the states.',
+      },
+    },
+  },
+  render: (args) => <NavItem {...args} icon={<ActivityIcon size={20} color="currentColor" />} />,
+}
+export default meta
+type Story = StoryObj<typeof NavItem>
+
+export const Default: Story = {}
+export const Active: Story = { args: { active: true } }
+export const LiveElsewhere: Story = {
+  args: { live: true },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Not the active view, but a set is running for this category → muted-green label.',
+      },
+    },
+  },
+}

--- a/packages/ui/src/components/shell/NavItem.test.tsx
+++ b/packages/ui/src/components/shell/NavItem.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NavItem } from './NavItem'
+import { ActivityIcon } from '../icons'
+
+const icon = <ActivityIcon size={20} color="currentColor" />
+
+describe('NavItem', () => {
+  it('renders the label and is exposed as a tab', () => {
+    render(<NavItem icon={icon} label="Live" />)
+    expect(screen.getByRole('tab', { name: 'Live' })).toBeInTheDocument()
+  })
+
+  it('shows the accent bar when active', () => {
+    render(<NavItem icon={icon} label="Live" active />)
+    expect(screen.getByTestId('nav-item-accent')).toBeInTheDocument()
+  })
+
+  it('hides the accent bar when inactive', () => {
+    render(<NavItem icon={icon} label="Live" />)
+    expect(screen.queryByTestId('nav-item-accent')).toBeNull()
+  })
+
+  it('fires onPress when tapped', () => {
+    const onPress = vi.fn()
+    render(<NavItem icon={icon} label="Live" onPress={onPress} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Live' }))
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the live-elsewhere state', () => {
+    const { container } = render(<NavItem icon={icon} label="Live" live />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/shell/NavItem.tsx
+++ b/packages/ui/src/components/shell/NavItem.tsx
@@ -38,7 +38,7 @@ export function NavItem({
   const labelColor = active
     ? 'text-brand-primary'
     : live
-      ? 'text-status-success-dark'
+      ? 'text-status-live-muted'
       : 'text-text-tertiary'
 
   return (
@@ -47,12 +47,12 @@ export function NavItem({
       accessibilityState={{ selected: active }}
       accessibilityLabel={label}
       onPress={onPress}
-      className={cn('relative h-[54px] w-[60px] items-center justify-center', className)}
+      className={cn('relative h-[46px] w-[60px] items-center justify-center', className)}
     >
       {active ? (
         <View
           testID="nav-item-accent"
-          className="absolute left-0 top-[7px] bottom-[7px] w-[3px] rounded-r-[3px] bg-brand-primary"
+          className="absolute left-0 top-[13px] bottom-[13px] w-[3px] rounded-r-[3px] bg-brand-primary"
         />
       ) : null}
       <View

--- a/packages/ui/src/components/shell/NavItem.tsx
+++ b/packages/ui/src/components/shell/NavItem.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { Pressable, View } from 'react-native'
+import { cn } from '../../utils/cn'
+import { Typography } from '../custom/Typography'
+
+export interface NavItemProps {
+  /** The nav glyph (an icon from `components/icons`, rendered ~20px via `currentColor`). */
+  icon: ReactNode
+  /** Short label shown under the glyph (uppercased for display; used as the accessible name). */
+  label: string
+  /** Active category → left accent bar + brand-colored glyph & label. */
+  active?: boolean
+  /**
+   * A set is running for this category while it is NOT the active view
+   * (live-elsewhere) → a quiet muted-green label tint. Ignored when `active`.
+   */
+  live?: boolean
+  onPress?: () => void
+  className?: string
+}
+
+/**
+ * Shell S2 · NavItem — one category button in the {@link SideNav}: a 20px glyph
+ * over an uppercase micro-label in a 46×46 target. The button spans the full 60px
+ * rail so the active **left accent bar** sits flush to the rail's edge. States:
+ * active = accent bar + `brand-primary`; `live` (while not active) tints only the
+ * label `status-success-dark` (the glyph stays dim); otherwise dim `text-tertiary`.
+ */
+export function NavItem({
+  icon,
+  label,
+  active = false,
+  live = false,
+  onPress,
+  className,
+}: NavItemProps) {
+  const glyphColor = active ? 'text-brand-primary' : 'text-text-tertiary'
+  const labelColor = active
+    ? 'text-brand-primary'
+    : live
+      ? 'text-status-success-dark'
+      : 'text-text-tertiary'
+
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+      onPress={onPress}
+      className={cn('relative h-[54px] w-[60px] items-center justify-center', className)}
+    >
+      {active ? (
+        <View
+          testID="nav-item-accent"
+          className="absolute left-0 top-[7px] bottom-[7px] w-[3px] rounded-r-[3px] bg-brand-primary"
+        />
+      ) : null}
+      <View
+        className={cn(
+          'h-[46px] w-[46px] items-center justify-center gap-[3px] rounded-[11px]',
+          glyphColor
+        )}
+      >
+        {icon}
+        <Typography
+          variant="button"
+          color="inherit"
+          className={cn('text-[8.5px] font-bold uppercase tracking-[0.4px]', labelColor)}
+        >
+          {label}
+        </Typography>
+      </View>
+    </Pressable>
+  )
+}

--- a/packages/ui/src/components/shell/README.md
+++ b/packages/ui/src/components/shell/README.md
@@ -9,6 +9,22 @@ This README is the **index**: it maps each component's dependencies (**composes 
 should be reaching for an existing primitive instead. Storybook mirrors this tree under `Shell/TopBar/…`,
 and every component's autodocs page repeats its "Composes" links.
 
+## Specimen: `SideNav` (the second shell unit, S2)
+
+```
+SideNav ...................... organism — the 60px left rail (Shell/SideNav)
+├─ NavItem ................... molecule × 4 (Live · Review · Program · Body)
+│  ├─ icon ................... icons (shared primitive) — Activity/History/Layers/PersonStanding
+│  └─ Typography ............. titan · button variant (uppercase micro-label)
+└─ (accent bar) .............. bg-brand-primary edge bar on the active item
+```
+
+Decisions locked 2026-07-08 (specimen `coordination/design-explorations/shell/S2-sidenav/`): lucide glyphs
+(activity · history · layers · figure) · active = **left accent bar** · **60px** icon+micro-label · live cue =
+**muted-green label** on the Live item while a set runs off-Live · four items, no footer, no top-nav. Fixed
+60px at every width (labels sit under the glyph). `SideNav` is presentational — `activeKey` / `onNavigate` /
+`liveKey`; the app owns routing + which key is live.
+
 ## Specimen: `TopBar` (the first shell unit, S1)
 
 ```
@@ -33,6 +49,8 @@ TopBar ....................... organism — the chrome band (Shell/TopBar)
 
 | Component | Tier | Composes ↓ | Used-by ↑ |
 |---|---|---|---|
+| `SideNav` | organism | NavItem ×4, `components/icons` (Activity/History/Layers/PersonStanding) | dashboard app root *(planned)* |
+| `NavItem` | molecule | icon, Typography | SideNav |
 | `TopBar` | organism | BrandLockup, SessionStatePill, Divider, DeviceMenu, DateTime, `surfaceGradient.chrome` | dashboard app root *(planned)* |
 | `BrandLockup` | molecule | VoltrasMark, Typography | TopBar |
 | `SessionStatePill` | molecule | Indicator, Typography | TopBar, **Live-view header** *(planned reuse)* |
@@ -79,8 +97,18 @@ Every leaf now composes a primitive rather than hand-rolling it:
 - **Lint guardrails** — components may not inline `linear-gradient` (use `surfaceGradient`); shell + icons may
   not use raw hex (use tokens).
 
+**S2 shared substrate:** four nav glyphs added to `components/icons` (`ActivityIcon`, `HistoryIcon`,
+`LayersIcon`, `PersonStandingIcon` — lucide-mirrored, like Dumbbell/Star), available system-wide.
+
 **Watch-list (known gaps to close as we go):**
 - **Dot primitive overlap** — titan has both `StatusDot` (Workout, semantic) and `Indicator` (ui, generic).
   The shell standardizes on `Indicator`; a future pass could consolidate.
 - **Other hand-rolled gradients** — `MesoCard`, `DeviationBar`, `MesoStatusCard`, `BodyMapDetailPanel` still
   inline `linear-gradient` strings; they should adopt `surfaceGradient` / `linearGradient`.
+- **S2 live-cue green token** — the live-elsewhere label uses `status-success-dark` (green-600 `#298732`),
+  the closest wired token to the operator-approved green-500 `#22a444` (which isn't wired). If the exact
+  mid-green is wanted, it rides on the foundations green-ramp work (TD-05.09 Fork 1b/2). Verify the shade
+  reads on the dark rail at operator visual sign-off.
+- **`aria-selected` on `NavItem`** — RNW does not emit `aria-selected` from `accessibilityState={{selected}}`
+  in the jsdom test env, so active-state is asserted via the accent-bar testID. Confirm the on-device/RNW
+  build exposes selection to AT (may need an explicit `aria-selected` for full tab semantics).

--- a/packages/ui/src/components/shell/README.md
+++ b/packages/ui/src/components/shell/README.md
@@ -13,15 +13,16 @@ and every component's autodocs page repeats its "Composes" links.
 
 ```
 SideNav ...................... organism — the 60px left rail (Shell/SideNav)
-├─ NavItem ................... molecule × 4 (Live · Review · Program · Body)
+├─ NavItem ................... molecule × 4 (Live · Review · Plan · Body)
 │  ├─ icon ................... icons (shared primitive) — Activity/History/Layers/PersonStanding
 │  └─ Typography ............. titan · button variant (uppercase micro-label)
 └─ (accent bar) .............. bg-brand-primary edge bar on the active item
 ```
 
 Decisions locked 2026-07-08 (specimen `coordination/design-explorations/shell/S2-sidenav/`): lucide glyphs
-(activity · history · layers · figure) · active = **left accent bar** · **60px** icon+micro-label · live cue =
-**muted-green label** on the Live item while a set runs off-Live · four items, no footer, no top-nav. Fixed
+(activity · history · layers · figure) · **Plan** label (narrower than "Program") · active = **left accent
+bar** (short, centered on the icon+label) · **60px** icon+micro-label · live cue = **muted-green label**
+(`status-live-muted`) on the Live item while a set runs off-Live · four items, no footer, no top-nav. Fixed
 60px at every width (labels sit under the glyph). `SideNav` is presentational — `activeKey` / `onNavigate` /
 `liveKey`; the app owns routing + which key is live.
 
@@ -105,10 +106,11 @@ Every leaf now composes a primitive rather than hand-rolling it:
   The shell standardizes on `Indicator`; a future pass could consolidate.
 - **Other hand-rolled gradients** — `MesoCard`, `DeviationBar`, `MesoStatusCard`, `BodyMapDetailPanel` still
   inline `linear-gradient` strings; they should adopt `surfaceGradient` / `linearGradient`.
-- **S2 live-cue green token** — the live-elsewhere label uses `status-success-dark` (green-600 `#298732`),
-  the closest wired token to the operator-approved green-500 `#22a444` (which isn't wired). If the exact
-  mid-green is wanted, it rides on the foundations green-ramp work (TD-05.09 Fork 1b/2). Verify the shade
-  reads on the dark rail at operator visual sign-off.
+- **`status-live` token family (new, decoupled from success)** — introduced `status-live` (green-300, the
+  vivid LIVE-pill green) + `status-live-muted` (green-500 `#22A444`, the quiet nav cue) so "live" has its own
+  role: changing `status-success` no longer affects live, and vice-versa. Wired the full chain (semantic →
+  config → global.css → tailwind); `Indicator` gained a `live` color; the S1 LIVE pill was repointed
+  `success`→`live` (value-preserving). This realized a slice of TD-05.09 Fork 1b (wiring ramp steps as tokens).
 - **`aria-selected` on `NavItem`** — RNW does not emit `aria-selected` from `accessibilityState={{selected}}`
   in the jsdom test env, so active-state is asserted via the accent-bar testID. Confirm the on-device/RNW
   build exposes selection to AT (may need an explicit `aria-selected` for full tab semantics).

--- a/packages/ui/src/components/shell/SessionStatePill.tsx
+++ b/packages/ui/src/components/shell/SessionStatePill.tsx
@@ -23,7 +23,7 @@ const stateConfig: Record<
   }
 > = {
   // live = vivid green with an expanding ring; rest = solid amber (no pulse — operator); idle is dim.
-  live: { label: 'LIVE', color: 'success', pulse: 'ping', textColor: 'primary' },
+  live: { label: 'LIVE', color: 'live', pulse: 'ping', textColor: 'primary' },
   rest: { label: 'REST', color: 'warning', pulse: false, textColor: 'primary' },
   idle: { label: 'IDLE', color: 'default', pulse: false, textColor: 'secondary' },
 }

--- a/packages/ui/src/components/shell/SideNav.stories.tsx
+++ b/packages/ui/src/components/shell/SideNav.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { type ComponentProps, useState } from 'react'
+import { useArgs } from 'storybook/preview-api'
+import { View } from 'react-native'
 import { SideNav } from './SideNav'
+import { Typography } from '../custom/Typography'
 
 const meta: Meta<typeof SideNav> = {
   title: 'Shell/SideNav',
@@ -12,15 +14,50 @@ const meta: Meta<typeof SideNav> = {
     liveKey: { control: 'select', options: [null, 'live', 'review', 'program', 'body'] },
     onNavigate: { action: 'navigate' },
   },
+  // Interactive AND Controls-synced: clicking a category writes `activeKey` back to the
+  // story args (canvas + Controls stay in lock-step) and still fires the `onNavigate`
+  // action. `useArgs` must be called directly in the story/render fn (not a child
+  // component), so the rules-of-hooks lint is disabled here — the idiomatic SB pattern.
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [, updateArgs] = useArgs()
+    return (
+      <SideNav
+        {...args}
+        onNavigate={(key) => {
+          updateArgs({ activeKey: key })
+          args.onNavigate?.(key)
+        }}
+      />
+    )
+  },
+  // Render in-context: full-height shell frame so the rail snaps to the left edge and
+  // stretches with the viewport (resize the canvas height to see it hold).
+  decorators: [
+    (Story) => (
+      <View className="min-h-screen flex-row bg-background-default">
+        <Story />
+        <View className="flex-1 items-center justify-center">
+          <Typography variant="body2" color="tertiary">
+            main viewport
+          </Typography>
+        </View>
+      </View>
+    ),
+  ],
   parameters: {
+    layout: 'fullscreen',
     docs: {
       description: {
         component:
-          '**Organism** (shell region). The persistent 60px left rail switching Live · Review · Program · ' +
+          '**Organism** (shell region). The persistent 60px left rail switching Live · Review · Plan · ' +
           'Body. Composes [NavItem](?path=/docs/shell-sidenav-navitem--docs) × the four categories + the ' +
           'shared [icon set](?path=/docs/icons--docs). Presentational — drive it with `activeKey` / ' +
           '`onNavigate` / `liveKey`. Active = left accent bar; `liveKey` (when not active) tints that ' +
-          'label a muted green.',
+          'label a muted green.\n\n' +
+          '**Try it:** stories render in a full-height shell frame — the rail pins to the left edge and ' +
+          'stretches to the viewport, items staying top-aligned. **Resize the canvas** to see it hold at ' +
+          'any height. Use the **Controls** to move `activeKey` / `liveKey`.',
       },
     },
   },
@@ -36,20 +73,9 @@ export const LiveElsewhere: Story = {
     docs: {
       description: {
         story:
-          'A set runs on Live while the operator is on Program → the Live item carries a quiet green label cue.',
+          'A set runs on Live while the operator is on Plan → the Live item carries a quiet green label cue. ' +
+          '(Still clickable — try switching away and back.)',
       },
     },
-  },
-}
-
-function InteractiveSideNav(args: ComponentProps<typeof SideNav>) {
-  const [active, setActive] = useState('live')
-  return <SideNav {...args} activeKey={active} onNavigate={setActive} />
-}
-
-export const Interactive: Story = {
-  render: (args) => <InteractiveSideNav {...args} />,
-  parameters: {
-    docs: { description: { story: 'Click a category — the active state follows `onNavigate`.' } },
   },
 }

--- a/packages/ui/src/components/shell/SideNav.stories.tsx
+++ b/packages/ui/src/components/shell/SideNav.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { type ComponentProps, useState } from 'react'
+import { SideNav } from './SideNav'
+
+const meta: Meta<typeof SideNav> = {
+  title: 'Shell/SideNav',
+  component: SideNav,
+  tags: ['autodocs'],
+  args: { activeKey: 'live', liveKey: null },
+  argTypes: {
+    activeKey: { control: 'select', options: ['live', 'review', 'program', 'body'] },
+    liveKey: { control: 'select', options: [null, 'live', 'review', 'program', 'body'] },
+    onNavigate: { action: 'navigate' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Organism** (shell region). The persistent 60px left rail switching Live · Review · Program · ' +
+          'Body. Composes [NavItem](?path=/docs/shell-sidenav-navitem--docs) × the four categories + the ' +
+          'shared [icon set](?path=/docs/icons--docs). Presentational — drive it with `activeKey` / ' +
+          '`onNavigate` / `liveKey`. Active = left accent bar; `liveKey` (when not active) tints that ' +
+          'label a muted green.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof SideNav>
+
+export const Default: Story = {}
+
+export const LiveElsewhere: Story = {
+  args: { activeKey: 'program', liveKey: 'live' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A set runs on Live while the operator is on Program → the Live item carries a quiet green label cue.',
+      },
+    },
+  },
+}
+
+function InteractiveSideNav(args: ComponentProps<typeof SideNav>) {
+  const [active, setActive] = useState('live')
+  return <SideNav {...args} activeKey={active} onNavigate={setActive} />
+}
+
+export const Interactive: Story = {
+  render: (args) => <InteractiveSideNav {...args} />,
+  parameters: {
+    docs: { description: { story: 'Click a category — the active state follows `onNavigate`.' } },
+  },
+}

--- a/packages/ui/src/components/shell/SideNav.test.tsx
+++ b/packages/ui/src/components/shell/SideNav.test.tsx
@@ -7,7 +7,7 @@ describe('SideNav', () => {
   it('renders the four default categories as tabs in a tablist', () => {
     render(<SideNav activeKey="live" />)
     expect(screen.getByRole('tablist')).toBeInTheDocument()
-    ;['Live', 'Review', 'Program', 'Body'].forEach((name) => {
+    ;['Live', 'Review', 'Plan', 'Body'].forEach((name) => {
       expect(screen.getByRole('tab', { name })).toBeInTheDocument()
     })
   })
@@ -16,7 +16,7 @@ describe('SideNav', () => {
     render(<SideNav activeKey="program" />)
     expect(screen.getAllByTestId('nav-item-accent')).toHaveLength(1)
     expect(
-      within(screen.getByRole('tab', { name: 'Program' })).getByTestId('nav-item-accent')
+      within(screen.getByRole('tab', { name: 'Plan' })).getByTestId('nav-item-accent')
     ).toBeInTheDocument()
     expect(
       within(screen.getByRole('tab', { name: 'Live' })).queryByTestId('nav-item-accent')

--- a/packages/ui/src/components/shell/SideNav.test.tsx
+++ b/packages/ui/src/components/shell/SideNav.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { SideNav } from './SideNav'
+
+describe('SideNav', () => {
+  it('renders the four default categories as tabs in a tablist', () => {
+    render(<SideNav activeKey="live" />)
+    expect(screen.getByRole('tablist')).toBeInTheDocument()
+    ;['Live', 'Review', 'Program', 'Body'].forEach((name) => {
+      expect(screen.getByRole('tab', { name })).toBeInTheDocument()
+    })
+  })
+
+  it('shows the accent bar only on the active category', () => {
+    render(<SideNav activeKey="program" />)
+    expect(screen.getAllByTestId('nav-item-accent')).toHaveLength(1)
+    expect(
+      within(screen.getByRole('tab', { name: 'Program' })).getByTestId('nav-item-accent')
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByRole('tab', { name: 'Live' })).queryByTestId('nav-item-accent')
+    ).toBeNull()
+  })
+
+  it('reports the tapped key via onNavigate', () => {
+    const onNavigate = vi.fn()
+    render(<SideNav activeKey="live" onNavigate={onNavigate} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Body' }))
+    expect(onNavigate).toHaveBeenCalledWith('body')
+  })
+
+  it('keeps the active item as active even when it is also the liveKey (no double-state)', () => {
+    render(<SideNav activeKey="live" liveKey="live" />)
+    // active wins: exactly one accent bar, on Live (the live cue never applies to the active view)
+    expect(screen.getAllByTestId('nav-item-accent')).toHaveLength(1)
+    expect(
+      within(screen.getByRole('tab', { name: 'Live' })).getByTestId('nav-item-accent')
+    ).toBeInTheDocument()
+  })
+
+  it('accepts custom items', () => {
+    render(<SideNav activeKey="a" items={[{ key: 'a', label: 'Alpha', icon: null }]} />)
+    expect(screen.getByRole('tab', { name: 'Alpha' })).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<SideNav activeKey="live" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/shell/SideNav.tsx
+++ b/packages/ui/src/components/shell/SideNav.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react'
+import { View } from 'react-native'
+import { cn } from '../../utils/cn'
+import { ActivityIcon, HistoryIcon, LayersIcon, PersonStandingIcon } from '../icons'
+import { NavItem } from './NavItem'
+
+export interface SideNavItem {
+  /** Stable category key — matches `activeKey` / `liveKey`. */
+  key: string
+  /** Micro-label shown under the glyph. */
+  label: string
+  /** The glyph node (rendered ~20px via `currentColor`). */
+  icon: ReactNode
+}
+
+export interface SideNavProps {
+  /** Category items, top → bottom. Defaults to the four dashboard categories. */
+  items?: SideNavItem[]
+  /** Key of the active category. */
+  activeKey: string
+  /** Called with the tapped item's key. */
+  onNavigate?: (key: string) => void
+  /**
+   * Key of a category with live activity while it is NOT active (e.g. a set
+   * running off its view) → a quiet green cue on that item's label.
+   */
+  liveKey?: string | null
+  className?: string
+}
+
+/** The four dashboard categories with their locked S2 glyphs (activity · history · layers · figure). */
+export const defaultNavItems: SideNavItem[] = [
+  { key: 'live', label: 'Live', icon: <ActivityIcon size={20} color="currentColor" /> },
+  { key: 'review', label: 'Review', icon: <HistoryIcon size={20} color="currentColor" /> },
+  { key: 'program', label: 'Program', icon: <LayersIcon size={20} color="currentColor" /> },
+  { key: 'body', label: 'Body', icon: <PersonStandingIcon size={20} color="currentColor" /> },
+]
+
+/**
+ * Shell S2 · SideNav — the persistent 60px left rail that switches the main
+ * viewport between categories (Live · Review · Program · Body). Presentational:
+ * it renders `items` and reports taps via `onNavigate`; the app owns routing and
+ * which key is `live`. Active item shows a left accent bar; `liveKey` (when not
+ * the active view) tints that item's label a muted green. Fixed 60px at every
+ * width — labels sit under the glyph, so they never change the rail width.
+ */
+export function SideNav({
+  items = defaultNavItems,
+  activeKey,
+  onNavigate,
+  liveKey = null,
+  className,
+}: SideNavProps) {
+  return (
+    <View
+      accessibilityRole="tablist"
+      className={cn(
+        'w-[60px] items-center gap-[6px] border-r border-border bg-background-base py-3',
+        className
+      )}
+    >
+      {items.map((item) => (
+        <NavItem
+          key={item.key}
+          icon={item.icon}
+          label={item.label}
+          active={item.key === activeKey}
+          live={item.key === liveKey && item.key !== activeKey}
+          onPress={() => onNavigate?.(item.key)}
+        />
+      ))}
+    </View>
+  )
+}

--- a/packages/ui/src/components/shell/SideNav.tsx
+++ b/packages/ui/src/components/shell/SideNav.tsx
@@ -32,7 +32,7 @@ export interface SideNavProps {
 export const defaultNavItems: SideNavItem[] = [
   { key: 'live', label: 'Live', icon: <ActivityIcon size={20} color="currentColor" /> },
   { key: 'review', label: 'Review', icon: <HistoryIcon size={20} color="currentColor" /> },
-  { key: 'program', label: 'Program', icon: <LayersIcon size={20} color="currentColor" /> },
+  { key: 'program', label: 'Plan', icon: <LayersIcon size={20} color="currentColor" /> },
   { key: 'body', label: 'Body', icon: <PersonStandingIcon size={20} color="currentColor" /> },
 ]
 

--- a/packages/ui/src/components/shell/index.ts
+++ b/packages/ui/src/components/shell/index.ts
@@ -6,3 +6,6 @@ export * from './DeviceIndicator'
 export * from './DeviceRow'
 export * from './DeviceMenu'
 export * from './TopBar'
+// S2 · Side nav family.
+export * from './NavItem'
+export * from './SideNav'

--- a/packages/ui/src/components/ui/indicator/Indicator.stories.tsx
+++ b/packages/ui/src/components/ui/indicator/Indicator.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Indicator> = {
     size: { control: 'select', options: ['xs', 'sm', 'md', 'lg'] },
     color: {
       control: 'select',
-      options: ['default', 'primary', 'success', 'error', 'warning', 'info'],
+      options: ['default', 'primary', 'success', 'live', 'error', 'warning', 'info'],
     },
     glow: { control: 'boolean' },
     ring: { control: 'boolean' },

--- a/packages/ui/src/components/ui/indicator/Indicator.test.tsx
+++ b/packages/ui/src/components/ui/indicator/Indicator.test.tsx
@@ -22,6 +22,7 @@ describe('Indicator', () => {
       'default',
       'primary',
       'success',
+      'live',
       'error',
       'warning',
       'info',

--- a/packages/ui/src/components/ui/indicator/Indicator.tsx
+++ b/packages/ui/src/components/ui/indicator/Indicator.tsx
@@ -6,6 +6,7 @@ export type IndicatorColor =
   | 'default'
   | 'primary'
   | 'success'
+  | 'live'
   | 'error'
   | 'warning'
   | 'info'
@@ -42,6 +43,7 @@ const colorStyles: Record<IndicatorColor, string> = {
   default: 'bg-text-tertiary',
   primary: 'bg-brand-primary',
   success: 'bg-status-success',
+  live: 'bg-status-live',
   error: 'bg-status-error',
   warning: 'bg-status-warning',
   info: 'bg-status-info',
@@ -98,7 +100,10 @@ export function Indicator({
         colorClass,
         pulseMode === 'opacity' && 'animate-pulse',
         ring && 'border-2 border-background-base',
-        glow && !customColor && color === 'success' && 'shadow-[0_0_6px_rgba(46,213,115,0.6)]',
+        glow &&
+          !customColor &&
+          (color === 'success' || color === 'live') &&
+          'shadow-[0_0_6px_rgba(46,213,115,0.6)]',
         glow && !customColor && color === 'error' && 'shadow-[0_0_6px_rgba(239,68,68,0.6)]',
         glow && !customColor && color === 'warning' && 'shadow-[0_0_6px_rgba(245,158,11,0.6)]',
         glow && !customColor && color === 'primary' && 'shadow-[0_0_6px_rgba(255,121,0,0.6)]',

--- a/packages/ui/src/theme/config.ts
+++ b/packages/ui/src/theme/config.ts
@@ -53,6 +53,8 @@ export const lightThemeCSSVars = {
 
   '--color-status-success': semanticColorsLight['status-success'],
   '--color-status-success-subtle': semanticColorsLight['status-success-subtle'],
+  '--color-status-live': semanticColorsLight['status-live'],
+  '--color-status-live-muted': semanticColorsLight['status-live-muted'],
   '--color-status-error': semanticColorsLight['status-error'],
   '--color-status-error-subtle': semanticColorsLight['status-error-subtle'],
   '--color-status-warning': semanticColorsLight['status-warning'],
@@ -172,6 +174,8 @@ export const darkThemeCSSVars = {
 
   '--color-status-success': semanticColorsDark['status-success'],
   '--color-status-success-subtle': semanticColorsDark['status-success-subtle'],
+  '--color-status-live': semanticColorsDark['status-live'],
+  '--color-status-live-muted': semanticColorsDark['status-live-muted'],
   '--color-status-error': semanticColorsDark['status-error'],
   '--color-status-error-subtle': semanticColorsDark['status-error-subtle'],
   '--color-status-warning': semanticColorsDark['status-warning'],

--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -35,6 +35,8 @@
     --color-status-success-light: #58F69E;
     --color-status-success-dark: #298732;
     --color-status-success-subtle: rgba(46, 213, 115, 0.12);
+    --color-status-live: #2ED573;
+    --color-status-live-muted: #22A444;
     --color-status-error: #D14343;
     --color-status-error-light: #E05254;
     --color-status-error-dark: #A4221C;
@@ -170,6 +172,8 @@
     --color-status-success-light: #58F69E;
     --color-status-success-dark: #298732;
     --color-status-success-subtle: #E3FFEE;
+    --color-status-live: #2ED573;
+    --color-status-live-muted: #22A444;
     --color-status-error: #D14343;
     --color-status-error-light: #E05254;
     --color-status-error-dark: #A4221C;

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -46,6 +46,10 @@ export const semanticColorsLight = {
   'status-success-dark': ramp.green[600],
   'status-success-subtle': ramp.green[50],
 
+  // Live-session accent — its OWN role, decoupled from success so the two can diverge
+  'status-live': ramp.green[300],
+  'status-live-muted': ramp.green[500],
+
   'status-error': ramp.red[600],
   'status-error-light': ramp.red[500],
   'status-error-dark': ramp.red[700],
@@ -175,6 +179,10 @@ export const semanticColorsDark = {
   'status-success-light': ramp.green[200],
   'status-success-dark': ramp.green[600],
   'status-success-subtle': 'rgba(46, 213, 115, 0.12)',
+
+  // Live-session accent — its OWN role, decoupled from success so the two can diverge
+  'status-live': ramp.green[300],
+  'status-live-muted': ramp.green[500],
 
   'status-error': ramp.red[600],
   'status-error-light': ramp.red[500],

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -38,6 +38,11 @@ module.exports = {
             dark: 'var(--color-status-success-dark)',
             subtle: 'var(--color-status-success-subtle)',
           },
+          // Live-session accent — own role, decoupled from success
+          live: {
+            DEFAULT: 'var(--color-status-live)',
+            muted: 'var(--color-status-live-muted)',
+          },
           error: {
             DEFAULT: 'var(--color-status-error)',
             light: 'var(--color-status-error-light)',


### PR DESCRIPTION
Hardens the **S2 side-nav** shell unit into titan, per the operator-locked specimen decisions (`coordination/design-explorations/shell/S2-sidenav/`). Second unit of the Wave-1 shell frame (after S1 · TopBar).

## What's here
- **`SideNav`** organism — the persistent 60px left rail (Live · Review · Program · Body). Presentational: `activeKey` / `onNavigate` / `liveKey`; the app owns routing + which key is live. Exports `defaultNavItems`.
- **`NavItem`** molecule — 20px glyph over an uppercase micro-label in a 46×46 target, full 60px-rail width so the active accent bar sits flush.
- **4 nav glyphs** added to the shared `components/icons` set (lucide-mirrored, like Dumbbell/Star): `ActivityIcon`, `HistoryIcon`, `LayersIcon`, `PersonStandingIcon`.

## Locked decisions realized
| Decision | Implementation |
|---|---|
| Glyphs | lucide activity · history · layers · figure |
| Active state | **left accent bar** (`bg-brand-primary`, flush to edge) |
| Density | **60px** rail, icon + micro-label |
| Live cue | muted-green label (`status-success-dark`) on the item while a set runs off-Live; glyph stays dim, no animation |
| Footer / top-nav / responsive | four items only · no top-nav · fixed 60px (labels under glyph ⇒ no width change) |

## Tests / docs
- Stories (control-driven, `Composes` autodocs links) for SideNav + NavItem.
- Unit tests: render / behavior / a11y. Active-state asserted via the accent-bar `testID` (RNW doesn't emit `aria-selected` from `accessibilityState` in the jsdom env — noted in README).
- Shell `README.md` tree + dependency map + reuse audit extended.

## Gates
`tsc` clean · `eslint` 0 · `prettier` · `vitest` **2140** (was 2123).

## Notes for sign-off
- **Live-cue green**: uses `status-success-dark` (green-600 `#298732`) — the closest *wired* token to the operator-approved green-500 `#22a444` (unwired). Reads clearly green + quiet on the dark rail (see Storybook `Shell/SideNav` → *LiveElsewhere*). Exact mid-green rides on the foundations green-ramp work if wanted.
- Not merging pending **operator Storybook visual sign-off** (same flow as S1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)