### PR TITLE
SetRow/SetTableHeader showPrevious + expansion direction study

### DIFF
--- a/packages/ui/src/components/custom/Workout/S3WorkoutExpansion.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/S3WorkoutExpansion.stories.tsx
@@ -1,65 +1,170 @@
 /**
- * SHEET · Workout Expansion (page 2, EARLY) — what a rail item reveals when expanded.
- * Shows the REAL ExerciseCard expanded (responsive fit + isLive already landed this session) in the rail
- * context, alongside the open questions. NOT yet explored — this frames the next exploration.
- * OPEN: drop the PREV column · embed reps/RPE/weight INTO the velocity bar (vs the current table) · live-set
- * treatment in the expanded view · read-only density (tempo row? per-rep strips per row?). See DECISIONS doc.
+ * SHEET · Workout Expansion (page 2) — what a rail item reveals when expanded.
+ * Anchored on the REAL unexpanded rail row (`ExerciseCardHeading`) as the persistent header, then the
+ * revealed body in two REAL-component directions so the fork is concrete:
+ *   A — Table   (real `SetTableHeader` + real `SetRow`s — the current expanded body).
+ *   C — Embed   (real `VelocityStrip` full/expanded per set + a compact caption — the bar IS the set).
+ * B (drop PREV) is a trivial prop on the table, noted but not forked here. Same data across both: set 1 done
+ * · set 2 LIVE 5/10 · set 3 upcoming, with velocities that DECAY within a set so the "shape" reading is real.
+ * OPEN: A-vs-C · live-set treatment in the body · read-only density (drop TEMPO row? per-row strips?). DECISIONS doc.
  */
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { ExerciseCard, type ExerciseCardProps } from './ExerciseCard'
-import { INSET, INSET_SHADOW, RAISED, T_PRIMARY, T_SECONDARY, ORANGE, Page } from './setHeadingKit'
+import { View, Text } from 'react-native'
+import { ExerciseCardHeading } from './ExerciseCardHeading'
+import { SetTableHeader } from './SetTableHeader'
+import { SetRow, type SetRowProps } from './SetRow'
+import { VelocityStrip } from './VelocityStrip'
+import { type SetStripSet } from './SetStrip'
+import {
+  INSET, INSET_SHADOW, RAISED, BORDER_SUBTLE, GREEN,
+  T_PRIMARY, T_SECONDARY, T_TERTIARY, Page, sectionTitle, monoTag,
+} from './setHeadingKit'
 
-const perRep = (n: number, start: number) => Array.from({ length: n }, (_, r) => +(start + 0.04 - r * 0.015).toFixed(2))
+// Per-rep mean velocity that DECAYS across a set (fast → slow) so bar height/color carries shape.
+const decay = (n: number, start: number, span = 0.5) =>
+  Array.from({ length: n }, (_, r) => +(start - (span * r) / Math.max(1, n - 1)).toFixed(3))
 
-// the active exercise expanded: set 1 done, set 2 LIVE (5/8), set 3 not-started
-const EXPANDED: ExerciseCardProps = {
-  name: 'Cable Chest Press',
-  state: 'expanded',
-  onToggle: () => {},
-  summary: { sets: 3, reps: 10, weight: 90, unit: 'lbs' },
-  tempo: [2, 1, 2, 0],
-  sets: [
-    { mode: 'completed', setNumber: 1, previous: { reps: 10, weight: 90 }, reps: 10, weight: 90, rpe: 7.5, unit: 'lbs', velocities: perRep(10, 0.7) },
-    { mode: 'active', setNumber: 2, previous: { reps: 10, weight: 90 }, reps: null, weight: null, unit: 'lbs', isLive: true, targets: { reps: 10, weight: 90 }, velocities: perRep(5, 0.62) },
-    { mode: 'active', setNumber: 3, previous: { reps: 10, weight: 90 }, reps: null, weight: null, unit: 'lbs', isNextSet: false, targets: { reps: 10, weight: 90 } },
-  ],
+// ---- shared data (real prop shapes) ------------------------------------------------
+// Heading strip (SetStripSet[]): set1 done · set2 active 5/10 · set3 todo.
+const HEADING_STATES: SetStripSet[] = [
+  { status: 'done', velocities: decay(10, 1.05) },
+  { status: 'active', velocities: decay(5, 0.95, 0.3), planned: 10 },
+  { status: 'todo', planned: 10 },
+]
+// Expanded-body per-set rows (real SetRowProps).
+const BODY_SETS: SetRowProps[] = [
+  { mode: 'completed', setNumber: 1, previous: { reps: 10, weight: 90 }, reps: 10, weight: 90, rpe: 7.5, unit: 'lbs', velocities: decay(10, 1.05) },
+  { mode: 'active', setNumber: 2, previous: { reps: 10, weight: 90 }, reps: null, weight: null, unit: 'lbs', isLive: true, targets: { reps: 10, weight: 90 }, velocities: decay(5, 0.95, 0.3) },
+  { mode: 'active', setNumber: 3, previous: { reps: 10, weight: 90 }, reps: null, weight: null, unit: 'lbs', isNextSet: false, targets: { reps: 10, weight: 90 } },
+]
+
+// ---- the real unexpanded rail row, used as the persistent expansion header ---------
+function RailHeader() {
+  return (
+    <View style={{ position: 'relative', zIndex: 2, backgroundColor: RAISED }}>
+      <ExerciseCardHeading
+        name="Cable Chest Press"
+        sets={3}
+        reps={10}
+        load={90}
+        unit="lbs"
+        tempo={[2, 1, 2, 0]}
+        indicator="info"
+        setStates={HEADING_STATES}
+      />
+    </View>
+  )
 }
 
-const OPEN: [string, string][] = [
-  ['Drop PREV', 'The PREV column is reference data, not decision-relevant mid-set — operator wants it gone. Keeps set# · reps · weight · RPE.'],
-  ['Embed in the bar', 'Reps/RPE may be redundant with the per-rep velocity bar + the load at top. Explore riding reps/RPE/weight ON the velocity bar instead of a separate table row (a suite of iterations — like the heading was).'],
-  ['Live set', 'isLive landed (green “5/8” + grey remainder). In the expanded table it needs to read as clearly in-progress vs the not-started row below.'],
-  ['Read-only density', 'Rail is read-only. Candidates to drop for rail density: the TEMPO row, per-rep strips on every completed row. The heading already carries tempo + the set strip.'],
-]
+// ---- A · table body: real SetTableHeader + real SetRow (LOCKED: drop PREV, keep strips)
+function TableBody() {
+  return (
+    <View>
+      <SetTableHeader unit="lbs" showPrevious={false} />
+      {BODY_SETS.map((s, i) => (
+        <SetRow key={i} {...s} showPrevious={false} />
+      ))}
+    </View>
+  )
+}
+
+// ---- C · embed body: real VelocityStrip (full/expanded) per set + compact caption ---
+const capText = { fontFamily: 'Inter, sans-serif', fontSize: 11, fontWeight: '600' as const, color: T_PRIMARY }
+const dimText = { ...capText, color: T_SECONDARY, fontWeight: '500' as const }
+function EmbedSetRow({ s }: { s: SetRowProps }) {
+  const live = s.isLive
+  const todo = s.mode === 'active' && !s.isLive && s.reps == null
+  const done = s.mode === 'completed'
+  const vels = s.velocities ?? []
+  return (
+    <View
+      style={{
+        paddingVertical: 7,
+        paddingHorizontal: 10,
+        marginHorizontal: 2,
+        marginBottom: 4,
+        borderRadius: 8,
+        opacity: todo ? 0.55 : 1,
+        ...(live ? { backgroundColor: 'rgba(46,213,115,0.06)', borderWidth: 1, borderColor: 'rgba(46,213,115,0.30)' } : {}),
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 6 }}>
+        <Text style={{ ...dimText, width: 22, color: T_TERTIARY }}>{s.setNumber}</Text>
+        {live ? (
+          <Text style={{ ...capText, color: GREEN, fontWeight: '700' }}>
+            {vels.length}/{s.targets?.reps} × {s.targets?.weight}
+          </Text>
+        ) : done ? (
+          <Text style={capText}>{s.reps} × {s.weight}</Text>
+        ) : (
+          <Text style={dimText}>{s.targets?.reps} × {s.targets?.weight}</Text>
+        )}
+        <View style={{ flex: 1 }} />
+        {s.rpe != null && <Text style={dimText}>RPE {s.rpe}</Text>}
+        {live && <Text style={{ ...capText, color: GREEN, fontWeight: '700' }}>live</Text>}
+      </View>
+      {vels.length > 0 ? (
+        <VelocityStrip velocities={vels} variant="full" expanded showInfo={false} />
+      ) : (
+        <View style={{ height: 24, flexDirection: 'row', gap: 2 }}>
+          {Array.from({ length: s.targets?.reps ?? 10 }).map((_, i) => (
+            <View key={i} style={{ flex: 1, height: 6, alignSelf: 'flex-end', backgroundColor: '#2C2C2C', borderRadius: 1, opacity: 0.5 }} />
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}
+function EmbedBody() {
+  return (
+    <View style={{ paddingTop: 6 }}>
+      {BODY_SETS.map((s, i) => (
+        <EmbedSetRow key={i} s={s} />
+      ))}
+    </View>
+  )
+}
+
+// ---- expanded item = real rail header + revealed body ------------------------------
+function ExpandedItem({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <View style={{ gap: 8 }}>
+      <Text style={{ ...monoTag, color: T_SECONDARY }}>{label}</Text>
+      <View style={{ width: 260, backgroundColor: INSET, boxShadow: INSET_SHADOW, borderRadius: 4, overflow: 'hidden' } as object}>
+        <RailHeader />
+        <View style={{ backgroundColor: INSET, paddingBottom: 8, borderTopWidth: 1, borderTopColor: BORDER_SUBTLE }}>
+          {children}
+        </View>
+      </View>
+    </View>
+  )
+}
 
 const meta: Meta = { title: 'Lab/Explorations/Workout Expansion', parameters: { layout: 'fullscreen' } }
 export default meta
 type Story = StoryObj
 
-export const Framing: Story = {
-  name: 'Expanded item · current + open questions',
+export const DirectionStudy: Story = {
+  name: 'Expanded item · A table / C embed-in-bar (real components)',
   render: () => (
     <Page
-      title="Workout expansion — page 2 (early / framing)"
-      note="The real ExerciseCard expanded (responsive fit + isLive landed this session) in the rail. This is the NEXT exploration, not yet done — the panel lists the open questions. The big idea: embed reps/RPE/weight into the velocity bar and drop PREV."
+      title="Workout expansion — direction study (page 2)"
+      note="LOCKED (2026-07-10): body = direction A, the SetTableHeader+SetRow table, with PREV dropped (real showPrevious={false}) and the per-row velocity strips kept. C (per-rep VelocityStrip becomes the set row) shown for the record — rejected as too novel; the table already carries velocity shape via the per-row strip. Anchored on the REAL unexpanded rail row (ExerciseCardHeading) as the persistent header; data: set 1 done · set 2 live 5/10 · set 3 upcoming, velocities decaying within a set."
     >
-      <div style={{ display: 'flex', gap: 40, alignItems: 'flex-start', flexWrap: 'wrap' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <span style={{ fontFamily: 'monospace', fontSize: 11, color: T_SECONDARY }}>real ExerciseCard · expanded @ rail width</span>
-          <div style={{ width: 246, background: INSET, boxShadow: INSET_SHADOW, padding: '0 0 8px' }}>
-            <ExerciseCard {...EXPANDED} />
-          </div>
-        </div>
-        <div style={{ width: 360, display: 'flex', flexDirection: 'column', gap: 14 }}>
-          <span style={{ fontSize: 11, fontWeight: 800, letterSpacing: 1.2, textTransform: 'uppercase', color: ORANGE }}>Open questions</span>
-          {OPEN.map(([k, v]) => (
-            <div key={k} style={{ display: 'flex', flexDirection: 'column', gap: 3, background: RAISED, borderRadius: 8, padding: '10px 12px' }}>
-              <span style={{ fontSize: 12, fontWeight: 800, color: T_PRIMARY }}>{k}</span>
-              <span style={{ fontSize: 12, lineHeight: 1.45, color: T_SECONDARY }}>{v}</span>
-            </div>
-          ))}
-        </div>
-      </div>
+      <View style={{ flexDirection: 'row', gap: 44, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        <View style={{ gap: 12 }}>
+          <Text style={sectionTitle}>A · Table (current body)</Text>
+          <ExpandedItem label="real SetTableHeader + SetRow">
+            <TableBody />
+          </ExpandedItem>
+        </View>
+        <View style={{ gap: 12 }}>
+          <Text style={sectionTitle}>C · Embed in the bar</Text>
+          <ExpandedItem label="real VelocityStrip (full) + caption">
+            <EmbedBody />
+          </ExpandedItem>
+        </View>
+      </View>
     </Page>
   ),
 }

--- a/packages/ui/src/components/custom/Workout/SetRow.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.stories.tsx
@@ -21,6 +21,10 @@ const meta: Meta<typeof SetRow> = {
       control: 'boolean',
       description: 'Whether this is the next set to perform',
     },
+    showPrevious: {
+      control: 'boolean',
+      description: 'Show the PREV column (false blanks it to a flex spacer for rail density)',
+    },
   },
 }
 

--- a/packages/ui/src/components/custom/Workout/SetRow.test.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.test.tsx
@@ -33,6 +33,15 @@ describe('SetRow', () => {
       expect(screen.getByTestId('set-row-previous')).toHaveTextContent('\u2014')
     })
 
+    it('blanks the previous column when showPrevious is false', () => {
+      render(
+        <SetRow {...baseProps} previous={{ reps: 6, weight: 130 }} showPrevious={false} />,
+      )
+      // the flex spacer stays (testID present so positions hold) but its value is gone
+      expect(screen.getByTestId('set-row-previous')).toBeInTheDocument()
+      expect(screen.getByTestId('set-row-previous')).not.toHaveTextContent('130')
+    })
+
     it('applies reduced opacity for non-next completed sets', () => {
       render(<SetRow {...baseProps} />)
       const row = screen.getByTestId('set-row')

--- a/packages/ui/src/components/custom/Workout/SetRow.tsx
+++ b/packages/ui/src/components/custom/Workout/SetRow.tsx
@@ -32,6 +32,12 @@ export interface SetRowProps {
    * treatment; `velocities.length` is the reps-done count. Distinct from `isNextSet` (queued next).
    */
   isLive?: boolean
+  /**
+   * Show the PREV (previous-best) column. Default true; false blanks it to an empty
+   * flex spacer (rail density) so REPS/LOAD/RPE keep their positions. Pair with
+   * {@link SetTableHeader}'s `showPrevious`.
+   */
+  showPrevious?: boolean
 }
 
 function formatAccessibilityLabel(
@@ -63,6 +69,7 @@ export function SetRow({
   isNextSet,
   targets,
   isLive,
+  showPrevious = true,
 }: SetRowProps) {
   const isActive = mode === 'active'
   const isCompleted = mode === 'completed'
@@ -142,18 +149,20 @@ export function SetRow({
         style={{ minWidth: 44 }}
         testID="set-row-previous"
       >
-        <Text
-          className="text-text-secondary"
-          numberOfLines={1}
-          style={{
-            fontSize: 12,
-            fontFamily: 'Inter, sans-serif',
-          }}
-        >
-          {previous
-            ? `${previous.reps} x ${roundWeight(previous.weight)}`
-            : '\u2014'}
-        </Text>
+        {showPrevious && (
+          <Text
+            className="text-text-secondary"
+            numberOfLines={1}
+            style={{
+              fontSize: 12,
+              fontFamily: 'Inter, sans-serif',
+            }}
+          >
+            {previous
+              ? `${previous.reps} x ${roundWeight(previous.weight)}`
+              : '\u2014'}
+          </Text>
+        )}
       </View>
 
       <View

--- a/packages/ui/src/components/custom/Workout/SetTableHeader.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/SetTableHeader.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof SetTableHeader> = {
   },
   argTypes: {
     unit: { control: 'select', options: ['lbs', 'kg'] },
+    showPrevious: { control: 'boolean' },
   },
   decorators: [
     (Story) => (
@@ -49,5 +50,18 @@ export const Kg: Story = {
   args: { unit: 'kg' },
   parameters: {
     docs: { description: { story: 'The weight column reflects the `kg` unit.' } },
+  },
+}
+
+export const NoPrevious: Story = {
+  args: { unit: 'lbs', showPrevious: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'PREV dropped for rail density (`showPrevious={false}`); the column blanks to a flex ' +
+          'spacer so REPS/LOAD/RPE hold their positions. Pair with `SetRow`’s `showPrevious`.',
+      },
+    },
   },
 }

--- a/packages/ui/src/components/custom/Workout/SetTableHeader.test.tsx
+++ b/packages/ui/src/components/custom/Workout/SetTableHeader.test.tsx
@@ -14,6 +14,16 @@ describe('SetTableHeader', () => {
     expect(header).toHaveTextContent('RPE')
   })
 
+  it('drops the PREV column when showPrevious is false', () => {
+    render(<SetTableHeader showPrevious={false} />)
+    const header = screen.getByTestId('table-header')
+    expect(header).not.toHaveTextContent('PREV')
+    // the other columns remain
+    expect(header).toHaveTextContent('SET')
+    expect(header).toHaveTextContent('REPS')
+    expect(header).toHaveTextContent('RPE')
+  })
+
   it('shows the KG weight column when unit is kg', () => {
     render(<SetTableHeader unit="kg" />)
     const header = screen.getByTestId('table-header')

--- a/packages/ui/src/components/custom/Workout/SetTableHeader.tsx
+++ b/packages/ui/src/components/custom/Workout/SetTableHeader.tsx
@@ -1,30 +1,46 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text } from 'react-native'
 
-// Column widths, in order: SET · PREV (flex) · REPS · LOAD · RPE. Matches SetRow's
-// per-cell widths so the header aligns over the rows beneath it.
-const COLUMN_WIDTHS: (number | undefined)[] = [36, undefined, 44, 56, 36]
+// One header column: its label and its fixed width (PREV is the lone flex column,
+// `undefined`). Order + widths mirror SetRow's cells so headers align over rows.
+type Column = { label: string; width: number | undefined }
 
 export interface SetTableHeaderProps {
   /** Weight-column label: LBS / KG. Default lbs. */
   unit?: 'lbs' | 'kg'
+  /** Show the PREV (previous-best) column. Default true; false drops it for rail density. */
+  showPrevious?: boolean
   /** Overridable so a host card can keep its own testID. Default "table-header". */
   testID?: string
 }
 
-/** Column labels; the weight column reflects the given unit (LBS / KG). */
-function buildColumnHeaders(unit: 'lbs' | 'kg'): string[] {
-  return ['SET', 'PREV', 'REPS', unit.toUpperCase(), 'RPE']
+// The flex (previous-best) column keeps its slot even when hidden — blanked to an
+// empty spacer — so REPS/LOAD/RPE hold the same positions over the full-width strip.
+const PREV_COLUMN: Column = { label: 'PREV', width: undefined }
+
+/** Columns in order, with the weight column reflecting `unit`; PREV blanked when hidden. */
+function buildColumns(unit: 'lbs' | 'kg', showPrevious: boolean): Column[] {
+  return [
+    { label: 'SET', width: 36 },
+    showPrevious ? PREV_COLUMN : { label: '', width: undefined },
+    { label: 'REPS', width: 44 },
+    { label: unit.toUpperCase(), width: 56 },
+    { label: 'RPE', width: 36 },
+  ]
 }
 
 /**
  * The expanded-set-table column-header row: SET · PREV · REPS · LOAD · RPE, with
- * the weight column reflecting `unit`. Its per-column widths mirror {@link SetRow}
- * so headers align over the rows. Extracted from {@link ExerciseCard}'s expanded
- * state so the expanded workout drawer can reuse it.
+ * the weight column reflecting `unit`. `showPrevious={false}` drops PREV (rail
+ * density). Its per-column widths mirror {@link SetRow} so headers align over the
+ * rows. Extracted from {@link ExerciseCard}'s expanded state for reuse.
  */
-export function SetTableHeader({ unit = 'lbs', testID = 'table-header' }: SetTableHeaderProps) {
-  const columnHeaders = buildColumnHeaders(unit)
+export function SetTableHeader({
+  unit = 'lbs',
+  showPrevious = true,
+  testID = 'table-header',
+}: SetTableHeaderProps) {
+  const columns = buildColumns(unit, showPrevious)
 
   return (
     <View
@@ -32,13 +48,12 @@ export function SetTableHeader({ unit = 'lbs', testID = 'table-header' }: SetTab
       style={{ paddingVertical: 8, paddingHorizontal: 8, paddingBottom: 4 }}
       testID={testID}
     >
-      {columnHeaders.map((header, i) => {
-        const width = COLUMN_WIDTHS[i]
+      {columns.map(({ label, width }) => {
         const isFlex = width === undefined
 
         return (
           <View
-            key={header}
+            key={label}
             style={{
               ...(isFlex ? { minWidth: 44 } : { width, flexShrink: 1 }),
               alignItems: 'center',
@@ -57,7 +72,7 @@ export function SetTableHeader({ unit = 'lbs', testID = 'table-header' }: SetTab
                 letterSpacing: 0.8,
               }}
             >
-              {header}
+              {label}
             </Text>
           </View>
         )


### PR DESCRIPTION
## Workout Expansion (page 2, S3) — direction locked

Design exploration for the rail item's expanded body. Anchored the specimen on the **real** unexpanded rail row (`ExerciseCardHeading`) and the body on **real components** (per the titan-component-workflow "use the real component, not a lookalike" rule), then locked the direction with the operator:

- **Body = the table** (`SetTableHeader` + `SetRow`), **PREV dropped**, **per-row velocity strips kept**. Rejected the "per-rep `VelocityStrip` becomes the set row" direction (C) — too novel; the table already carries velocity shape via the per-row strip.

### Changes
- **`showPrevious?: boolean`** (default `true`, backward-compat) on `SetTableHeader` + `SetRow`. When `false`, the PREV column blanks to a flex spacer so REPS/LOAD/RPE keep their positions over the full-width strip. Tests + `NoPrevious` story + controls.
- **`S3WorkoutExpansion`** specimen reworked into a real-component direction study (A table w/ `showPrevious={false}` vs rejected C), kept for the record.

### Verification
- `tsc --noEmit` 0 · `eslint src` 0 · `vitest run` 2405 pass. Defaults byte-identical (no visual baseline drift).

### Follow-ups (next chunk, not here)
- The rail-**expandable organism** (tap a `SessionRail` item → reveal this body) — composes `ExerciseCardHeading` + the drop-PREV table; there's an existing `Shell/SessionRail/ExpandedDrawer` to build on. Ticket to file.
- `TD-03.56` SetTableHeader/SetRow responsive column unification (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)