### PR TITLE
Add R2 live-page candidates + S4/S5 shell exploration specimens

### DIFF
--- a/packages/ui/src/components/custom/Workout/candidates/r2/CategoricalNav.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/CategoricalNav.r2.candidate.stories.tsx
@@ -1,0 +1,100 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). Selection
+// state is passed as a static prop rather than owned locally — this shows
+// the LOOK only.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/nav.tsx + r2.css `.r2-nav`
+// Rating:   Medium · titan equiv: shell `SideNav` / `NavItem` — R2's version is a slim 62px
+//           icon-only rail (glyph + tiny label) with NO "Idle" tab (idle is a state of Live);
+//           `SideNav` is the wider labeled app-shell nav
+// Why:      C's top-level section switch (Live / Review / Program / Body / Specs) — compare
+//           against the shipped `SideNav` to decide whether the dashboard needs a second,
+//           denser nav tier or should fold into the existing one.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, Pressable } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+const ITEMS = [
+  { key: 'live', label: 'Live', glyph: '∿' },
+  { key: 'review', label: 'Review', glyph: '▮▮' },
+  { key: 'program', label: 'Program', glyph: '▦' },
+  { key: 'body', label: 'Body', glyph: '☰' },
+  { key: 'specimens', label: 'Specs', glyph: '▤' },
+] as const
+
+/** Static faithful re-render of the R2 CategoricalNav — slim icon rail. */
+function CategoricalNavSpecimen({ active }: { active: (typeof ITEMS)[number]['key'] }) {
+  return (
+    <View
+      style={{
+        width: 62,
+        paddingTop: 10,
+        gap: 4,
+        alignItems: 'center',
+        backgroundColor: t['background-subtle'],
+        borderRightWidth: 1,
+        borderRightColor: t['border-default'],
+      }}
+    >
+      {ITEMS.map((it) => {
+        const on = it.key === active
+        return (
+          <Pressable
+            key={it.key}
+            onPress={() => {}}
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 11,
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 3,
+              backgroundColor: on ? 'rgba(255,121,0,0.14)' : 'transparent',
+            }}
+          >
+            <Text style={{ fontSize: 15, color: on ? t['brand-primary'] : t['text-tertiary'] }}>
+              {it.glyph}
+            </Text>
+            <Text
+              style={{
+                fontSize: 8,
+                fontWeight: '700',
+                letterSpacing: 0.3,
+                color: on ? t['brand-primary'] : t['text-tertiary'],
+              }}
+            >
+              {it.label}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+const meta: Meta<typeof CategoricalNavSpecimen> = {
+  title: 'Lab/Candidates/R2Live/CategoricalNav',
+  component: CategoricalNavSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). A 62px ' +
+          'icon-only section rail (Live / Review / Program / Body / Specs, no Idle tab — idle ' +
+          'is a state of Live). Compare against the shipped shell `SideNav`. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof CategoricalNavSpecimen>
+
+export const OnLive: Story = { args: { active: 'live' } }
+export const OnReview: Story = { args: { active: 'review' } }
+export const OnBody: Story = { args: { active: 'body' } }

--- a/packages/ui/src/components/custom/Workout/candidates/r2/CueFlag.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/CueFlag.r2.candidate.stories.tsx
@@ -1,0 +1,74 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). This shows
+// the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/status.tsx (CueFlag) + r2.css `.r2-cue`
+// Rating:   Low-Medium · titan equiv: none (nearest is the generic coaching-card shell concept,
+//           not yet built)
+// Why:      A trigger-only in-set coaching cue banner (amber/red) that appears only at the
+//           VL20/VL28 thresholds — deterministic, not continuous. Renders nothing below threshold
+//           (mirrored here as a null-state note rather than a story, since there is nothing to
+//           show).
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+type Level = 'amber' | 'red'
+
+const LEVEL_COLOR: Record<Level, string> = { amber: t['status-warning'], red: t['status-error'] }
+const LEVEL_BG: Record<Level, string> = {
+  amber: 'rgba(255,176,32,0.14)',
+  red: 'rgba(209,67,67,0.16)',
+}
+const LEVEL_BORDER: Record<Level, string> = {
+  amber: 'rgba(255,176,32,0.4)',
+  red: 'rgba(209,67,67,0.45)',
+}
+
+/** Static faithful re-render of the R2 CueFlag — deterministic in-set trigger cue. */
+function CueFlagSpecimen({ level }: { level: Level }) {
+  const text =
+    level === 'red'
+      ? '■ Velocity loss 31% — end the set now.'
+      : '▲ VL20 · target reps met — final rep or end set.'
+  return (
+    <View
+      style={{
+        borderRadius: 10,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        backgroundColor: LEVEL_BG[level],
+        borderWidth: 1,
+        borderColor: LEVEL_BORDER[level],
+      }}
+    >
+      <Text style={{ fontSize: 12, fontWeight: '700', color: LEVEL_COLOR[level] }}>{text}</Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof CueFlagSpecimen> = {
+  title: 'Lab/Candidates/R2Live/CueFlag',
+  component: CueFlagSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Trigger-only ' +
+          'in-set coaching cue banner, shown only at the VL20/VL28 velocity-loss thresholds ' +
+          '(deterministic, not continuous). No titan equivalent. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof CueFlagSpecimen>
+
+export const Vl20Threshold: Story = { args: { level: 'amber' } }
+export const StopNow: Story = { args: { level: 'red' } }

--- a/packages/ui/src/components/custom/Workout/candidates/r2/FatigueMeter.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/FatigueMeter.r2.candidate.stories.tsx
@@ -1,0 +1,96 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). The needle
+// transition is stripped — this shows the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/status.tsx (FatigueMeter) + r2.css `.r2-fmeter`
+// Rating:   Medium · titan equiv: none real; the mobile FatigueGauge candidate (linear fill
+//           bar, trend-colored) is a related but distinct shape — no needle, no fixed VL scale
+// Why:      Zoned gradient track + sliding needle + VL10/20/30/stop scale markers, in a chunky
+//           `size='wall'` density for the across-room glance. Prototypes a proposed size/density
+//           prop rather than a fork.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+/** Static faithful re-render of the R2 FatigueMeter — zoned gradient + needle + VL scale. */
+function FatigueMeterSpecimen({
+  lossPct,
+  size = 'wall',
+}: {
+  lossPct: number
+  size?: 'md' | 'wall'
+}) {
+  const left = Math.min(98, (lossPct / 40) * 100)
+  const trackHeight = size === 'wall' ? 22 : 14
+  const needleHeight = size === 'wall' ? 32 : 20
+  return (
+    <View style={{ width: '100%', maxWidth: 420 }}>
+      <View style={{ position: 'relative', height: needleHeight }}>
+        <View
+          style={{
+            position: 'absolute',
+            top: (needleHeight - trackHeight) / 2,
+            left: 0,
+            right: 0,
+            height: trackHeight,
+            borderRadius: trackHeight / 2,
+            backgroundColor: '#2ed573',
+            overflow: 'hidden',
+            flexDirection: 'row',
+          }}
+        >
+          {['#2ed573', '#ffd43b', '#ffa502', '#ff4757'].map((c, i) => (
+            <View key={i} style={{ flex: 1, backgroundColor: c }} />
+          ))}
+        </View>
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: `${left}%`,
+            width: 4,
+            height: needleHeight,
+            borderRadius: 2,
+            backgroundColor: '#fff',
+          }}
+        />
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 4 }}>
+        {['fresh', 'VL10', 'VL20', 'VL30', 'stop'].map((label) => (
+          <Text key={label} style={{ fontSize: 8, color: t['text-tertiary'] }}>
+            {label}
+          </Text>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+const meta: Meta<typeof FatigueMeterSpecimen> = {
+  title: 'Lab/Candidates/R2Live/FatigueMeter',
+  component: FatigueMeterSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Zoned ' +
+          'green→yellow→orange→red gradient track with a sliding needle and VL10/20/30/stop ' +
+          'scale markers, in a chunky wall-glanceable density. Distinct from the mobile ' +
+          '`FatigueGauge` candidate (linear fill bar, no needle). Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof FatigueMeterSpecimen>
+
+export const Fresh: Story = { args: { lossPct: 5, size: 'wall' } }
+export const Vl20: Story = { args: { lossPct: 21, size: 'wall' } }
+export const StopZone: Story = { args: { lossPct: 34, size: 'wall' } }
+export const CompactMd: Story = { args: { lossPct: 15, size: 'md' } }

--- a/packages/ui/src/components/custom/Workout/candidates/r2/HeroVelocityBars.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/HeroVelocityBars.r2.candidate.stories.tsx
@@ -1,0 +1,152 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). Live SSE
+// streaming, the latest-bar pop animation, and DOM refs are stripped — this
+// shows the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/herobars.tsx + r2.css `.r2-herobars`
+// Rating:   High · titan equiv: VelocityStrip 'expanded' variant — compact (~100px,
+//           info footer), cannot stretch to wall-hero proportions (component-audit.md gap)
+// Why:      Full-height per-rep velocity bars for the across-room glance: value labels,
+//           running-best reference line, dashed pending-rep placeholders. R2's Direction-C
+//           synthesis labels this the candidate titan VelocityStrip 'hero' variant.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+const ZONE_COLOR: Record<string, string> = {
+  strength: '#ff4757',
+  'strength-speed': '#ffa502',
+  power: '#ffd43b',
+  speed: '#2ed573',
+}
+const ZONES: Array<{ id: string; min: number; max: number | null }> = [
+  { id: 'strength', min: 0, max: 0.3 },
+  { id: 'strength-speed', min: 0.3, max: 0.5 },
+  { id: 'power', min: 0.5, max: 0.75 },
+  { id: 'speed', min: 0.75, max: null },
+]
+
+function zoneColor(v: number): string {
+  for (const z of ZONES) {
+    if (v >= z.min && (z.max == null || v < z.max)) return ZONE_COLOR[z.id]
+  }
+  return t['text-tertiary']
+}
+
+/** Static faithful re-render of the R2 HeroVelocityBars — full-height per-rep bars. */
+function HeroVelocityBarsSpecimen({
+  velocities,
+  targetReps,
+}: {
+  velocities: number[]
+  targetReps: number
+}) {
+  const chartHeight = 190
+  const best = velocities.length ? Math.max(...velocities) : 0
+  const scale = Math.max(best * 1.1, 0.2)
+  const refY = best > 0 ? chartHeight - (best / scale) * chartHeight * 0.94 : null
+  return (
+    <View
+      style={{
+        height: 220,
+        paddingTop: 24,
+        borderBottomWidth: 2,
+        borderBottomColor: t['border-strong'],
+      }}
+    >
+      <View style={{ height: chartHeight, flexDirection: 'row', alignItems: 'flex-end', gap: 8 }}>
+        {refY != null && (
+          <View
+            style={{
+              position: 'absolute',
+              left: 4,
+              right: 4,
+              top: refY,
+              borderTopWidth: 1,
+              borderStyle: 'dashed',
+              borderTopColor: 'rgba(232,234,237,0.4)',
+            }}
+          >
+            <Text
+              style={{
+                position: 'absolute',
+                right: 0,
+                top: -13,
+                fontSize: 9,
+                color: t['text-secondary'],
+              }}
+            >
+              best {best.toFixed(2)}
+            </Text>
+          </View>
+        )}
+        {velocities.map((v, i) => (
+          <View key={i} style={{ flex: 1, maxWidth: 48, alignItems: 'center' }}>
+            <Text
+              style={{ fontSize: 12, fontWeight: '800', color: t['text-primary'], marginBottom: 4 }}
+            >
+              {v.toFixed(2)}
+            </Text>
+            <View
+              style={{
+                width: '100%',
+                minHeight: 4,
+                height: Math.max((v / scale) * chartHeight * 0.94, 4),
+                backgroundColor: zoneColor(v),
+                borderTopLeftRadius: 5,
+                borderTopRightRadius: 5,
+              }}
+            />
+          </View>
+        ))}
+        {Array.from({ length: Math.max(0, targetReps - velocities.length) }, (_, k) => (
+          <View key={`p${k}`} style={{ flex: 1, maxWidth: 48, alignItems: 'center' }}>
+            <View
+              style={{
+                width: '100%',
+                height: 6,
+                borderWidth: 1,
+                borderStyle: 'dashed',
+                borderColor: '#33363d',
+              }}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+const meta: Meta<typeof HeroVelocityBarsSpecimen> = {
+  title: 'Lab/Candidates/R2Live/HeroVelocityBars',
+  component: HeroVelocityBarsSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Full-height ' +
+          'per-rep velocity bars for the wall glance, zone-colored, with a running-best reference ' +
+          'line and dashed pending-rep placeholders. Candidate titan `VelocityStrip` "hero" variant — ' +
+          'the real component cannot stretch to these proportions. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof HeroVelocityBarsSpecimen>
+
+export const MidSet: Story = {
+  args: { velocities: [0.61, 0.58, 0.55], targetReps: 8 },
+}
+export const NearComplete: Story = {
+  args: { velocities: [0.62, 0.6, 0.57, 0.54, 0.52, 0.5, 0.47], targetReps: 8 },
+}
+export const FatigueDecline: Story = {
+  args: { velocities: [0.63, 0.6, 0.55, 0.5, 0.44, 0.38, 0.33, 0.29], targetReps: 8 },
+}

--- a/packages/ui/src/components/custom/Workout/candidates/r2/LiveAuraFrame.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/LiveAuraFrame.r2.candidate.stories.tsx
@@ -1,0 +1,94 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// background treatment (voltras-mcp, branch feat/VMCP-r2-react-harness). The
+// `r2aura` pulse keyframe is stripped (shown as its "on" frame) — this shows
+// the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/views-live.tsx (`aura-${aura}` on `.r2-live`)
+//           + r2.css `.r2-live.aura-amber` / `.aura-red` / `@keyframes r2aura`
+// Rating:   Low (background treatment, not a standalone widget) · titan equiv: none
+// Why:      The shipped `auraFor()` background wash (radial gradient, amber at VL20 / red +
+//           1.3s pulse at VL28) is the SAME mechanism the fable drill-down-pass Direction B
+//           ("sticky hero lane" color-flood border+glow) and Direction C (V3 header
+//           color-flood) both proposed independently for signaling fatigue state at a glance —
+//           R2 shipped a page-background version; B/C proposed a card-border version. Included
+//           here as the one fable "color-flood" concept with real shipped code to port
+//           faithfully; the border+glow card treatment itself has no implementation yet (see
+//           audit doc for that gap).
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, type ViewStyle } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+type Aura = '' | 'amber' | 'red'
+
+const AURA_BG: Record<Aura, string> = {
+  '': 'transparent',
+  amber: 'radial-gradient(130% 95% at 50% 0%, rgba(255,176,32,0.12), transparent 62%)',
+  red: 'radial-gradient(130% 95% at 50% 0%, rgba(209,67,67,0.18), transparent 62%)',
+}
+
+/** Static faithful re-render of R2's live-view background aura wash. */
+function LiveAuraFrameSpecimen({ aura }: { aura: Aura }) {
+  return (
+    <View
+      style={
+        {
+          width: 420,
+          height: 200,
+          borderRadius: 10,
+          padding: 18,
+          backgroundColor: t['background-base'],
+          // react-native-web renders backgroundImage at runtime; not in RN ViewStyle types
+          backgroundImage: AURA_BG[aura],
+          borderWidth: 1,
+          borderColor: t['border-default'],
+        } as ViewStyle
+      }
+    >
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '800',
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          color: t['text-tertiary'],
+        }}
+      >
+        Cable Row · Set 4/5
+      </Text>
+      <Text style={{ marginTop: 8, fontSize: 12, color: t['text-secondary'] }}>
+        {aura === 'red'
+          ? 'aura: red — VL28+, pulses 1.3s'
+          : aura === 'amber'
+            ? 'aura: amber — VL20 threshold reached'
+            : 'aura: none — productive, quiet background'}
+      </Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof LiveAuraFrameSpecimen> = {
+  title: 'Lab/Candidates/R2Live/LiveAuraFrame',
+  component: LiveAuraFrameSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). The live-view ' +
+          'background wash that floods amber at VL20 and pulses red at VL28 — a fable-mined ' +
+          '"color-flood" fatigue signal (Direction B/C both proposed it as a card border+glow; ' +
+          'R2 shipped it as a page background). No titan equivalent. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof LiveAuraFrameSpecimen>
+
+export const Productive: Story = { args: { aura: '' } }
+export const AmberThreshold: Story = { args: { aura: 'amber' } }
+export const RedStop: Story = { args: { aura: 'red' } }

--- a/packages/ui/src/components/custom/Workout/candidates/r2/PinnedLiveStrip.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/PinnedLiveStrip.r2.candidate.stories.tsx
@@ -1,0 +1,166 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). The real
+// `VelocityStrip` mini variant is stood in with a simplified bar row to keep
+// this specimen self-contained — this shows the LOOK only.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/strip.tsx + r2.css `.r2-strip`
+// Rating:   High · titan equiv: none as a composite; it wraps the real `VelocityStrip` (mini) +
+//           `Metric` in a sticky top bar, a shell titan does not have
+// Why:      Keeps the live set visible whenever the operator walks away from the Live view —
+//           the "persistent live strip bridges passive and interactive" mechanism, traced
+//           directly to fable Direction D's glance-overlay brief (the strip that survives
+//           behind any drill/overlay).
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, Pressable } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+function miniBarColor(v: number): string {
+  if (v >= 0.75) return '#2ed573'
+  if (v >= 0.5) return '#ffd43b'
+  if (v >= 0.3) return '#ffa502'
+  return '#ff4757'
+}
+
+/** Static faithful re-render of the R2 PinnedLiveStrip — sticky live/rest keeper bar. */
+function PinnedLiveStripSpecimen({
+  reps,
+  targetReps,
+  exerciseName,
+  setLabel,
+  resting,
+  restLabel,
+}: {
+  reps: number[]
+  targetReps: number
+  exerciseName: string
+  setLabel: string
+  resting: boolean
+  restLabel: string
+}) {
+  const mean = reps.length ? reps.reduce((a, b) => a + b, 0) / reps.length : 0
+  return (
+    <View
+      style={{
+        height: 44,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        paddingHorizontal: 14,
+        backgroundColor: t['surface-elevated'],
+        borderBottomWidth: 1,
+        borderBottomColor: t['border-strong'],
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 7 }}>
+        <View
+          style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: t['status-success'] }}
+        />
+        <Text
+          style={{
+            fontSize: 11,
+            fontWeight: '800',
+            textTransform: 'uppercase',
+            color: t['status-success'],
+          }}
+        >
+          {resting ? 'Resting' : 'Live'}
+        </Text>
+      </View>
+      <Text style={{ fontSize: 12, fontWeight: '700', color: t['text-primary'] }}>
+        {exerciseName} · {setLabel}
+      </Text>
+      {resting ? (
+        <Text
+          style={{
+            fontFamily: 'ui-monospace, monospace',
+            fontSize: 15,
+            fontWeight: '800',
+            color: t['brand-primary'],
+          }}
+        >
+          {restLabel}
+        </Text>
+      ) : (
+        <>
+          <View>
+            <Text style={{ fontSize: 13, fontWeight: '800', color: t['text-primary'] }}>
+              {reps.length}/{targetReps}
+            </Text>
+            <Text style={{ fontSize: 8, color: t['text-tertiary'] }}>Rep</Text>
+          </View>
+          <View>
+            <Text style={{ fontSize: 13, fontWeight: '800', color: t['text-primary'] }}>
+              {mean.toFixed(2)} m/s
+            </Text>
+            <Text style={{ fontSize: 8, color: t['text-tertiary'] }}>Mean con</Text>
+          </View>
+          <View
+            style={{ flexDirection: 'row', alignItems: 'flex-end', gap: 2, width: 120, height: 22 }}
+          >
+            {reps.map((v, i) => (
+              <View
+                key={i}
+                style={{
+                  flex: 1,
+                  height: Math.max(4, v * 24),
+                  backgroundColor: miniBarColor(v),
+                  borderRadius: 1,
+                }}
+              />
+            ))}
+          </View>
+        </>
+      )}
+      <Pressable style={{ marginLeft: 'auto' }} onPress={() => {}}>
+        <Text style={{ fontSize: 11, fontWeight: '800', color: t['brand-primary'] }}>
+          return to Live ▸
+        </Text>
+      </Pressable>
+    </View>
+  )
+}
+
+const meta: Meta<typeof PinnedLiveStripSpecimen> = {
+  title: 'Lab/Candidates/R2Live/PinnedLiveStrip',
+  component: PinnedLiveStripSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Sticky top bar ' +
+          'that pins the running set whenever the operator navigates away from Live — composes ' +
+          'the real `VelocityStrip` mini + `Metric` in-app. No titan shell equivalent. ' +
+          'Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof PinnedLiveStripSpecimen>
+
+export const LiveMidSet: Story = {
+  args: {
+    reps: [0.61, 0.58, 0.52],
+    targetReps: 8,
+    exerciseName: 'Cable Row',
+    setLabel: 'Set 4/5',
+    resting: false,
+    restLabel: '',
+  },
+}
+export const RestingBetweenSets: Story = {
+  args: {
+    reps: [],
+    targetReps: 8,
+    exerciseName: 'Cable Row',
+    setLabel: 'Set 4/5',
+    resting: true,
+    restLabel: '1:42',
+  },
+}

--- a/packages/ui/src/components/custom/Workout/candidates/r2/RestRing.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/RestRing.r2.candidate.stories.tsx
@@ -1,0 +1,105 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). The live
+// countdown tick is stripped — this shows the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/restring.tsx + r2.css `.r2-restring`
+// Rating:   High · titan equiv: RestTimer (compact linear bar) + the mobile CircularTimer
+//           candidate (elapsed/target countdown w/ overshoot) — a related but distinct shape
+// Why:      "Beautiful timer": a large SVG ring countdown with the remaining seconds as the
+//           center numeral — Direction C's wall-hero rest treatment, sized for the across-room
+//           glance. `RestTimer` cannot take this form.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import Svg, { Circle } from 'react-native-svg'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+/** Static faithful re-render of the R2 RestRing — large countdown ring, no live tick. */
+function RestRingSpecimen({
+  totalSeconds,
+  elapsedMs,
+  size = 180,
+}: {
+  totalSeconds: number
+  elapsedMs: number
+  size?: number
+}) {
+  const remaining = Math.max(0, totalSeconds - Math.floor(elapsedMs / 1000))
+  const frac = totalSeconds > 0 ? remaining / totalSeconds : 0
+  const strokeWidth = 8
+  const r = size / 2 - strokeWidth
+  const circ = 2 * Math.PI * r
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
+      <Svg width={size} height={size} style={{ position: 'absolute' }}>
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="#20232a"
+          strokeWidth={strokeWidth}
+        />
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={t['brand-primary']}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circ}
+          strokeDashoffset={circ * (1 - frac)}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      </Svg>
+      <Text
+        style={{
+          fontSize: size * 0.26,
+          fontWeight: '800',
+          letterSpacing: -1,
+          color: t['text-primary'],
+        }}
+      >
+        {remaining}
+      </Text>
+      <Text
+        style={{
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: 1.5,
+          color: t['text-secondary'],
+        }}
+      >
+        seconds
+      </Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof RestRingSpecimen> = {
+  title: 'Lab/Candidates/R2Live/RestRing',
+  component: RestRingSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Large SVG ring ' +
+          'countdown, remaining seconds as the center numeral — the wall-hero rest treatment. ' +
+          'Candidate titan `RestTimer` ring variant (the real component renders a compact linear ' +
+          'bar and cannot take this form). Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof RestRingSpecimen>
+
+export const JustStarted: Story = { args: { totalSeconds: 120, elapsedMs: 8000 } }
+export const Midway: Story = { args: { totalSeconds: 120, elapsedMs: 60000 } }
+export const AlmostDone: Story = { args: { totalSeconds: 120, elapsedMs: 112000 } }

--- a/packages/ui/src/components/custom/Workout/candidates/r2/SessionPaceTile.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/SessionPaceTile.r2.candidate.stories.tsx
@@ -1,0 +1,145 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). The toggle
+// interaction and the real `CapacityBandChart` reveal animation are stripped
+// (a simplified static mini-chart stands in) — this shows the LOOK only.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/pace.tsx + r2.css `.r2-pace`
+// Rating:   Medium · titan equiv: real `SessionHeader`'s chunked pace bar (Shell/SessionRail) —
+//           R2's tile is a MOCK derivation (no workout-analytics support yet, per component-audit
+//           §4.1) bundling volume/load/fatigue + a trim/add suggestion + a capacity trend, where
+//           SessionHeader carries a slimmer live glance
+// Why:      Session budget readout (elapsed/of-budget, progress bar) + a mocked ahead/behind
+//           trim-or-add suggestion + a capacity trend chart — every number here is a stand-in,
+//           not derived, and is labeled as such in the source.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, Pressable } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+function mmss(totalSec: number): string {
+  const m = Math.floor(totalSec / 60)
+  const s = Math.floor(totalSec % 60)
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/** Static faithful re-render of the R2 SessionPaceTile — mock session-budget readout. */
+function SessionPaceTileSpecimen({
+  elapsedSec,
+  budgetSec,
+  ahead,
+  volumePct,
+  loadLbs,
+}: {
+  elapsedSec: number
+  budgetSec: number
+  ahead: boolean
+  volumePct: number
+  loadLbs: number
+}) {
+  const pct = Math.min(100, (elapsedSec / budgetSec) * 100)
+  const fillColor = ahead ? t['status-success'] : t['status-warning']
+  return (
+    <View
+      style={{ width: 260, padding: 12, backgroundColor: t['surface-elevated'], borderRadius: 8 }}
+    >
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 6 }}>
+        <Text
+          style={{ fontSize: 10, fontWeight: '800', letterSpacing: 0.6, color: t['brand-primary'] }}
+        >
+          SESSION PACE
+        </Text>
+        <Pressable onPress={() => {}}>
+          <Text
+            style={{
+              fontSize: 8,
+              fontFamily: 'ui-monospace, monospace',
+              color: t['text-tertiary'],
+            }}
+          >
+            {ahead ? 'show behind ▸' : 'show ahead ▸'}
+          </Text>
+        </Pressable>
+      </View>
+      <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 6 }}>
+        <Text style={{ fontSize: 19, fontWeight: '800', color: t['text-primary'] }}>
+          {mmss(elapsedSec)}
+        </Text>
+        <Text style={{ fontSize: 10, color: t['text-secondary'] }}>
+          of {mmss(budgetSec)} budget
+        </Text>
+      </View>
+      <View
+        style={{
+          height: 6,
+          borderRadius: 3,
+          backgroundColor: t['background-base'],
+          marginVertical: 8,
+          overflow: 'hidden',
+        }}
+      >
+        <View style={{ width: `${pct}%`, height: '100%', backgroundColor: fillColor }} />
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}>
+        {[
+          { label: 'Volume', value: `${volumePct}%` },
+          { label: 'Load', value: `${(loadLbs / 1000).toFixed(1)}k` },
+          { label: 'Fatigue', value: 'MOD' },
+        ].map((m) => (
+          <View key={m.label}>
+            <Text style={{ fontSize: 13, fontWeight: '800', color: t['text-primary'] }}>
+              {m.value}
+            </Text>
+            <Text style={{ fontSize: 8, color: t['text-tertiary'] }}>{m.label}</Text>
+          </View>
+        ))}
+      </View>
+      <Text
+        style={{
+          fontSize: 10,
+          lineHeight: 14,
+          borderRadius: 8,
+          padding: 8,
+          color: fillColor,
+          backgroundColor: ahead ? 'rgba(20,184,166,0.1)' : 'rgba(255,176,32,0.12)',
+          borderWidth: 1,
+          borderColor: ahead ? 'rgba(20,184,166,0.3)' : 'rgba(255,176,32,0.35)',
+        }}
+      >
+        {ahead
+          ? '＋ Ahead of pace — ~7 min headroom. Room to add a Cable Fly drop-set.'
+          : '▲ Behind pace — ~9 min over budget at this rate. Drop Face Pull to 2 sets to finish on time.'}
+      </Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof SessionPaceTileSpecimen> = {
+  title: 'Lab/Candidates/R2Live/SessionPaceTile',
+  component: SessionPaceTileSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Mock ' +
+          'session-budget readout — elapsed/budget, volume/load/fatigue tiles, and a ' +
+          'trim-or-add pacing suggestion. Every number is a stand-in (no workout-analytics ' +
+          'derivation exists yet). Compare against the real `SessionHeader` pace glance. ' +
+          'Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof SessionPaceTileSpecimen>
+
+export const AheadOfPace: Story = {
+  args: { elapsedSec: 1450, budgetSec: 3120, ahead: true, volumePct: 62, loadLbs: 8400 },
+}
+export const BehindPace: Story = {
+  args: { elapsedSec: 2380, budgetSec: 3120, ahead: false, volumePct: 71, loadLbs: 11200 },
+}

--- a/packages/ui/src/components/custom/Workout/candidates/r2/SessionRailHeader.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/SessionRailHeader.r2.candidate.stories.tsx
@@ -1,0 +1,154 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). This isolates
+// R2's NET-NEW rail chrome only — the rail's item list itself is the REAL
+// titan `ExerciseCard` (already in Storybook, not re-ported here). Shows the
+// LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/rail.tsx (SessionRail head + live-pending row)
+//           + r2.css `.r2-rail-head`, `.r2-rail-pending`
+// Rating:   Medium · titan equiv: real titan `SessionRail` organism (Shell/SessionRail) — R2's
+//           header adds a live/review context dot + set-count meta that `SessionRail`'s
+//           `SessionHeader` does not carry in this exact shape
+// Why:      Context bar (live-dot + "Live session"/"Reviewing" + set meta) that frames the
+//           rail's real `ExerciseCard` list, plus the live pending-set row (`PlaceholderStrip`
+//           segments + "N/M reps" label) shown only on the in-flight exercise.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+/** Static faithful re-render of R2's SessionRail header + live-pending-set row. */
+function SessionRailHeaderSpecimen({
+  context,
+  title,
+  meta,
+  pendingReps,
+  targetReps,
+}: {
+  context: 'live' | 'review'
+  title: string
+  meta: string
+  pendingReps: number | null
+  targetReps: number
+}) {
+  return (
+    <View
+      style={{
+        width: 296,
+        backgroundColor: t['background-subtle'],
+        borderWidth: 1,
+        borderColor: t['border-default'],
+        borderRadius: 8,
+      }}
+    >
+      <View
+        style={{
+          padding: 12,
+          borderBottomWidth: 1,
+          borderBottomColor: t['border-default'],
+          gap: 2,
+        }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+          <View
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 3,
+              backgroundColor: context === 'review' ? t['status-info'] : t['status-success'],
+            }}
+          />
+          <Text
+            style={{
+              fontSize: 9,
+              fontWeight: '800',
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              color: t['text-tertiary'],
+            }}
+          >
+            {context === 'review' ? 'Reviewing · session Mar 11' : 'Live session'}
+          </Text>
+        </View>
+        <Text style={{ fontSize: 14, fontWeight: '800', color: t['text-primary'] }}>{title}</Text>
+        <Text
+          style={{
+            fontSize: 10,
+            fontFamily: 'ui-monospace, monospace',
+            color: t['text-secondary'],
+          }}
+        >
+          {meta}
+        </Text>
+      </View>
+      {pendingReps != null && (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, padding: 10 }}>
+          <View style={{ flexDirection: 'row', gap: 2 }}>
+            {Array.from({ length: targetReps }, (_, i) => (
+              <View
+                key={i}
+                style={{
+                  width: 10,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: i < pendingReps ? t['brand-primary'] : t['border-strong'],
+                }}
+              />
+            ))}
+          </View>
+          <Text
+            style={{
+              fontSize: 10,
+              fontFamily: 'ui-monospace, monospace',
+              color: t['brand-primary'],
+            }}
+          >
+            set live · {pendingReps}/{targetReps} reps
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const meta: Meta<typeof SessionRailHeaderSpecimen> = {
+  title: 'Lab/Candidates/R2Live/SessionRailHeader',
+  component: SessionRailHeaderSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "**Candidate visual specimen** (R2 dashboard harness → titan review). The rail's " +
+          'context bar (live/review dot + set meta) and the live pending-set segmented row — the ' +
+          'NET-NEW chrome that frames the real titan `ExerciseCard` list. Compare against the ' +
+          'real `SessionRail` organism. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof SessionRailHeaderSpecimen>
+
+export const LiveWithPendingSet: Story = {
+  args: {
+    context: 'live',
+    title: 'Pull A · Intensification',
+    meta: 'set 4 live',
+    pendingReps: 3,
+    targetReps: 8,
+  },
+}
+export const Reviewing: Story = {
+  args: {
+    context: 'review',
+    title: 'Pull A · Intensification',
+    meta: '22 sets · 48 min · complete',
+    pendingReps: null,
+    targetReps: 8,
+  },
+}

--- a/packages/ui/src/components/custom/Workout/candidates/r2/StatusPill.r2.candidate.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/candidates/r2/StatusPill.r2.candidate.stories.tsx
@@ -1,0 +1,96 @@
+// CANDIDATE VISUAL SPECIMEN — do not consume in app surfaces.
+//
+// A faithful *static* re-render of the R2 dashboard harness's live-view
+// subcomponent (voltras-mcp, branch feat/VMCP-r2-react-harness), ported in for
+// the component-direction review (see packages/ui/MATURITY.md). This shows
+// the LOOK only, in a still state.
+//
+// Source:   voltras-mcp/src/dashboard/spa/r2/status.tsx (StatusPill) + r2.css `.r2-status-pill`
+// Rating:   Medium · titan equiv: none (StatusDot atom is a bare dot; no pill+dot+verdict-text
+//           composite exists)
+// Why:      Human-readable auto-regulation verdict — productive / threshold / stop — driven by
+//           velocity-loss %, glowing dot + colored pill text. Read-once summary of FatigueMeter's
+//           needle position.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { getSemanticColors } from '../../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+type Level = '' | 'amber' | 'red'
+
+function auraFor(lossPct: number, repCount: number): Level {
+  if (repCount === 0) return ''
+  if (lossPct >= 28) return 'red'
+  if (lossPct >= 20) return 'amber'
+  return ''
+}
+
+const LEVEL_COLOR: Record<Level, string> = {
+  '': t['status-success'],
+  amber: t['status-warning'],
+  red: t['status-error'],
+}
+const LEVEL_BG: Record<Level, string> = {
+  '': 'rgba(20,184,166,0.13)',
+  amber: 'rgba(255,176,32,0.14)',
+  red: 'rgba(209,67,67,0.16)',
+}
+const LEVEL_BORDER: Record<Level, string> = {
+  '': 'rgba(20,184,166,0.35)',
+  amber: 'rgba(255,176,32,0.4)',
+  red: 'rgba(209,67,67,0.45)',
+}
+
+/** Static faithful re-render of the R2 StatusPill — auto-reg verdict pill. */
+function StatusPillSpecimen({ lossPct, repCount }: { lossPct: number; repCount: number }) {
+  const level = auraFor(lossPct, repCount)
+  const color = LEVEL_COLOR[level]
+  const text =
+    level === 'red'
+      ? `Stop · velocity loss ${Math.round(lossPct)}%`
+      : level === 'amber'
+        ? 'Threshold · VL20 reached'
+        : 'Productive · in the band'
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 7,
+        alignSelf: 'flex-start',
+        paddingVertical: 7,
+        paddingHorizontal: 13,
+        borderRadius: 9,
+        backgroundColor: LEVEL_BG[level],
+        borderWidth: 1,
+        borderColor: LEVEL_BORDER[level],
+      }}
+    >
+      <View style={{ width: 9, height: 9, borderRadius: 5, backgroundColor: color }} />
+      <Text style={{ fontSize: 13, fontWeight: '800', color }}>{text}</Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof StatusPillSpecimen> = {
+  title: 'Lab/Candidates/R2Live/StatusPill',
+  component: StatusPillSpecimen,
+  tags: ['status:candidate', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Candidate visual specimen** (R2 dashboard harness → titan review). Auto-regulation ' +
+          'verdict pill — productive / threshold / stop — glowing dot + colored text, driven by ' +
+          'velocity-loss %. No titan equivalent composite exists. Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof StatusPillSpecimen>
+
+export const Productive: Story = { args: { lossPct: 8, repCount: 3 } }
+export const Threshold: Story = { args: { lossPct: 21, repCount: 6 } }
+export const Stop: Story = { args: { lossPct: 31, repCount: 8 } }

--- a/packages/ui/src/components/custom/Workout/lab/S4Drawer.lab.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/lab/S4Drawer.lab.stories.tsx
@@ -1,0 +1,304 @@
+// LAB EXPLORATION — do not consume in app surfaces.
+//
+// Candidate design directions for shell unit S4 (overlay/drawer system): the
+// scrim + right drawer that hosts drill-ins from any view, with a bottom-sheet
+// form on phone. Net-new — no mobile source; composes the S1–S3 shell visual
+// language (charcoal surfaces, orange brand accent, mono micro-labels). Static:
+// scrim + drawer are shown permanently open, no animation/gesture/backdrop-press
+// wiring.
+//
+// Spec:    coordination/design-explorations/DASHBOARD-DECOMPOSITION.md (S4 row)
+// Rating:  Exploration · titan equiv: none (first drawer/overlay primitive)
+// Why:     Two structural questions compete: drawer WIDTH/density (a wide
+//          detail drill-in vs a narrow quick-action panel) and FORM FACTOR
+//          (right-anchored panel on tablet/wall vs bottom sheet on phone).
+//          Static specimen.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, Pressable } from 'react-native'
+import { getSemanticColors } from '../../../../theme/tokens/semantic'
+import { alpha } from '../../../../utils/colors'
+
+const t = getSemanticColors('dark')
+
+interface DrawerRow {
+  title: string
+  subtitle?: string
+}
+
+/** Simplified shell backdrop (rail + topbar + content blocks) so the scrim reads as "over the app". */
+function BackdropSpecimen() {
+  return (
+    <View style={{ flex: 1, flexDirection: 'row', backgroundColor: t['surface-base'] }}>
+      <View
+        style={{
+          width: 46,
+          backgroundColor: t['surface-elevated'],
+          borderRightWidth: 1,
+          borderRightColor: t['border-default'],
+        }}
+      />
+      <View style={{ flex: 1 }}>
+        <View
+          style={{
+            height: 40,
+            backgroundColor: t['surface-elevated'],
+            borderBottomWidth: 1,
+            borderBottomColor: t['border-default'],
+          }}
+        />
+        <View style={{ flex: 1, padding: 16, gap: 10 }}>
+          {[0, 1, 2].map((i) => (
+            <View
+              key={i}
+              style={{ height: 56, borderRadius: 10, backgroundColor: t['surface-raised'] }}
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+/** Static faithful re-render of the S4 drawer direction: scrim + a right panel or bottom sheet. */
+function ShellDrawerSpecimen({
+  stageWidth,
+  stageHeight,
+  anchor,
+  drawerSize,
+  density,
+  headerTitle,
+  headerSubtitle,
+  rows,
+  actionLabel,
+}: {
+  stageWidth: number
+  stageHeight: number
+  anchor: 'right' | 'bottom'
+  drawerSize: number
+  density: 'compact' | 'full'
+  headerTitle: string
+  headerSubtitle?: string
+  rows: DrawerRow[]
+  actionLabel?: string
+}) {
+  const pad = density === 'compact' ? 12 : 20
+  const panelStyle =
+    anchor === 'right'
+      ? {
+          position: 'absolute' as const,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: drawerSize,
+          backgroundColor: t['surface-elevated'],
+          borderLeftWidth: 1,
+          borderLeftColor: t['border-prominent'],
+          padding: pad,
+          gap: 12,
+          shadowColor: '#000',
+          shadowOpacity: 0.45,
+          shadowRadius: 18,
+          shadowOffset: { width: -6, height: 0 },
+        }
+      : {
+          position: 'absolute' as const,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: drawerSize,
+          backgroundColor: t['surface-elevated'],
+          borderTopLeftRadius: 20,
+          borderTopRightRadius: 20,
+          borderTopWidth: 1,
+          borderTopColor: t['border-prominent'],
+          padding: pad,
+          gap: 12,
+        }
+
+  return (
+    <View
+      style={{
+        width: stageWidth,
+        height: stageHeight,
+        borderRadius: 10,
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <BackdropSpecimen />
+      <View
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: alpha('#000000', 0.55),
+        }}
+      />
+      <View style={panelStyle}>
+        {anchor === 'bottom' ? (
+          <View style={{ alignItems: 'center', marginBottom: 4 }}>
+            <View
+              style={{
+                width: 36,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: t['border-prominent'],
+              }}
+            />
+          </View>
+        ) : null}
+
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+          }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                fontSize: density === 'compact' ? 14 : 17,
+                fontWeight: '700',
+                color: t['text-primary'],
+              }}
+            >
+              {headerTitle}
+            </Text>
+            {headerSubtitle ? (
+              <Text style={{ fontSize: 11, color: t['text-tertiary'], marginTop: 2 }}>
+                {headerSubtitle}
+              </Text>
+            ) : null}
+          </View>
+          <Pressable onPress={() => {}}>
+            <Text style={{ fontSize: 16, color: t['text-tertiary'] }}>✕</Text>
+          </Pressable>
+        </View>
+
+        <View style={{ gap: density === 'compact' ? 6 : 10 }}>
+          {rows.map((row, i) => (
+            <Pressable
+              key={i}
+              onPress={() => {}}
+              style={{
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: t['border-default'],
+                backgroundColor: t['surface-raised'],
+                paddingVertical: density === 'compact' ? 8 : 12,
+                paddingHorizontal: 12,
+              }}
+            >
+              <Text style={{ fontSize: 13, fontWeight: '600', color: t['text-primary'] }}>
+                {row.title}
+              </Text>
+              {row.subtitle ? (
+                <Text style={{ fontSize: 11, color: t['text-tertiary'], marginTop: 2 }}>
+                  {row.subtitle}
+                </Text>
+              ) : null}
+            </Pressable>
+          ))}
+        </View>
+
+        {actionLabel ? (
+          <Pressable
+            onPress={() => {}}
+            style={{
+              marginTop: 'auto',
+              borderRadius: 10,
+              backgroundColor: t['brand-primary'],
+              paddingVertical: 12,
+              alignItems: 'center',
+            }}
+          >
+            <Text style={{ fontSize: 13, fontWeight: '700', color: t['text-inverse'] }}>
+              {actionLabel}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  )
+}
+
+const meta: Meta<typeof ShellDrawerSpecimen> = {
+  title: 'Lab/Explorations/S4-Drawer',
+  component: ShellDrawerSpecimen,
+  tags: ['status:lab', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Lab exploration** — candidate directions for shell unit S4 (overlay/drawer system): ' +
+          'scrim + right drawer for drill-ins from any view, bottom-sheet form on phone. Three ' +
+          'directions vary width/density and form factor. titan has no drawer/overlay primitive yet. ' +
+          'Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof ShellDrawerSpecimen>
+
+/** Wide right drawer — full exercise drill-in detail (tablet/wall). */
+export const TabletDrawerWide: Story = {
+  args: {
+    stageWidth: 640,
+    stageHeight: 400,
+    anchor: 'right',
+    drawerSize: 420,
+    density: 'full',
+    headerTitle: 'Bulgarian Split Squat',
+    headerSubtitle: 'Set 3 of 4 · 185 lb · RPE 8',
+    rows: [
+      { title: 'Set 1', subtitle: '8 reps · 0.71 m/s mean con' },
+      { title: 'Set 2', subtitle: '8 reps · 0.68 m/s mean con' },
+      { title: 'Set 3 (current)', subtitle: '6 reps so far · 0.61 m/s mean con' },
+      { title: 'Set 4', subtitle: 'not started' },
+    ],
+    actionLabel: 'Log Set Note',
+  },
+}
+
+/** Narrow right drawer — a quick-action panel (density test against the wide direction). */
+export const TabletDrawerCompact: Story = {
+  args: {
+    stageWidth: 640,
+    stageHeight: 400,
+    anchor: 'right',
+    drawerSize: 280,
+    density: 'compact',
+    headerTitle: 'Swap Exercise',
+    headerSubtitle: 'Quad-dominant alternatives',
+    rows: [
+      { title: 'Leg Press' },
+      { title: 'Walking Lunge' },
+      { title: 'Cable Step-Up' },
+      { title: 'Goblet Squat' },
+    ],
+    actionLabel: 'Confirm Swap',
+  },
+}
+
+/** Bottom-sheet form on phone — quick-note capture, rounded top + drag handle. */
+export const PhoneBottomSheet: Story = {
+  args: {
+    stageWidth: 360,
+    stageHeight: 600,
+    anchor: 'bottom',
+    drawerSize: 320,
+    density: 'full',
+    headerTitle: 'Add Set Note',
+    headerSubtitle: 'Set 3 · Bulgarian Split Squat',
+    rows: [
+      { title: 'Felt strong' },
+      { title: 'Left knee twinge' },
+      { title: 'Reduce load next set' },
+    ],
+    actionLabel: 'Save Note',
+  },
+}

--- a/packages/ui/src/components/custom/Workout/lab/S5LiveStrip.lab.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/lab/S5LiveStrip.lab.stories.tsx
@@ -1,0 +1,312 @@
+// LAB EXPLORATION — do not consume in app surfaces.
+//
+// Candidate design directions for shell unit S5 (pinned Live strip): the
+// off-Live anchor that live-updates rep/mean while the operator is on another
+// view, plus a "return to Live" affordance. Net-new — no mobile source (R2
+// harness `strip.tsx` seeded the concept: real VelocityStrip `mini` + Metric);
+// this specimen composes the S1–S3 shell visual language locally (charcoal
+// surfaces, brand-orange accent, mono micro-labels). Static: velocity bars and
+// the "LIVE" dot are drawn in a fixed still state, no live-tick/reanimated wiring.
+//
+// Spec:    coordination/design-explorations/DASHBOARD-DECOMPOSITION.md (S5 row)
+// Rating:  Exploration · titan equiv: none (first pinned-anchor primitive)
+// Why:     Two open questions: WHERE it pins (top band vs a floating bottom
+//          capsule) and how much it shows (compact rep/mean vs expanded with
+//          loss% + taller bars). Static specimen.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text, Pressable } from 'react-native'
+import { getSemanticColors } from '../../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+/** Same 4-band velocity scale as VelocityStrip's default path, via titan tokens. */
+function velocityColor(v: number): string {
+  if (v >= 1.0) return t['status-live']
+  if (v >= 0.75) return t['status-warning']
+  if (v >= 0.5) return t['brand-primary']
+  return t['status-error']
+}
+
+/** A VelocityStrip-`mini`-style bar row: per-rep bars, height ∝ velocity. */
+function MiniVelocityBars({ velocities, height = 16 }: { velocities: number[]; height?: number }) {
+  const max = Math.max(...velocities, 1)
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'flex-end', gap: 2, height }}>
+      {velocities.map((v, i) => (
+        <View
+          key={i}
+          style={{
+            width: 4,
+            height: Math.max(3, (v / max) * height),
+            borderRadius: 1,
+            backgroundColor: velocityColor(v),
+          }}
+        />
+      ))}
+    </View>
+  )
+}
+
+/** A `Metric`-style stat: value(+unit) over an uppercase micro-label. */
+function MiniMetric({
+  value,
+  label,
+  unit,
+  size = 'sm',
+}: {
+  value: string
+  label: string
+  unit?: string
+  size?: 'sm' | 'md'
+}) {
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 2 }}>
+        <Text
+          style={{ fontSize: size === 'md' ? 18 : 14, fontWeight: '700', color: t['text-primary'] }}
+        >
+          {value}
+        </Text>
+        {unit ? <Text style={{ fontSize: 9, color: t['text-tertiary'] }}>{unit}</Text> : null}
+      </View>
+      <Text
+        style={{
+          fontSize: 8,
+          fontWeight: '700',
+          color: t['text-tertiary'],
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+          marginTop: 1,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  )
+}
+
+function LiveDot({ resting }: { resting?: boolean }) {
+  const color = resting ? t['status-warning'] : t['status-live']
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: color }} />
+      <Text style={{ fontSize: 10, fontWeight: '700', color, letterSpacing: 0.6 }}>
+        {resting ? 'REST' : 'LIVE'}
+      </Text>
+    </View>
+  )
+}
+
+/** Content placeholder rows behind the floating capsule, so it reads as "pinned over the view". */
+function ContentBackdrop() {
+  return (
+    <View
+      style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, padding: 16, gap: 10 }}
+    >
+      {[0, 1, 2].map((i) => (
+        <View
+          key={i}
+          style={{ height: 48, borderRadius: 10, backgroundColor: t['surface-raised'] }}
+        />
+      ))}
+    </View>
+  )
+}
+
+/** Static faithful re-render of an S5 pinned-strip direction. */
+function LiveStripSpecimen({
+  stageWidth,
+  pin,
+  density,
+  exerciseName,
+  setLabel,
+  reps,
+  targetReps,
+  meanVelocity,
+  lossPct,
+  resting,
+  restLabel,
+}: {
+  stageWidth: number
+  pin: 'top' | 'bottom-floating'
+  density: 'compact' | 'expanded'
+  exerciseName: string
+  setLabel: string
+  reps: number[]
+  targetReps: number
+  meanVelocity: number
+  lossPct?: number
+  resting?: boolean
+  restLabel?: string
+}) {
+  const barHeight = density === 'expanded' ? 28 : 16
+  const metricSize = density === 'expanded' ? 'md' : 'sm'
+
+  const content = resting ? (
+    <Text style={{ fontSize: 12, fontWeight: '600', color: t['status-warning'] }}>{restLabel}</Text>
+  ) : (
+    <View
+      style={{ flexDirection: 'row', alignItems: 'center', gap: density === 'expanded' ? 18 : 12 }}
+    >
+      <MiniMetric value={`${reps.length}/${targetReps}`} label="Rep" size={metricSize} />
+      <MiniMetric value={meanVelocity.toFixed(2)} unit="m/s" label="Mean con" size={metricSize} />
+      {density === 'expanded' && lossPct != null ? (
+        <MiniMetric value={`${lossPct}%`} label="Loss" size="md" />
+      ) : null}
+      <MiniVelocityBars velocities={reps} height={barHeight} />
+    </View>
+  )
+
+  const returnButton = (
+    <Pressable
+      onPress={() => {}}
+      style={{
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: t['brand-primary'],
+        paddingVertical: 6,
+        paddingHorizontal: 10,
+      }}
+    >
+      <Text style={{ fontSize: 11, fontWeight: '700', color: t['brand-primary'] }}>
+        Return to Live ›
+      </Text>
+    </Pressable>
+  )
+
+  if (pin === 'bottom-floating') {
+    return (
+      <View
+        style={{
+          width: stageWidth,
+          height: 260,
+          position: 'relative',
+          borderRadius: 10,
+          overflow: 'hidden',
+          backgroundColor: t['surface-base'],
+        }}
+      >
+        <ContentBackdrop />
+        <View style={{ position: 'absolute', left: 0, right: 0, bottom: 16, alignItems: 'center' }}>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 12,
+              borderRadius: 999,
+              backgroundColor: t['surface-elevated'],
+              borderWidth: 1,
+              borderColor: t['border-prominent'],
+              paddingVertical: 8,
+              paddingHorizontal: 14,
+              shadowColor: '#000',
+              shadowOpacity: 0.4,
+              shadowRadius: 12,
+              shadowOffset: { width: 0, height: 4 },
+            }}
+          >
+            <LiveDot resting={resting} />
+            {content}
+            {returnButton}
+          </View>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <View
+      style={{
+        width: stageWidth,
+        height: density === 'expanded' ? 56 : 40,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 14,
+        paddingHorizontal: 16,
+        backgroundColor: t['surface-elevated'],
+        borderBottomWidth: 1,
+        borderBottomColor: t['border-prominent'],
+      }}
+    >
+      <LiveDot resting={resting} />
+      <View style={{ flexShrink: 1 }}>
+        <Text
+          style={{ fontSize: 12, fontWeight: '600', color: t['text-primary'] }}
+          numberOfLines={1}
+        >
+          {exerciseName}
+        </Text>
+        <Text style={{ fontSize: 10, color: t['text-tertiary'] }}>{setLabel}</Text>
+      </View>
+      <View style={{ flex: 1 }} />
+      {content}
+      {returnButton}
+    </View>
+  )
+}
+
+const meta: Meta<typeof LiveStripSpecimen> = {
+  title: 'Lab/Explorations/S5-LiveStrip',
+  component: LiveStripSpecimen,
+  tags: ['status:lab', '!status:review'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Lab exploration** — candidate directions for shell unit S5 (pinned Live strip): the ' +
+          'off-Live anchor that live-updates rep/mean, composing a VelocityStrip-`mini`-style bar row ' +
+          '+ Metric-style stats + a "return to Live" affordance. Three directions vary pin location ' +
+          '(top band vs floating bottom capsule) and density (compact vs expanded). Static specimen.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof LiveStripSpecimen>
+
+/** Top-pinned, compact — mirrors the R2 harness strip: dot · name/set · rep/mean · mini bars · return. */
+export const TopStripCompact: Story = {
+  args: {
+    stageWidth: 900,
+    pin: 'top',
+    density: 'compact',
+    exerciseName: 'Cable Row',
+    setLabel: 'Set 2 of 3 · 140 lb',
+    reps: [1.12, 1.05, 0.98, 0.89, 0.81],
+    targetReps: 8,
+    meanVelocity: 0.97,
+    resting: false,
+  },
+}
+
+/** Top-pinned, expanded — taller bars + loss% for more density, and the resting sub-state. */
+export const TopStripExpandedResting: Story = {
+  args: {
+    stageWidth: 900,
+    pin: 'top',
+    density: 'expanded',
+    exerciseName: 'Cable Row',
+    setLabel: 'Set 2 of 3 · 140 lb',
+    reps: [1.12, 1.05, 0.98, 0.89, 0.81],
+    targetReps: 8,
+    meanVelocity: 0.97,
+    lossPct: 28,
+    resting: true,
+    restLabel: '0:42 rest · next: Lat Pulldown',
+  },
+}
+
+/** Floating bottom capsule — thumb-reachable on a touch surface, pinned over content. */
+export const FloatingReturnCapsule: Story = {
+  args: {
+    stageWidth: 420,
+    pin: 'bottom-floating',
+    density: 'compact',
+    exerciseName: 'Cable Row',
+    setLabel: 'Set 2 of 3',
+    reps: [1.12, 1.05, 0.98, 0.89],
+    targetReps: 8,
+    meanVelocity: 1.01,
+    resting: false,
+  },
+}


### PR DESCRIPTION
Stacked on #101 (candidate infra). Two review threads as Lab specimens.

## R2 live-page → candidates (10)
Audited the R2 react live page (`voltras-mcp` `feat/VMCP-r2-react-harness`) → `Lab/Candidates/R2Live/*`, each flagged against its pre-existing titan equivalent to compare designs:
- HeroVelocityBars (vs `VelocityStrip`) · RestRing (vs `RestTimer` + `CircularTimer` candidate) · SessionPaceTile (vs `SessionHeader` pace) · CategoricalNav (vs `SideNav`) · SessionRailHeader (vs `SessionRail`; only net-new chrome ported) · FatigueMeter (vs mobile `FatigueGauge` candidate — needle vs linear) · StatusPill · CueFlag · PinnedLiveStrip · LiveAuraFrame (no titan equiv).

**Fable mining:** the 4 drilldown directions (A/B/C/D) only ever got briefs, never built markup — so their concepts (rep-detail tooltip, breadcrumb rail, Miller-column compression, etc.) are **listed in the audit for discussion**, not fabricated as specimens. Exception: `LiveAuraFrame`, ported from R2's real shipped `aura-*` CSS.

## S4/S5 shell explorations
Design directions to discuss before building the last two Wave-1 shell units:
- `Lab/Explorations/S4-Drawer` — tablet-wide / tablet-compact / phone-bottom-sheet
- `Lab/Explorations/S5-LiveStrip` — top-compact / top-expanded-resting / floating-return-capsule

## Verification
tsc 0 · 807 stories render · eslint + prettier clean

Audit docs: `sources/deepdive-r2-live-audit.md`, `sources/s4-s5-directions.md`. Tracks VW-34 (S4/S5) + VW-35 (R2/fable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)