### PR TITLE
Make Foundations/Color stories reflect the shipped color system

### DIFF
--- a/packages/ui/src/theme/ColorSystem.stories.tsx
+++ b/packages/ui/src/theme/ColorSystem.stories.tsx
@@ -11,6 +11,10 @@ import {
   sequentialEffort,
   bestTextColor,
 } from './tokens/primitives'
+import { WORKOUT_TOKENS } from './workout-tokens'
+import { getSemanticColors } from './tokens/semantic'
+import { WORKOUT_PILL_DELOAD } from './extracted-colors-dataviz'
+import { SPINNER_PRIMARY } from './extracted-colors-ui'
 
 const meta: Meta = {
   title: 'Foundations/Color/System',
@@ -23,9 +27,13 @@ const hexToRgb = (hex: string): [number, number, number] => {
   const h = hex.replace('#', '')
   return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255) as [number, number, number]
 }
-const toHex = (v: number) => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0')
+const toHex = (v: number) =>
+  Math.round(Math.min(1, Math.max(0, v)) * 255)
+    .toString(16)
+    .padStart(2, '0')
 const lin = (c: number) => (c >= 0.04045 ? ((c + 0.055) / 1.055) ** 2.4 : c / 12.92)
-const gamma = (c: number) => (c >= 0.0031308 ? 1.055 * Math.max(0, c) ** (1 / 2.4) - 0.055 : 12.92 * c)
+const gamma = (c: number) =>
+  c >= 0.0031308 ? 1.055 * Math.max(0, c) ** (1 / 2.4) - 0.055 : 12.92 * c
 const relLum = (hex: string) => {
   const [r, g, b] = hexToRgb(hex).map(lin)
   return 0.2126 * r + 0.7152 * g + 0.0722 * b
@@ -34,11 +42,16 @@ const contrast = (a: string, b: string) => {
   const [l1, l2] = [relLum(a), relLum(b)].sort((x, y) => y - x)
   return (l1 + 0.05) / (l2 + 0.05)
 }
-const bestText = (hex: string) => (contrast(hex, '#000000') >= contrast(hex, '#FFFFFF') ? '#000000' : '#FFFFFF')
+const bestText = (hex: string) =>
+  contrast(hex, '#000000') >= contrast(hex, '#FFFFFF') ? '#000000' : '#FFFFFF'
 // Machado-2009 dichromacy simulation (severity 1.0)
 const CVD = {
-  deuteranopia: [0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881],
-  protanopia: [0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998],
+  deuteranopia: [
+    0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881,
+  ],
+  protanopia: [
+    0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998,
+  ],
 } as const
 const simulate = (M: readonly number[], hex: string) => {
   const [r, g, b] = hexToRgb(hex).map(lin)
@@ -62,7 +75,16 @@ function Ramp({ name, ramp }: { name: string; ramp: Record<number, string> }) {
       <Text className="text-text-secondary text-xs" style={{ width: 150 }}>
         {name}
       </Text>
-      <View style={{ flexDirection: 'row', flex: 1, borderRadius: 6, overflow: 'hidden', borderWidth: 1, borderColor: '#2C2C2C' }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          flex: 1,
+          borderRadius: 6,
+          overflow: 'hidden',
+          borderWidth: 1,
+          borderColor: '#2C2C2C',
+        }}
+      >
         {STEPS.map((s) => (
           <View key={s} style={{ flex: 1, height: 30, backgroundColor: ramp[s] }} />
         ))}
@@ -86,9 +108,15 @@ function Chip({ hex, label, sub }: { hex: string; label?: string; sub?: string }
           justifyContent: 'center',
         }}
       >
-        {label ? <Text style={{ color: bestText(hex), fontSize: 11, fontWeight: '700' }}>{label}</Text> : null}
+        {label ? (
+          <Text style={{ color: bestText(hex), fontSize: 11, fontWeight: '700' }}>{label}</Text>
+        ) : null}
       </View>
-      {sub ? <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>{sub}</Text> : null}
+      {sub ? (
+        <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>
+          {sub}
+        </Text>
+      ) : null}
     </View>
   )
 }
@@ -103,16 +131,20 @@ const RAMP_NAMES: Array<[keyof typeof primitiveRamps, string]> = [
   ['magenta', 'Magenta'],
 ]
 
+// Sourced from the real semantic-token layer (not re-derived) so the story can't
+// silently desync if semantic.ts changes. deload/spinner come from the same
+// extracted-colors modules the components consume.
+const DARK = getSemanticColors('dark')
 const SEM = {
-  success: primitiveRamps.green[300],
-  warning: primitiveRamps.amber[300],
-  error: primitiveRamps.red[600],
-  info: primitiveRamps.blue[500],
-  deload: primitiveRamps.magenta[600],
-  brand: primitiveRamps.orange[400],
-  brandDark: primitiveRamps.orange[600],
-  brandSecondary: primitiveRamps.cyan[600],
-  spinner: primitiveRamps.cyan[600],
+  success: DARK['status-success'],
+  warning: DARK['status-warning'],
+  error: DARK['status-error'],
+  info: DARK['status-info'],
+  deload: WORKOUT_PILL_DELOAD,
+  brand: DARK['brand-primary'],
+  brandDark: DARK['brand-primary-dark'],
+  brandSecondary: DARK['brand-secondary'],
+  spinner: SPINNER_PRIMARY,
   neutral: primitiveColors.neutral[500],
 } as const
 
@@ -124,8 +156,8 @@ export const Overview: StoryObj = {
     <View style={{ padding: 24, gap: 6 }}>
       <Text className="text-2xl font-bold text-text-primary mb-1">Color System</Text>
       <Text className="text-text-secondary mb-4">
-        Seven OKLCH tonal ramps and an ordered, colorblind-safe categorical palette. Ramps are the single
-        source of truth; the categorical references ramp steps.
+        Seven OKLCH tonal ramps and an ordered, colorblind-safe categorical palette. Ramps are the
+        single source of truth; the categorical references ramp steps.
       </Text>
 
       <SectionTitle>Tonal ramps</SectionTitle>
@@ -148,12 +180,20 @@ export const Overview: StoryObj = {
       <SectionTitle>Categorical — ordered, nested, CVD-safe to 6</SectionTitle>
       {(['default', 'dark'] as const).map((variant) => (
         <View key={variant} style={{ marginBottom: 10 }}>
-          <Text className="text-text-secondary text-xs mb-1" style={{ textTransform: 'capitalize' }}>
+          <Text
+            className="text-text-secondary text-xs mb-1"
+            style={{ textTransform: 'capitalize' }}
+          >
             {variant}
           </Text>
           <View style={{ flexDirection: 'row', gap: 6 }}>
             {categoricalPalette[variant].map((hex, i) => (
-              <Chip key={i} hex={hex} label={`${i + 1}`} sub={i < CATEGORICAL_CVD_SAFE_MAX ? undefined : 'ext'} />
+              <Chip
+                key={i}
+                hex={hex}
+                label={`${i + 1}`}
+                sub={i < CATEGORICAL_CVD_SAFE_MAX ? undefined : 'ext'}
+              />
             ))}
           </View>
         </View>
@@ -166,19 +206,45 @@ export const Overview: StoryObj = {
       </Text>
       <View style={{ flexDirection: 'row', gap: 6, marginBottom: 12 }}>
         {['under', 'maint', 'optimal', 'approach', 'over'].map((l, i) => (
-          <View key={l} style={{ flex: 1, height: 40, borderRadius: 6, backgroundColor: divergingScale[i], alignItems: 'center', justifyContent: 'center' }}>
-            <Text style={{ color: bestTextColor(divergingScale[i]), fontSize: 10, fontWeight: '700' }}>{l}</Text>
+          <View
+            key={l}
+            style={{
+              flex: 1,
+              height: 40,
+              borderRadius: 6,
+              backgroundColor: divergingScale[i],
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text
+              style={{ color: bestTextColor(divergingScale[i]), fontSize: 10, fontWeight: '700' }}
+            >
+              {l}
+            </Text>
           </View>
         ))}
       </View>
       <Text className="text-text-secondary text-xs mb-2">
-        Sequential effort (low → high) — an ordinal green→yellow→orange→red scale that IntensityBar uses
-        in full and VelocityStrip/RPE sub-samples.
+        Sequential effort (low → high) — an ordinal green→yellow→orange→red scale that IntensityBar
+        uses in full and VelocityStrip/RPE sub-samples.
       </Text>
       <View style={{ flexDirection: 'row', gap: 4, marginBottom: 4 }}>
         {sequentialEffort.map((hex, i) => (
-          <View key={i} style={{ flex: 1, height: 34, borderRadius: 5, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
-            <Text style={{ color: bestTextColor(hex), fontSize: 10, fontWeight: '700' }}>{i + 1}</Text>
+          <View
+            key={i}
+            style={{
+              flex: 1,
+              height: 34,
+              borderRadius: 5,
+              backgroundColor: hex,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text style={{ color: bestTextColor(hex), fontSize: 10, fontWeight: '700' }}>
+              {i + 1}
+            </Text>
           </View>
         ))}
       </View>
@@ -189,11 +255,32 @@ export const Overview: StoryObj = {
         <Demo label="BodyMap · training status">
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 132, gap: 4 }}>
             {[
-              ['Chest', 4], ['Quads', 2], ['Back', 3],
-              ['Delts', 0], ['Biceps', 4], ['Calves', 1],
+              ['Chest', 4],
+              ['Quads', 2],
+              ['Back', 3],
+              ['Delts', 0],
+              ['Biceps', 4],
+              ['Calves', 1],
             ].map(([m, idx]) => (
-              <View key={m as string} style={{ width: 40, backgroundColor: D3_STATUS[idx as number], borderRadius: 5, paddingVertical: 6 }}>
-                <Text style={{ color: bestTextColor(D3_STATUS[idx as number]), fontSize: 8, fontWeight: '700', textAlign: 'center' }}>{m as string}</Text>
+              <View
+                key={m as string}
+                style={{
+                  width: 40,
+                  backgroundColor: D3_STATUS[idx as number],
+                  borderRadius: 5,
+                  paddingVertical: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: bestTextColor(D3_STATUS[idx as number]),
+                    fontSize: 8,
+                    fontWeight: '700',
+                    textAlign: 'center',
+                  }}
+                >
+                  {m as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -201,10 +288,22 @@ export const Overview: StoryObj = {
         {/* StatusDot — semantic */}
         <Demo label="StatusDot · semantic">
           <View style={{ gap: 6 }}>
-            {[['ok', SEM.success], ['warn', SEM.warning], ['err', SEM.error], ['neutral', SEM.neutral]].map(([l, c]) => (
-              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <View style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: c as string }} />
-                <Text className="text-text-secondary" style={{ fontSize: 11 }}>{l as string}</Text>
+            {[
+              ['ok', SEM.success],
+              ['warn', SEM.warning],
+              ['err', SEM.error],
+              ['neutral', SEM.neutral],
+            ].map(([l, c]) => (
+              <View
+                key={l as string}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+              >
+                <View
+                  style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: c as string }}
+                />
+                <Text className="text-text-secondary" style={{ fontSize: 11 }}>
+                  {l as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -212,9 +311,25 @@ export const Overview: StoryObj = {
         {/* WorkoutPill — status */}
         <Demo label="WorkoutPill">
           <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap', maxWidth: 220 }}>
-            {[['Done', SEM.success], ['Now', SEM.brand], ['Next', SEM.neutral], ['Deload', SEM.deload]].map(([t, c]) => (
-              <View key={t as string} style={{ borderRadius: 99, borderWidth: 1, borderColor: c as string, paddingHorizontal: 10, paddingVertical: 3 }}>
-                <Text style={{ color: c as string, fontSize: 11, fontWeight: '700' }}>{t as string}</Text>
+            {[
+              ['Done', SEM.success],
+              ['Now', SEM.brand],
+              ['Next', SEM.neutral],
+              ['Deload', SEM.deload],
+            ].map(([t, c]) => (
+              <View
+                key={t as string}
+                style={{
+                  borderRadius: 99,
+                  borderWidth: 1,
+                  borderColor: c as string,
+                  paddingHorizontal: 10,
+                  paddingVertical: 3,
+                }}
+              >
+                <Text style={{ color: c as string, fontSize: 11, fontWeight: '700' }}>
+                  {t as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -222,10 +337,22 @@ export const Overview: StoryObj = {
         {/* StrengthTrend legend — series → semantic */}
         <Demo label="StrengthTrend · series">
           <View style={{ flexDirection: 'row', gap: 12, flexWrap: 'wrap' }}>
-            {[['1RM', SEM.brand], ['vel', SEM.success], ['miss', SEM.error], ['RPE', SEM.warning]].map(([l, c]) => (
-              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                <View style={{ width: 14, height: 3, backgroundColor: c as string, borderRadius: 2 }} />
-                <Text className="text-text-secondary" style={{ fontSize: 10 }}>{l as string}</Text>
+            {[
+              ['1RM', SEM.brand],
+              ['vel', SEM.success],
+              ['miss', SEM.error],
+              ['RPE', SEM.warning],
+            ].map(([l, c]) => (
+              <View
+                key={l as string}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+              >
+                <View
+                  style={{ width: 14, height: 3, backgroundColor: c as string, borderRadius: 2 }}
+                />
+                <Text className="text-text-secondary" style={{ fontSize: 10 }}>
+                  {l as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -234,28 +361,62 @@ export const Overview: StoryObj = {
         <Demo label="Treemap · categorical">
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 140, gap: 2 }}>
             {[46, 30, 30, 24, 24, 24, 20].map((h, i) => (
-              <View key={i} style={{ height: h, flexGrow: 1, flexBasis: h > 40 ? 60 : 40, backgroundColor: getCategoricalColor(i), borderRadius: 3 }} />
+              <View
+                key={i}
+                style={{
+                  height: h,
+                  flexGrow: 1,
+                  flexBasis: h > 40 ? 60 : 40,
+                  backgroundColor: getCategoricalColor(i),
+                  borderRadius: 3,
+                }}
+              />
             ))}
           </View>
         </Demo>
         {/* Spinner */}
         <Demo label="Spinner">
-          <View style={{ width: 24, height: 24, borderRadius: 12, borderWidth: 3, borderColor: '#2C2C2C', borderTopColor: SEM.spinner }} />
+          <View
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: 12,
+              borderWidth: 3,
+              borderColor: '#2C2C2C',
+              borderTopColor: SEM.spinner,
+            }}
+          />
         </Demo>
         {/* IntensityBar — full effort scale */}
         <Demo label="IntensityBar · effort">
           <View style={{ flexDirection: 'row', gap: 2, width: 132 }}>
             {sequentialEffort.map((hex, i) => (
-              <View key={i} style={{ flex: 1, height: 20, backgroundColor: hex, borderRadius: 2 }} />
+              <View
+                key={i}
+                style={{ flex: 1, height: 20, backgroundColor: hex, borderRadius: 2 }}
+              />
             ))}
           </View>
         </Demo>
-        {/* VelocityStrip / RPE — effort sub-sample */}
+        {/* VelocityStrip / RPE — the real 4-band production scale (WORKOUT_TOKENS.scale,
+            sequentialEffort indices [0,2,3,4] → red-600, NOT red-700). */}
         <Demo label="VelocityStrip · RPE">
           <View style={{ flexDirection: 'row', gap: 3 }}>
-            {[sequentialEffort[0], sequentialEffort[2], sequentialEffort[3], sequentialEffort[5]].map((hex, i) => (
-              <View key={i} style={{ width: 30, height: 26, borderRadius: 4, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
-                <Text style={{ color: bestTextColor(hex), fontSize: 9, fontWeight: '700' }}>{['S', 'M', 'F', 'X'][i]}</Text>
+            {Object.values(WORKOUT_TOKENS.scale).map((hex, i) => (
+              <View
+                key={i}
+                style={{
+                  width: 30,
+                  height: 26,
+                  borderRadius: 4,
+                  backgroundColor: hex,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Text style={{ color: bestTextColor(hex), fontSize: 9, fontWeight: '700' }}>
+                  {['S', 'M', 'F', 'X'][i]}
+                </Text>
               </View>
             ))}
           </View>
@@ -268,7 +429,9 @@ export const Overview: StoryObj = {
 function Demo({ label, children }: { label: string; children: ReactNode }) {
   return (
     <View style={{ padding: 10, backgroundColor: '#1A1A1A', borderRadius: 8 }}>
-      <Text className="text-text-secondary" style={{ fontSize: 9, marginBottom: 6 }}>{label}</Text>
+      <Text className="text-text-secondary" style={{ fontSize: 9, marginBottom: 6 }}>
+        {label}
+      </Text>
       {children}
     </View>
   )
@@ -279,8 +442,9 @@ export const Accessibility: StoryObj = {
     <View style={{ padding: 24 }}>
       <Text className="text-2xl font-bold text-text-primary mb-1">Categorical Accessibility</Text>
       <Text className="text-text-secondary mb-5">
-        In-place text contrast and colorblind simulation for the categorical series. Converging strips across
-        two swatches signal a collision for that viewer; all pairs hold ΔE ≥ 8 through the first {CATEGORICAL_CVD_SAFE_MAX}.
+        In-place text contrast and colorblind simulation for the categorical series. Converging
+        strips across two swatches signal a collision for that viewer; all pairs hold ΔE ≥ 8 through
+        the first {CATEGORICAL_CVD_SAFE_MAX}.
       </Text>
 
       {(['default', 'dark'] as const).map((variant) => {
@@ -288,14 +452,26 @@ export const Accessibility: StoryObj = {
         const textColor = variant === 'dark' ? '#FFFFFF' : '#000000'
         return (
           <View key={variant} style={{ marginBottom: 22 }}>
-            <Text className="text-lg font-bold text-text-primary mb-2" style={{ textTransform: 'capitalize' }}>
+            <Text
+              className="text-lg font-bold text-text-primary mb-2"
+              style={{ textTransform: 'capitalize' }}
+            >
               {variant}
             </Text>
             {/* swatches with in-place text + contrast ratio */}
             <View style={{ flexDirection: 'row', gap: 6, marginBottom: 6 }}>
               {colors.map((hex, i) => (
                 <View key={i} style={{ alignItems: 'center' }}>
-                  <View style={{ width: 56, height: 40, borderRadius: 6, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
+                  <View
+                    style={{
+                      width: 56,
+                      height: 40,
+                      borderRadius: 6,
+                      backgroundColor: hex,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
                     <Text style={{ color: textColor, fontSize: 11, fontWeight: '700' }}>Aa</Text>
                   </View>
                   <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>
@@ -307,10 +483,20 @@ export const Accessibility: StoryObj = {
             {/* CVD simulation strips */}
             {(['deuteranopia', 'protanopia'] as const).map((mode) => (
               <View key={mode} style={{ flexDirection: 'row', alignItems: 'center', marginTop: 3 }}>
-                <Text className="text-text-secondary" style={{ fontSize: 9, width: 96 }}>{mode}</Text>
+                <Text className="text-text-secondary" style={{ fontSize: 9, width: 96 }}>
+                  {mode}
+                </Text>
                 <View style={{ flexDirection: 'row', gap: 6 }}>
                   {colors.map((hex, i) => (
-                    <View key={i} style={{ width: 56, height: 14, borderRadius: 3, backgroundColor: simulate(CVD[mode], hex) }} />
+                    <View
+                      key={i}
+                      style={{
+                        width: 56,
+                        height: 14,
+                        borderRadius: 3,
+                        backgroundColor: simulate(CVD[mode], hex),
+                      }}
+                    />
                   ))}
                 </View>
               </View>

--- a/packages/ui/src/theme/Colors.stories.tsx
+++ b/packages/ui/src/theme/Colors.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
-import { primitiveColors, discreteRainbow, primitiveRamps, categoricalPalette } from './tokens/primitives'
+import {
+  primitiveColors,
+  discreteRainbow,
+  primitiveRamps,
+  categoricalPalette,
+} from './tokens/primitives'
 import { semanticColorsLight, semanticColorsDark } from './tokens/semantic'
 
 const meta: Meta = {
@@ -32,12 +37,8 @@ function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
         }}
       />
       <View>
-        <Text className="font-semibold text-text-primary text-sm">
-          {name}
-        </Text>
-        <Text className="text-text-secondary text-xs">
-          {displayValue}
-        </Text>
+        <Text className="font-semibold text-text-primary text-sm">{name}</Text>
+        <Text className="text-text-secondary text-xs">{displayValue}</Text>
       </View>
     </View>
   )
@@ -46,9 +47,7 @@ function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
 function ColorScale({ name, colors }: { name: string; colors: Record<string | number, string> }) {
   return (
     <View style={{ marginBottom: 32 }}>
-      <Text className="text-lg font-bold text-text-primary mb-3">
-        {name}
-      </Text>
+      <Text className="text-lg font-bold text-text-primary mb-3">{name}</Text>
       <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
         {Object.entries(colors).map(([shade, color]) => (
           <View key={shade} style={{ alignItems: 'center' }}>
@@ -62,9 +61,7 @@ function ColorScale({ name, colors }: { name: string; colors: Record<string | nu
                 borderColor: '#374151',
               }}
             />
-            <Text className="text-text-secondary text-xs mt-1">
-              {shade}
-            </Text>
+            <Text className="text-text-secondary text-xs mt-1">{shade}</Text>
           </View>
         ))}
       </View>
@@ -75,9 +72,7 @@ function ColorScale({ name, colors }: { name: string; colors: Record<string | nu
 export const PrimitiveColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Primitive Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Primitive Colors</Text>
       <Text className="text-text-secondary mb-6">
         Raw color values. Chromatic hues live as OKLCH tonal ramps (see the Tonal Ramps story);
         these are the achromatic and support scales. Use semantic tokens when building components.
@@ -95,17 +90,24 @@ export const PrimitiveColors: StoryObj = {
 export const BrandColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Brand Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Brand Colors</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="brand-primary" value={semanticColorsLight['brand-primary']} />
-        <ColorSwatch name="brand-primary-light" value={semanticColorsLight['brand-primary-light']} />
+        <ColorSwatch
+          name="brand-primary-light"
+          value={semanticColorsLight['brand-primary-light']}
+        />
         <ColorSwatch name="brand-primary-dark" value={semanticColorsLight['brand-primary-dark']} />
         <ColorSwatch name="brand-secondary" value={semanticColorsLight['brand-secondary']} />
-        <ColorSwatch name="brand-secondary-light" value={semanticColorsLight['brand-secondary-light']} />
-        <ColorSwatch name="brand-secondary-dark" value={semanticColorsLight['brand-secondary-dark']} />
+        <ColorSwatch
+          name="brand-secondary-light"
+          value={semanticColorsLight['brand-secondary-light']}
+        />
+        <ColorSwatch
+          name="brand-secondary-dark"
+          value={semanticColorsLight['brand-secondary-dark']}
+        />
       </View>
     </View>
   ),
@@ -114,9 +116,7 @@ export const BrandColors: StoryObj = {
 export const StatusColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Status Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Status Colors</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="status-success" value={semanticColorsLight['status-success']} />
@@ -131,9 +131,7 @@ export const StatusColors: StoryObj = {
 export const TextColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Text Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Text Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="text-primary" value={semanticColorsDark['text-primary']} />
@@ -149,9 +147,7 @@ export const TextColors: StoryObj = {
 export const SurfaceColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Surface Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Surface Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="surface-base" value={semanticColorsDark['surface-base']} />
@@ -168,34 +164,52 @@ export const SurfaceColors: StoryObj = {
 export const ResultColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Result/Outcome Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Result/Outcome Colors</Text>
       <Text className="text-text-secondary mb-6">
         Colors for indicating positive, negative, or neutral outcomes.
       </Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="result-improve" value={semanticColorsLight['result-improve']} />
-        <ColorSwatch name="result-improve-light" value={semanticColorsLight['result-improve-light']} />
+        <ColorSwatch
+          name="result-improve-light"
+          value={semanticColorsLight['result-improve-light']}
+        />
         <ColorSwatch name="result-degrade" value={semanticColorsLight['result-degrade']} />
-        <ColorSwatch name="result-degrade-light" value={semanticColorsLight['result-degrade-light']} />
-        <ColorSwatch name="result-inconclusive" value={semanticColorsLight['result-inconclusive']} />
-        <ColorSwatch name="result-inconclusive-light" value={semanticColorsLight['result-inconclusive-light']} />
+        <ColorSwatch
+          name="result-degrade-light"
+          value={semanticColorsLight['result-degrade-light']}
+        />
+        <ColorSwatch
+          name="result-inconclusive"
+          value={semanticColorsLight['result-inconclusive']}
+        />
+        <ColorSwatch
+          name="result-inconclusive-light"
+          value={semanticColorsLight['result-inconclusive-light']}
+        />
         <ColorSwatch name="result-neutral" value={semanticColorsLight['result-neutral']} />
       </View>
     </View>
   ),
 }
 
-export const DataVisualizationColors: StoryObj = {
+/**
+ * LEGACY — superseded. The Paul-Tol `discreteRainbow` scale behind the `data-1..10`
+ * tokens is no longer used by any component; charts and qualitative series now use
+ * the {@link CategoricalPalette} (CVD-safe, nested-stable). Kept only to document the
+ * still-defined `--color-data-N` tokens; see `CategoricalPalette` for current work.
+ */
+export const LegacyDataVisualizationColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Data Visualization Colors
+      <Text className="text-2xl font-bold text-text-primary mb-2">
+        Data Visualization Colors — Legacy
       </Text>
       <Text className="text-text-secondary mb-6">
-        Colors optimized for charts and data visualization. Based on Paul Tol&apos;s color schemes.
+        SUPERSEDED. Paul Tol&apos;s discrete-rainbow scale behind the `data-1..10` tokens — no
+        longer used by any component. Use the Categorical Palette (below) for charts and qualitative
+        series; this is retained only to document the still-defined tokens.
       </Text>
 
       <View style={{ gap: 16 }}>
@@ -263,12 +277,11 @@ function CategoricalRow({ name, colors }: { name: string; colors: readonly strin
 export const TonalRamps: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Tonal Ramps (Foundations)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Tonal Ramps (Foundations)</Text>
       <Text className="text-text-secondary mb-6">
-        Seven OKLCH-generated hue ramps, 11 perceptual steps each (50 → 950). Built with hue-torsion and a
-        chroma arc; amber absorbs the former yellow (lemon → warm body) and cyan absorbs the former steel.
+        Seven OKLCH-generated hue ramps, 11 perceptual steps each (50 → 950). Built with hue-torsion
+        and a chroma arc; amber absorbs the former yellow (lemon → warm body) and cyan absorbs the
+        former steel.
       </Text>
 
       <ColorScale name="Red" colors={primitiveRamps.red} />
@@ -285,14 +298,13 @@ export const TonalRamps: StoryObj = {
 export const CategoricalPalette: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Categorical Palette
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Categorical Palette</Text>
       <Text className="text-text-secondary mb-6">
-        Ordered, colorblind-safe qualitative series (worst-case deut/protanopia floor 8 through the first
-        six colors; the 7th is extended — pair it with a legend). Series index is stable. Use{' '}
-        <Text className="font-semibold">default</Text> on neutral/light surfaces (also legible under black
-        text) and <Text className="font-semibold">dark</Text> where white text sits on the swatch.
+        Ordered, colorblind-safe qualitative series (worst-case deut/protanopia floor 8 through the
+        first six colors; the 7th is extended — pair it with a legend). Series index is stable. Use{' '}
+        <Text className="font-semibold">default</Text> on neutral/light surfaces (also legible under
+        black text) and <Text className="font-semibold">dark</Text> where white text sits on the
+        swatch.
       </Text>
 
       <CategoricalRow name="Default" colors={categoricalPalette.default} />
@@ -304,9 +316,7 @@ export const CategoricalPalette: StoryObj = {
 export const BorderColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Border Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Border Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="border-default" value={semanticColorsDark['border-default']} />


### PR DESCRIPTION
## What

The `Foundations/Color/*` stories drifted from the shipped color system (7-ramp categorical + `sequentialEffort` + semantic tokens). Audit found the older `main9`/`light7`/`dark6` palettes are already gone, but three real issues remained:

1. **Retired palette shown as current** — `DataVisualizationColors` headlined the Paul-Tol `discreteRainbow`/`data-1..10` scale (zero component consumers; everything moved to `categoricalPalette`). Renamed → `LegacyDataVisualizationColors` and captioned as superseded.
2. **Factually wrong "correct usage" example** — the "VelocityStrip · RPE" demo hardcoded `sequentialEffort[5]` (red-**700**); production `WORKOUT_TOKENS.scale` uses index 4 (red-**600**). Now sourced from `WORKOUT_TOKENS.scale` (the two-red-ramps gotcha, fixed at the source).
3. **Drift risk** — the `SEM` object re-derived semantic tokens by hand; now sourced from `getSemanticColors('dark')` + the `extracted-colors` modules the components consume.

Only visible change is the corrected RPE swatch; all other values identical.

## Verification
- `tsc --noEmit`: 0 errors · 673 stories render · prettier clean

Closes the color-stories half of VW-33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)