### PR TITLE
Re-sample effort scale to [0,2,3,4]; give velocity taxonomy 5 colors

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -46,8 +46,8 @@ const HTML_CSS = `
     --result-improve: #4caf50;
     --result-degrade: #ef5350;
     --vel-red: #d14343;
-    --vel-orange: #f9b415;
-    --vel-yellow: #ffd352;
+    --vel-orange: #ff7900;
+    --vel-yellow: #f9b415;
     --vel-green: #2ed573;
     --font-heading: 'Space Grotesk', sans-serif;
     --font-ui: 'Nunito Sans', sans-serif;

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
@@ -265,9 +265,17 @@ const compoundBands = [
 describe('VelocityStrip zones prop', () => {
   it('colors bars from the supplied bands (mini)', () => {
     render(<VelocityStrip velocities={[1.1, 0.45]} zones={compoundBands} variant="mini" />)
-    // 1.1 -> speed -> green; 0.45 -> maximalStrength -> red (shared with grinding).
+    // 1.1 -> speed -> green; 0.45 -> maximalStrength -> red-600.
     expect(screen.getByTestId('velocity-bar-0')).toHaveStyle({ backgroundColor: '#2ED573' })
     expect(screen.getByTestId('velocity-bar-1')).toHaveStyle({ backgroundColor: '#D14343' })
+  })
+
+  it('gives grinding and maximalStrength DISTINCT reds (5-band, no collapse)', () => {
+    // The 5-band taxonomy samples 5 stops of the effort ramp: maximalStrength =
+    // red-600 (#D14343), grinding = red-700 (#A4221C). They no longer share one red.
+    render(<VelocityStrip velocities={[0.45, 0.2]} zones={compoundBands} variant="mini" />)
+    expect(screen.getByTestId('velocity-bar-0')).toHaveStyle({ backgroundColor: '#D14343' }) // maximalStrength
+    expect(screen.getByTestId('velocity-bar-1')).toHaveStyle({ backgroundColor: '#A4221C' }) // grinding
   })
 
   it('labels the summary row with the band containing the mean velocity', () => {

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -10,7 +10,7 @@ import {
   type ViewStyle,
 } from 'react-native'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
-import { primitiveColors, primitiveRamps } from '../../../theme/tokens/primitives'
+import { primitiveColors, primitiveRamps, sequentialEffort } from '../../../theme/tokens/primitives'
 import { formatVelocity } from '../../../utils/workout-format'
 import { SET_STRIP_VARIABLE_COLOR } from './SetStrip'
 
@@ -84,26 +84,25 @@ export interface VelocityStripProps extends ViewProps {
 const VEL_COLORS = WORKOUT_TOKENS.scale
 
 /**
- * Map a velocity-zone id (WA's 5-band taxonomy) onto the canonical 4-color
- * scale. The scale has 4 hues but the taxonomy has 5 bands, so the two slowest
- * bands — `maximalStrength` and `grinding` — intentionally share `red`: both
- * read as "heavy / effortful" and there is no distinct 5th data-viz hue. The
- * top three bands align 1:1 with the legacy default scale so an exercise moving
- * from default to profile-derived zones never shifts its fast-end colors.
- *
- * Legacy default parity: speed=green, power=yellow, strengthSpeed=orange, and
- * the old sub-0.5 "Strength" band (now split into maximalStrength + grinding)
- * stays red.
+ * Map a velocity-zone id (WA's 5-band taxonomy) directly onto the 6-stop
+ * `sequentialEffort` ramp. The default strip uses the 4-color {@link VEL_COLORS}
+ * scale (a subsample of the same ramp), but the 5-band taxonomy has one more
+ * level than that scale carries, so it samples 5 stops: the top four align with
+ * the default scale (speed/power/strengthSpeed/maximalStrength = green/gold/
+ * orange/red) and `grinding` takes the ramp's darker red. `maximalStrength` and
+ * `grinding` therefore stay DISTINCT — they no longer collapse onto one red for
+ * lack of a 5th hue. An exercise moving from default to profile-derived zones
+ * never shifts its fast-end colors.
  *
  * Unknown ids fall back to `green` (matching the historical default-path
  * fallback), so a forward-compatible band id never renders an empty bar.
  */
-const zoneIdToScaleToken: Record<string, keyof typeof VEL_COLORS> = {
-  speed: 'green',
-  power: 'yellow',
-  strengthSpeed: 'orange',
-  maximalStrength: 'red',
-  grinding: 'red',
+const bandIdToEffortColor: Record<string, string> = {
+  speed: sequentialEffort[0], // green-300
+  power: sequentialEffort[2], // amber-300 (gold)
+  strengthSpeed: sequentialEffort[3], // orange-400
+  maximalStrength: sequentialEffort[4], // red-600
+  grinding: sequentialEffort[5], // red-700 — the distinct 5th band
 }
 
 // --- Default (no-zones) scale ------------------------------------------------
@@ -162,8 +161,7 @@ function classifyBand(
 }
 
 function bandColor(band: VelocityZoneBandProp): string {
-  const token = zoneIdToScaleToken[band.id]
-  return token ? VEL_COLORS[token] : VEL_COLORS.green
+  return bandIdToEffortColor[band.id] ?? VEL_COLORS.green
 }
 
 function getLossStyle(loss: number): Record<string, string> | null {

--- a/packages/ui/src/theme/workout-tokens.ts
+++ b/packages/ui/src/theme/workout-tokens.ts
@@ -8,14 +8,18 @@ export const WORKOUT_TOKENS = {
   // Canonical 4-band performance scale — the single source for BOTH the
   // VelocityStrip zone bars and the SetRow RPE color (TD-03.43). The direction
   // is intentionally inverted between the two consumers: for velocity, green =
-  // fastest/best; for RPE, green = easiest. This is the [0,1,2,4] subsample of
-  // the canonical `sequentialEffort` primitive. The `orange` key is the band
-  // label. Consumed inline (RN).
+  // fastest/best; for RPE, green = easiest. This is the [0,2,3,4] subsample of
+  // the canonical `sequentialEffort` primitive: an EVEN hue walk across the ramp
+  // (green → gold → orange → red). The earlier [0,1,2,4] spent two of its four
+  // bands on adjacent yellows (amber-200 + amber-300) and skipped orange, reading
+  // yellow-heavy with an abrupt jump to red; sampling amber-300 + orange-400
+  // instead gives four cleanly separable bands that hold at 3px strip scale.
+  // Consumed inline (RN).
   scale: {
-    green: sequentialEffort[0],
-    yellow: sequentialEffort[1],
-    orange: sequentialEffort[2], // gold band
-    red: sequentialEffort[4],
+    green: sequentialEffort[0], // green-300
+    yellow: sequentialEffort[2], // amber-300 (gold)
+    orange: sequentialEffort[3], // orange-400 (true orange)
+    red: sequentialEffort[4], // red-600
   },
 
   // BodyMap volume heatmap — the canonical `divergingScale` (under → optimal →


### PR DESCRIPTION
## What

Two related effort-palette fixes, both sampling the one canonical 6-stop `sequentialEffort` ramp:

1. **Re-sample the 4-color `WORKOUT_TOKENS.scale` from `[0,1,2,4]` → `[0,2,3,4]`.** The old subset spent two of its four bands on adjacent yellows (`amber-200 #FFD352` + `amber-300 #F9B415`) and skipped orange entirely, reading yellow-heavy with an abrupt jump to red. `[0,2,3,4]` is an even hue walk — green → gold → orange → red — four cleanly separable bands that hold at 3px strip scale. Velocity bars and `SetRow` RPE / set-type badge inherit it.

2. **Stop collapsing WA's 5-band velocity taxonomy onto 4 colors.** `VelocityStrip` mapped `maximalStrength` and `grinding` both onto one red "for lack of a 5th hue" — but the ramp has six. The taxonomy now samples 5 stops directly (`grinding` = `red-700 #A4221C`), so the two slowest bands stay distinct.

## Why

The 4-color subset was a legibility choice for small per-rep strips, but the *specific* subset was mis-chosen (lumpy, yellow-heavy). And the 5-band collapse discarded a real distinction the palette can carry. See the design discussion — match band-count to meaning + render size, all from one ramp.

## Verification

- Layer-3 parity green (updated GT `--vel-*` vars to track the new scale; header `setHeadingKit` already used the `[0,2,3,4]` colors, so header/body now converge)
- Full vitest (2422) + new 5-band regression test; tsc + eslint clean
- Layer-1 baselines regenerated in the pinned container — new colors fall within the committed baselines' pixel threshold (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)