### PR TITLE
Add DashboardShell composing the shell-nav chrome

### DIFF
--- a/packages/ui/src/components/shell/DashboardShell.stories.tsx
+++ b/packages/ui/src/components/shell/DashboardShell.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { DashboardShell } from './DashboardShell'
+
+/**
+ * `Pages/DashboardShell` — the wall-dashboard chrome as one registered surface.
+ * Composes the shell-nav island (SideNav + TopBar and everything they pull in) over a
+ * `children` content slot, so the dashboard app mounts a single component.
+ */
+const meta: Meta<typeof DashboardShell> = {
+  title: 'Pages/DashboardShell',
+  component: DashboardShell,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '**Page shell.** The wall-dashboard chrome. Composes ' +
+          '[SideNav](?path=/docs/shell-sidenav--docs) + ' +
+          '[TopBar](?path=/docs/shell-topbar--docs) — which pulls in DeviceMenu, DeviceRow, ' +
+          'DeviceIndicator, SessionStatePill, BrandLockup, DateTime and Divider — over a ' +
+          '`children` content slot. Mount this instead of re-assembling the chrome per view.',
+      },
+    },
+  },
+  argTypes: {
+    state: { control: 'select', options: ['live', 'rest', 'idle'] },
+    activeKey: { control: 'select', options: ['live', 'review', 'program', 'body'] },
+    liveKey: { control: 'select', options: [null, 'live', 'review', 'program', 'body'] },
+    onNavigate: { control: false },
+    onSelectDevice: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ height: '100vh' as unknown as number, backgroundColor: '#0E0E0E' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof DashboardShell>
+
+export const Default: Story = {
+  args: { activeKey: 'live', state: 'live' },
+}
+
+export const WithContent: Story = {
+  args: { activeKey: 'review', state: 'rest', liveKey: 'live' },
+  render: (args) => (
+    <DashboardShell {...args}>
+      <View style={{ flex: 1, padding: 28 }}>
+        <Text style={{ color: '#E5E5E5', fontSize: 22, fontWeight: '700' }}>Review</Text>
+        <Text style={{ color: '#8A8A8A', fontSize: 13, marginTop: 6 }}>
+          A page mounts its content here; the shell keeps the nav + top-bar chrome persistent.
+        </Text>
+      </View>
+    </DashboardShell>
+  ),
+  parameters: {
+    docs: { description: { story: 'The shell with a page mounted in its content slot.' } },
+  },
+}

--- a/packages/ui/src/components/shell/DashboardShell.test.tsx
+++ b/packages/ui/src/components/shell/DashboardShell.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Text } from 'react-native'
+import { axe } from 'jest-axe'
+import { DashboardShell } from './DashboardShell'
+
+describe('DashboardShell', () => {
+  it('composes the SideNav rail and its categories', () => {
+    render(<DashboardShell activeKey="live" />)
+    expect(screen.getByRole('tablist')).toBeInTheDocument()
+    ;['Live', 'Review', 'Plan', 'Body'].forEach((name) => {
+      expect(screen.getByRole('tab', { name })).toBeInTheDocument()
+    })
+  })
+
+  it('renders the content-slot placeholder when no children are given', () => {
+    render(<DashboardShell activeKey="live" />)
+    expect(screen.getByText('main content region')).toBeInTheDocument()
+  })
+
+  it('mounts children in the content slot and drops the placeholder', () => {
+    render(
+      <DashboardShell activeKey="review">
+        <Text>my page body</Text>
+      </DashboardShell>
+    )
+    expect(screen.getByText('my page body')).toBeInTheDocument()
+    expect(screen.queryByText('main content region')).not.toBeInTheDocument()
+  })
+
+  it('forwards nav taps through onNavigate', () => {
+    const onNavigate = vi.fn()
+    render(<DashboardShell activeKey="live" onNavigate={onNavigate} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Body' }))
+    expect(onNavigate).toHaveBeenCalledWith('body')
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<DashboardShell activeKey="live" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/shell/DashboardShell.tsx
+++ b/packages/ui/src/components/shell/DashboardShell.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react'
+import { View, Text } from 'react-native'
+import { cn } from '../../utils/cn'
+import { SideNav, type SideNavItem } from './SideNav'
+import { TopBar } from './TopBar'
+import { type Device } from './DeviceRow'
+import { type SessionState } from './SessionStatePill'
+
+/**
+ * `DashboardShell` — the wall-dashboard chrome: a persistent {@link SideNav} rail +
+ * {@link TopBar} over a main content region. A thin frame that wires the shell-nav
+ * organisms together and exposes a `children` content slot, so the dashboard app
+ * mounts one component instead of re-assembling the chrome. Driven entirely by props.
+ */
+export interface DashboardShellProps {
+  /** Active nav category key. */
+  activeKey?: string
+  /** Nav categories, top → bottom. Defaults to SideNav's four dashboard categories. */
+  navItems?: SideNavItem[]
+  /** A category with off-view live activity → a quiet cue on that item. */
+  liveKey?: string | null
+  /** Global session state → the TopBar status pill. */
+  state?: SessionState
+  /** Connected devices → the TopBar connection glyph + dropdown. */
+  devices?: Device[]
+  /** TopBar brand subtitle. */
+  subtitle?: string
+  onNavigate?: (key: string) => void
+  onSelectDevice?: (device: Device) => void
+  /** Main content region. A placeholder renders when omitted. */
+  children?: ReactNode
+  className?: string
+}
+
+const DEMO_DEVICES: Device[] = [
+  { id: 'Voltra-A3F2', nickname: 'Left Cable', slot: 'L', state: 'connected' },
+  { id: 'Voltra-9B1C', nickname: 'Right Cable', slot: 'R', state: 'connected' },
+]
+
+function ContentPlaceholder() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="font-heading text-sm text-text-tertiary">main content region</Text>
+    </View>
+  )
+}
+
+export function DashboardShell({
+  activeKey = 'live',
+  navItems,
+  liveKey = null,
+  state = 'live',
+  devices = DEMO_DEVICES,
+  subtitle = 'wall dashboard',
+  onNavigate,
+  onSelectDevice,
+  children,
+  className,
+}: DashboardShellProps) {
+  return (
+    <View className={cn('flex-1 flex-row bg-surface-base', className)}>
+      <SideNav activeKey={activeKey} items={navItems} liveKey={liveKey} onNavigate={onNavigate} />
+      <View className="flex-1">
+        <TopBar
+          state={state}
+          devices={devices}
+          subtitle={subtitle}
+          onSelectDevice={onSelectDevice}
+        />
+        <View className="flex-1">{children ?? <ContentPlaceholder />}</View>
+      </View>
+    </View>
+  )
+}

--- a/packages/ui/src/components/shell/index.ts
+++ b/packages/ui/src/components/shell/index.ts
@@ -9,3 +9,5 @@ export * from './TopBar'
 // S2 · Side nav family.
 export * from './NavItem'
 export * from './SideNav'
+// S3 · Dashboard shell — composes the nav + top-bar chrome over a content slot.
+export * from './DashboardShell'


### PR DESCRIPTION
## What

A `Pages/DashboardShell` organism that composes the wall-dashboard chrome — `SideNav` + `TopBar` (and everything they pull in) — over a `children` content slot. The dashboard app mounts one component instead of re-assembling the chrome per view.

## Why

The arch graph (#90) flagged the entire shell-nav chrome as a **dead island**: `TopBar`, `SideNav`, `NavItem`, `BrandLockup`, `DeviceMenu`, `DeviceRow`, `DeviceIndicator`, `SessionStatePill`, `DateTime`, `Divider`, `Popover` — all "dead everywhere" or kept alive only by each other (dead-by-association). They were specimens for the new dashboard with no consumer. This gives them one: a real, registered, previewable surface.

## Notes

- Exported from the shell barrel (`@titan-design/react-ui`), so the dashboard app can import it directly. Once it does, the whole island flips from dead → used in the arch graph (regenerate `arch-graph.json` after both this and #90 land).
- Follows shell conventions: `View` + nativewind `className`, driven entirely by props, sensible defaults so `Default` needs no args.
- Tests: composes the SideNav categories, content-slot placeholder vs. children, `onNavigate` forwarding, and an axe a11y pass (5 tests, all green).

## Gates

tsc 0 · eslint 0 · prettier clean · vitest 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)