### PR TITLE
TD-03.51: Indicator taxonomy — 6 kinds + precedence resolver

### DIFF
--- a/packages/ui/src/components/custom/Workout/ExerciseCardHeading.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseCardHeading.stories.tsx
@@ -27,7 +27,10 @@ const meta: Meta<typeof ExerciseCardHeading> = {
   },
   argTypes: {
     unit: { control: 'select', options: ['lbs', 'kg'] },
-    indicator: { control: 'select', options: [undefined, 'pr', 'issue', 'info'] },
+    indicator: {
+      control: 'select',
+      options: [undefined, 'imbalance', 'overshoot', 'velocity-loss', 'missed-reps', 'pr', 'info'],
+    },
     stripHeight: { control: { type: 'range', min: 2, max: 16, step: 1 } },
     dimmed: { control: 'boolean' },
     onPress: { action: 'press' },

--- a/packages/ui/src/components/custom/Workout/ExerciseHeading.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseHeading.stories.tsx
@@ -26,7 +26,10 @@ const meta: Meta<typeof ExerciseHeading> = {
   },
   argTypes: {
     unit: { control: 'select', options: ['lbs', 'kg'] },
-    indicator: { control: 'select', options: [undefined, 'pr', 'issue', 'info'] },
+    indicator: {
+      control: 'select',
+      options: [undefined, 'imbalance', 'overshoot', 'velocity-loss', 'missed-reps', 'pr', 'info'],
+    },
     dimmed: { control: 'boolean' },
     onPress: { action: 'press' },
   },

--- a/packages/ui/src/components/custom/Workout/ExerciseIndicator.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseIndicator.stories.tsx
@@ -1,11 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { View } from 'react-native'
-import { ExerciseIndicator } from './ExerciseIndicator'
+import { View, Text } from 'react-native'
+import {
+  ExerciseIndicator,
+  resolveIndicator,
+  INDICATOR_PRECEDENCE,
+  type ExerciseIndicatorKind,
+} from './ExerciseIndicator'
 
 /**
- * `ExerciseIndicator` — a small circular chip in an exercise heading's title line
- * (PR / issue / info). `kind` is an open union backed by a config record, so the
- * taxonomy can grow without touching call sites.
+ * `ExerciseIndicator` — a small circular OUTLINED chip in an exercise heading's
+ * title line. The LOCKED taxonomy is 6 precedence-ranked kinds across four tier
+ * colors (danger/warning/success/info): glyph = the specific signal, color = the
+ * severity tier. Only one chip is ever shown per exercise — {@link resolveIndicator}
+ * picks the highest-precedence active signal.
  */
 const meta: Meta<typeof ExerciseIndicator> = {
   title: 'Workout/ExerciseIndicator',
@@ -15,14 +22,16 @@ const meta: Meta<typeof ExerciseIndicator> = {
     docs: {
       description: {
         component:
-          '**Atom.** A small circular chip in an exercise heading title line (PR / issue / ' +
-          'info); `kind` is a config-backed open union. Used-by ↑ ' +
+          '**Atom.** A small circular outlined chip in an exercise heading title line. Six ' +
+          'precedence-ranked kinds (imbalance › overshoot › velocity-loss › missed-reps › pr › ' +
+          'info) over four status-token tier colors; glyph = signal, color = severity tier. ' +
+          '`resolveIndicator()` selects the single chip to show. Used-by ↑ ' +
           '[ExerciseHeading](?path=/docs/workout-exerciseheading--docs).',
       },
     },
   },
   argTypes: {
-    kind: { control: 'select', options: ['pr', 'issue', 'info'] },
+    kind: { control: 'select', options: [...INDICATOR_PRECEDENCE] },
     onPress: { action: 'press' },
   },
   decorators: [
@@ -37,16 +46,65 @@ const meta: Meta<typeof ExerciseIndicator> = {
 export default meta
 type Story = StoryObj<typeof ExerciseIndicator>
 
+export const Imbalance: Story = { args: { kind: 'imbalance' } }
+export const Overshoot: Story = { args: { kind: 'overshoot' } }
+export const VelocityLoss: Story = { args: { kind: 'velocity-loss' } }
+export const MissedReps: Story = { args: { kind: 'missed-reps' } }
 export const PersonalRecord: Story = { args: { kind: 'pr' } }
-export const Issue: Story = { args: { kind: 'issue' } }
 export const Info: Story = { args: { kind: 'info' } }
 
+const KIND_LABELS: Record<ExerciseIndicatorKind, string> = {
+  imbalance: 'imbalance · danger',
+  overshoot: 'overshoot · danger',
+  'velocity-loss': 'velocity-loss · warning',
+  'missed-reps': 'missed-reps · warning',
+  pr: 'pr · success',
+  info: 'info · info',
+}
+
+/** All six kinds in precedence order (1=highest → 6=lowest). */
 export const AllKinds: Story = {
   render: () => (
-    <View style={{ flexDirection: 'row', gap: 12 }}>
-      <ExerciseIndicator kind="pr" />
-      <ExerciseIndicator kind="issue" />
-      <ExerciseIndicator kind="info" />
+    <View style={{ gap: 12 }}>
+      {INDICATOR_PRECEDENCE.map((kind, i) => (
+        <View key={kind} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <Text style={{ color: '#8A8A8A', fontSize: 11, width: 14 }}>{i + 1}</Text>
+          <ExerciseIndicator kind={kind} />
+          <Text style={{ color: '#CFCFCF', fontSize: 12 }}>{KIND_LABELS[kind]}</Text>
+        </View>
+      ))}
     </View>
   ),
+}
+
+/**
+ * `resolveIndicator` demo — each row is a set of active signals; the resolver
+ * collapses them to the single highest-precedence chip actually shown.
+ */
+export const ResolvePrecedence: Story = {
+  render: () => {
+    const scenarios: ExerciseIndicatorKind[][] = [
+      ['info', 'pr'],
+      ['pr', 'missed-reps'],
+      ['velocity-loss', 'overshoot', 'info'],
+      ['missed-reps', 'imbalance', 'pr'],
+    ]
+    return (
+      <View style={{ gap: 12 }}>
+        {scenarios.map((candidates, i) => {
+          const winner = resolveIndicator(candidates)
+          return (
+            <View key={i} style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+              <Text style={{ color: '#8A8A8A', fontSize: 12, width: 200 }}>
+                {candidates.join(', ')}
+              </Text>
+              <Text style={{ color: '#8A8A8A', fontSize: 12 }}>→</Text>
+              {winner ? <ExerciseIndicator kind={winner} /> : null}
+              <Text style={{ color: '#CFCFCF', fontSize: 12 }}>{winner}</Text>
+            </View>
+          )
+        })}
+      </View>
+    )
+  },
 }

--- a/packages/ui/src/components/custom/Workout/ExerciseIndicator.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseIndicator.test.tsx
@@ -1,25 +1,40 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'jest-axe'
-import { ExerciseIndicator, type ExerciseIndicatorKind } from './ExerciseIndicator'
+import {
+  ExerciseIndicator,
+  resolveIndicator,
+  INDICATOR_PRECEDENCE,
+  type ExerciseIndicatorKind,
+} from './ExerciseIndicator'
 
-const kinds: { kind: ExerciseIndicatorKind; glyph: string; label: string }[] = [
-  { kind: 'pr', glyph: '★', label: 'Personal record' },
-  { kind: 'issue', glyph: '!', label: 'Form issue' },
-  { kind: 'info', glyph: 'i', label: 'More info' },
+// tier color = titan status token, applied as the glyph's SVG stroke (literal hex):
+// danger=status-error, warning=status-warning, success=status-success, info=status-info.
+const kinds: { kind: ExerciseIndicatorKind; label: string; tier: string }[] = [
+  { kind: 'imbalance', label: 'Left/right imbalance', tier: '#D14343' },
+  { kind: 'overshoot', label: 'Load overshoot', tier: '#D14343' },
+  { kind: 'velocity-loss', label: 'Velocity loss', tier: '#F9B415' },
+  { kind: 'missed-reps', label: 'Missed reps', tier: '#F9B415' },
+  { kind: 'pr', label: 'Personal record', tier: '#2ED573' },
+  { kind: 'info', label: 'More info', tier: '#2196F3' },
 ]
 
 describe('ExerciseIndicator', () => {
-  it.each(kinds)('renders the $kind chip glyph and accessible label', ({ kind, glyph, label }) => {
-    render(<ExerciseIndicator kind={kind} />)
-    expect(screen.getByTestId('exercise-indicator')).toHaveTextContent(glyph)
+  it.each(kinds)('renders the $kind chip glyph and accessible label', ({ kind, label }) => {
+    const { container } = render(<ExerciseIndicator kind={kind} />)
+    // glyph is an inline SVG (lucide-mirrored), not a text character
+    expect(container.querySelector('svg')).toBeInTheDocument()
     expect(screen.getByLabelText(label)).toBeInTheDocument()
   })
 
-  it('tints the glyph with the kind color', () => {
-    render(<ExerciseIndicator kind="issue" />)
-    // issue = red 600 ramp pin (#D14343), rendered by RNW as rgb
-    expect(screen.getByText('!')).toHaveStyle({ color: 'rgb(209, 67, 67)' })
+  it.each(kinds)('tints the $kind glyph with its tier color', ({ kind, tier }) => {
+    const { container } = render(<ExerciseIndicator kind={kind} />)
+    expect(container.querySelector('svg')!.getAttribute('stroke')).toBe(tier)
+  })
+
+  it('renders a decorative (aria-hidden) glyph so the chip owns the label', () => {
+    const { container } = render(<ExerciseIndicator kind="pr" />)
+    expect(container.querySelector('svg')!.getAttribute('aria-hidden')).toBe('true')
   })
 
   it('is presentational (no button role) without onPress', () => {
@@ -41,5 +56,38 @@ describe('ExerciseIndicator', () => {
       const results = await axe(container)
       expect(results).toHaveNoViolations()
     })
+  })
+})
+
+describe('resolveIndicator', () => {
+  it('returns undefined when no signals are active', () => {
+    expect(resolveIndicator([])).toBeUndefined()
+  })
+
+  it('returns the sole candidate unchanged', () => {
+    expect(resolveIndicator(['velocity-loss'])).toBe('velocity-loss')
+  })
+
+  it('picks the highest-precedence kind regardless of input order', () => {
+    expect(resolveIndicator(['info', 'pr', 'overshoot'])).toBe('overshoot')
+    expect(resolveIndicator(['overshoot', 'pr', 'info'])).toBe('overshoot')
+  })
+
+  it('lets imbalance (rank 1) win over every other signal', () => {
+    expect(resolveIndicator([...INDICATOR_PRECEDENCE])).toBe('imbalance')
+  })
+
+  it('ranks the soft alerts above pr (alert > pr)', () => {
+    expect(resolveIndicator(['pr', 'missed-reps'])).toBe('missed-reps')
+    expect(resolveIndicator(['pr', 'velocity-loss'])).toBe('velocity-loss')
+  })
+
+  it('falls to info only when it is the lowest active signal', () => {
+    expect(resolveIndicator(['info', 'pr'])).toBe('pr')
+    expect(resolveIndicator(['info'])).toBe('info')
+  })
+
+  it('ignores duplicate candidates', () => {
+    expect(resolveIndicator(['pr', 'pr', 'info'])).toBe('pr')
   })
 })

--- a/packages/ui/src/components/custom/Workout/ExerciseIndicator.tsx
+++ b/packages/ui/src/components/custom/Workout/ExerciseIndicator.tsx
@@ -1,40 +1,92 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import { View, Text, Pressable, type ViewProps } from 'react-native'
-import { primitiveRamps } from '../../../theme/tokens/primitives'
+import type { ComponentType } from 'react'
+import { View, Pressable, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import {
+  ScaleIcon,
+  AlertTriangleIcon,
+  TrendingDownIcon,
+  CircleSlashIcon,
+  AwardIcon,
+  InfoIcon,
+  type IconProps,
+} from '../../icons'
+
+// Literal-hex status pins (the TempoBar pattern) — `resolveColor()` yields a
+// `var(...)` under the RNW vitest alias, which breaks `toHaveStyle` in tests.
+const t = getSemanticColors('dark')
 
 /**
- * Indicator kinds surfaced in an exercise heading. A taxonomy expansion is being
- * designed separately, so `kind` is an open union backed by a config record —
- * adding a kind is one entry + one union member, no call-site changes.
+ * The LOCKED 6-kind indicator taxonomy (TD-03.51). One precedence-ranked slot is
+ * ever shown per exercise, resolved by {@link resolveIndicator}. Glyph = the
+ * specific signal; color = the severity tier (danger/warning/success/info, bound
+ * to titan status tokens). Outlined (border + glyph, no fill) so a chip never
+ * collides with the filled velocity strip beside it.
  */
-export type ExerciseIndicatorKind = 'pr' | 'issue' | 'info'
+export type ExerciseIndicatorKind =
+  | 'imbalance'
+  | 'overshoot'
+  | 'velocity-loss'
+  | 'missed-reps'
+  | 'pr'
+  | 'info'
 
 interface IndicatorConfig {
-  glyph: string
+  Icon: ComponentType<IconProps>
+  /** Tier color — a titan status semantic token (literal hex on `t`). */
   color: string
   /** Accessible description (also the intended tooltip subject). */
   label: string
 }
 
 const INDICATOR_CONFIG: Record<ExerciseIndicatorKind, IndicatorConfig> = {
-  pr: { glyph: '★', color: primitiveRamps.orange[400], label: 'Personal record' },
-  issue: { glyph: '!', color: primitiveRamps.red[600], label: 'Form issue' },
-  info: { glyph: 'i', color: primitiveRamps.blue[500], label: 'More info' },
+  imbalance: { Icon: ScaleIcon, color: t['status-error'], label: 'Left/right imbalance' },
+  overshoot: { Icon: AlertTriangleIcon, color: t['status-error'], label: 'Load overshoot' },
+  'velocity-loss': { Icon: TrendingDownIcon, color: t['status-warning'], label: 'Velocity loss' },
+  'missed-reps': { Icon: CircleSlashIcon, color: t['status-warning'], label: 'Missed reps' },
+  pr: { Icon: AwardIcon, color: t['status-success'], label: 'Personal record' },
+  info: { Icon: InfoIcon, color: t['status-info'], label: 'More info' },
+}
+
+/**
+ * Precedence order (1=highest → last=lowest). A single chip is shown, so when
+ * several signals are true the highest-ranked wins. Alerts outrank `pr`; `info`
+ * is the floor. This ordering is LOCKED — do not reshuffle.
+ */
+export const INDICATOR_PRECEDENCE: readonly ExerciseIndicatorKind[] = [
+  'imbalance',
+  'overshoot',
+  'velocity-loss',
+  'missed-reps',
+  'pr',
+  'info',
+]
+
+/**
+ * Given the signals currently true for an exercise, pick the single
+ * highest-precedence kind to surface (or `undefined` when none apply). Order and
+ * duplicates in `candidates` don't matter — {@link INDICATOR_PRECEDENCE} decides.
+ */
+export function resolveIndicator(
+  candidates: ExerciseIndicatorKind[],
+): ExerciseIndicatorKind | undefined {
+  return INDICATOR_PRECEDENCE.find((kind) => candidates.includes(kind))
 }
 
 export interface ExerciseIndicatorProps extends Omit<ViewProps, 'children'> {
   kind: ExerciseIndicatorKind
-  /** Optional tap handler (surfaces detail — PR history / issue / info). */
+  /** Optional tap handler (surfaces detail — PR history / alert / info). */
   onPress?: () => void
   className?: string
 }
 
 /**
- * A small circular indicator chip for an exercise heading (PR / issue / info).
- * Presentational; the tap detail (tooltip/sheet) is wired by the consumer.
+ * A small circular outlined chip for an exercise heading. Presentational and
+ * static (chips are chrome — no pulse); the tap detail (tooltip/sheet) is wired
+ * by the consumer.
  */
 export function ExerciseIndicator({ kind, onPress, className, ...props }: ExerciseIndicatorProps) {
-  const { glyph, color, label } = INDICATOR_CONFIG[kind]
+  const { Icon, color, label } = INDICATOR_CONFIG[kind]
 
   const chip = (
     <View
@@ -53,12 +105,7 @@ export function ExerciseIndicator({ kind, onPress, className, ...props }: Exerci
       testID="exercise-indicator"
       {...props}
     >
-      <Text
-        style={{ fontSize: 10, fontWeight: '800', color, lineHeight: 14 }}
-        accessibilityElementsHidden
-      >
-        {glyph}
-      </Text>
+      <Icon size={11} color={color} />
     </View>
   )
 

--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -84,6 +84,27 @@ type props without pulling the dependency.
   SVGs (`./icons.tsx`), not `lucide-react` — that dependency was dropped in 0.5.0
   to keep the root barrel light. The SVG paths mirror lucide's glyphs so rendering
   is unchanged.
+- **`ExerciseIndicator` taxonomy (LOCKED, TD-03.51)** — one precedence-ranked slot
+  per exercise, six distinct kinds over four tier colors (bound to titan status
+  tokens, read as literal hex via `getSemanticColors('dark')` — the TempoBar
+  pattern). Glyph = the specific signal; color = the severity tier. Chips are
+  outlined (border + glyph, no fill) so they never collide with the *filled*
+  velocity strip, and static (no pulse — they are chrome). Precedence, high → low:
+
+  | # | kind | tier | glyph (mirrors lucide) |
+  |---|------|------|------------------------|
+  | 1 | `imbalance` | danger (`status-error`) | `Scale` |
+  | 2 | `overshoot` | danger (`status-error`) | `AlertTriangle` |
+  | 3 | `velocity-loss` | warning (`status-warning`) | `TrendingDown` |
+  | 4 | `missed-reps` | warning (`status-warning`) | `CircleSlash` |
+  | 5 | `pr` | success (`status-success`) | `Award` |
+  | 6 | `info` | info (`status-info`) | `Info` |
+
+  `resolveIndicator(candidates)` collapses the active signals to the single
+  highest-precedence kind to show (`undefined` when none). Alerts outrank `pr`. The
+  glyphs are new inline SVGs in the shared `components/icons` set (not the local
+  `./icons.tsx` badge glyphs). The old generic `issue` kind is superseded by the
+  specific danger/warning kinds and was removed.
 
 ## Shell/SessionRail feature area
 

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -61,6 +61,8 @@ export {
 } from './SetStrip'
 export {
   ExerciseIndicator,
+  resolveIndicator,
+  INDICATOR_PRECEDENCE,
   type ExerciseIndicatorProps,
   type ExerciseIndicatorKind,
 } from './ExerciseIndicator'

--- a/packages/ui/src/components/icons/icons.stories.tsx
+++ b/packages/ui/src/components/icons/icons.stories.tsx
@@ -10,6 +10,12 @@ import {
   HistoryIcon,
   LayersIcon,
   PersonStandingIcon,
+  ScaleIcon,
+  AlertTriangleIcon,
+  TrendingDownIcon,
+  CircleSlashIcon,
+  AwardIcon,
+  InfoIcon,
 } from './icons'
 
 const meta: Meta = {
@@ -79,6 +85,36 @@ export const All: Story = {
       <Swatch label="PersonStandingIcon">
         <View className="text-text-primary">
           <PersonStandingIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="ScaleIcon">
+        <View className="text-status-error">
+          <ScaleIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="AlertTriangleIcon">
+        <View className="text-status-error">
+          <AlertTriangleIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="TrendingDownIcon">
+        <View className="text-status-warning">
+          <TrendingDownIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="CircleSlashIcon">
+        <View className="text-status-warning">
+          <CircleSlashIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="AwardIcon">
+        <View className="text-status-success">
+          <AwardIcon size={28} />
+        </View>
+      </Swatch>
+      <Swatch label="InfoIcon">
+        <View className="text-status-info">
+          <InfoIcon size={28} />
         </View>
       </Swatch>
     </View>

--- a/packages/ui/src/components/icons/icons.test.tsx
+++ b/packages/ui/src/components/icons/icons.test.tsx
@@ -10,6 +10,12 @@ import {
   HistoryIcon,
   LayersIcon,
   PersonStandingIcon,
+  ScaleIcon,
+  AlertTriangleIcon,
+  TrendingDownIcon,
+  CircleSlashIcon,
+  AwardIcon,
+  InfoIcon,
 } from './icons'
 import { SvgIcon } from './SvgIcon'
 
@@ -24,6 +30,12 @@ describe('icon primitives', () => {
       HistoryIcon,
       LayersIcon,
       PersonStandingIcon,
+      ScaleIcon,
+      AlertTriangleIcon,
+      TrendingDownIcon,
+      CircleSlashIcon,
+      AwardIcon,
+      InfoIcon,
     ].forEach((Icon) => {
       const { container, unmount } = render(<Icon />)
       expect(container.querySelector('svg')).toBeInTheDocument()

--- a/packages/ui/src/components/icons/icons.tsx
+++ b/packages/ui/src/components/icons/icons.tsx
@@ -86,3 +86,68 @@ export function PersonStandingIcon(props: IconProps) {
     </SvgIcon>
   )
 }
+
+/** Balance-scale glyph (mirrors lucide-react `Scale`). ExerciseIndicator → `imbalance`. */
+export function ScaleIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
+      <path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
+      <path d="M7 21h10" />
+      <path d="M12 3v18" />
+      <path d="M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2" />
+    </SvgIcon>
+  )
+}
+
+/** Warning-triangle glyph (mirrors lucide-react `AlertTriangle`). ExerciseIndicator → `overshoot`. */
+export function AlertTriangleIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </SvgIcon>
+  )
+}
+
+/** Down-trend glyph (mirrors lucide-react `TrendingDown`). ExerciseIndicator → `velocity-loss`. */
+export function TrendingDownIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M16 17h6v-6" />
+      <path d="m22 17-8.5-8.5-5 5L2 7" />
+    </SvgIcon>
+  )
+}
+
+/** Slashed-circle glyph (mirrors lucide-react `CircleSlash`). ExerciseIndicator → `missed-reps`. */
+export function CircleSlashIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 15 6-6" />
+    </SvgIcon>
+  )
+}
+
+/** Medal glyph (mirrors lucide-react `Award`). ExerciseIndicator → `pr`. */
+export function AwardIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526" />
+      <circle cx="12" cy="8" r="6" />
+    </SvgIcon>
+  )
+}
+
+/** Info-circle glyph (mirrors lucide-react `Info`). ExerciseIndicator → `info`. */
+export function InfoIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </SvgIcon>
+  )
+}


### PR DESCRIPTION
## TD-03.51 — Indicator taxonomy: expand to 6 kinds + precedence resolver

Grows the hardened `ExerciseIndicator` outlined chip from 3 ad-hoc kinds to the **LOCKED 6-kind taxonomy** and adds a `resolveIndicator()` precedence picker. One precedence-ranked slot per exercise; glyph = the specific signal, color = the severity tier. Chips stay outlined (border + glyph, no fill) and static (no pulse) so they never collide with the filled velocity strip.

### Taxonomy (precedence high → low)
| # | kind | tier (status token) | glyph (mirrors lucide) |
|---|------|---------------------|------------------------|
| 1 | `imbalance` | danger · `status-error` | `Scale` |
| 2 | `overshoot` | danger · `status-error` | `AlertTriangle` |
| 3 | `velocity-loss` | warning · `status-warning` | `TrendingDown` |
| 4 | `missed-reps` | warning · `status-warning` | `CircleSlash` |
| 5 | `pr` | success · `status-success` | `Award` |
| 6 | `info` | info · `status-info` | `Info` |

`resolveIndicator(candidates)` → the single highest-precedence active kind (or `undefined`). Alerts outrank `pr`; `info` is the floor. Exported alongside `INDICATOR_PRECEDENCE`.

### Decisions
- **`issue` kind: REMOVED** (no runtime alias). It was a generic catch-all superseded by the specific danger/warning kinds. All type-ref call sites (`ExerciseCard`/`ExerciseHeading`/`SessionRail`) were unaffected; the two dependent story option lists (`ExerciseHeading.stories`, `ExerciseCardHeading.stories`) listed `'issue'` and were migrated to the 6-kind set. `setHeadingKit.tsx` is a decoupled dead-candidate demo kit with its own local literal union (does not import `ExerciseIndicatorKind`) — left untouched per scope.
- **Color tokens: titan status semantic tokens**, read as literal hex via `getSemanticColors('dark')[token]` (the TempoBar pattern) rather than `resolveColor()` (which yields `var(...)` under the RNW vitest alias and breaks assertions). This is the ticket's specified binding and matches the tested-component convention.
- **Glyphs**: six new inline SVGs added to the shared `components/icons` set mirroring the current lucide outline paths (lucide-react was dropped in 0.5.0 — no dependency added). The chip swaps its text glyph for the sized icon (11px, `color` = tier).

### Gates (from `packages/ui/`)
- `CI=true npx tsc --noEmit` → **0 errors**
- `CI=true npx vitest run` → **2385 passed / 123 files** (no pre-existing test regressed)
- `CI=true npx eslint src` → **exit 0, 0 errors** (89 warnings, all pre-existing; none in touched files)

### Files
- `ExerciseIndicator.tsx` — 6-kind union, status-token config, `resolveIndicator` + `INDICATOR_PRECEDENCE`, SVG glyph render
- `icons.tsx` — `ScaleIcon`/`AlertTriangleIcon`/`TrendingDownIcon`/`CircleSlashIcon`/`AwardIcon`/`InfoIcon`
- Tests: `ExerciseIndicator.test.tsx` (chips + tier color + a11y + resolver), `icons.test.tsx`
- Stories: `ExerciseIndicator.stories.tsx` (precedence sheet + resolver demo), `icons.stories.tsx`, migrated `ExerciseHeading.stories`/`ExerciseCardHeading.stories` options
- `README.md` taxonomy table + `index.ts` barrel exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)