### PR TITLE
Build consolidated live-view components (wave 1: ZoneTrack, FatigueMeter, VolumeLandmarkBar, StatusPill, LiveAuraFrame)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-design/react-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Cross-platform design system built on Gluestack UI",
   "author": "Henry Jewkes",
   "license": "MIT",

--- a/packages/ui/src/components/custom/Workout/FatigueMeter.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.stories.tsx
@@ -1,0 +1,51 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { FatigueMeter } from './FatigueMeter'
+
+const meta: Meta<typeof FatigueMeter> = {
+  title: 'Workout/DataViz/FatigueMeter',
+  component: FatigueMeter,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: { type: 'range', min: 0, max: 40, step: 1 } },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Component.** The winning fatigue-visual lineage: a sliding needle over a fixed ' +
+          'green→gold→orange→red velocity-loss gradient with VL10/VL20/VL30/stop markers. ' +
+          'Composes the [ZoneTrack](?path=/docs/workout-dataviz-zonetrack--docs) primitive. ' +
+          'Prop-driven: `value` plus overridable `thresholds` / `max` / `zoneColors` / `labels`.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 360, padding: 20, backgroundColor: '#131313' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof FatigueMeter>
+
+/** Fresh — needle sits in the green zone. */
+export const Fresh: Story = { args: { value: 5 } }
+
+/** VL20 — needle crossing into the orange zone. */
+export const Vl20: Story = { args: { value: 21 } }
+
+/** Stop zone — deep into the red. */
+export const StopZone: Story = { args: { value: 34 } }
+
+/** Chunky wall-glanceable density via a taller track. */
+export const WallDensity: Story = { args: { value: 21, trackHeight: 22 } }
+
+/** Custom scale — a tighter 0..30 domain with earlier thresholds. */
+export const CustomScale: Story = {
+  args: { value: 12, max: 30, thresholds: [8, 16, 24], labels: ['ok', 'w1', 'w2', 'w3', 'max'] },
+}

--- a/packages/ui/src/components/custom/Workout/FatigueMeter.test.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { FatigueMeter } from './FatigueMeter'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const { green, red } = WORKOUT_TOKENS.scale
+
+describe('FatigueMeter', () => {
+  it('renders the four fatigue zone bands', () => {
+    render(<FatigueMeter value={0} />)
+    expect(screen.getAllByTestId('zone-track-band')).toHaveLength(4)
+  })
+
+  it('colours the bands from the canonical effort scale', () => {
+    render(<FatigueMeter value={0} />)
+    const bands = screen.getAllByTestId('zone-track-band')
+    expect(bands[0]).toHaveStyle({ backgroundColor: green })
+    expect(bands[3]).toHaveStyle({ backgroundColor: red })
+  })
+
+  it('renders the default VL scale labels', () => {
+    render(<FatigueMeter value={0} />)
+    for (const label of ['fresh', 'VL10', 'VL20', 'VL30', 'stop']) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it('positions the needle at the value on the 0..40 loss scale', () => {
+    render(<FatigueMeter value={20} />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ left: '50%' })
+  })
+
+  it('clamps a value beyond the stop end to the track end', () => {
+    render(<FatigueMeter value={60} />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ left: '100%' })
+  })
+
+  it('reshapes the zones from custom thresholds + max', () => {
+    render(<FatigueMeter value={5} max={20} thresholds={[5, 10, 15]} />)
+    const bands = screen.getAllByTestId('zone-track-band')
+    expect(bands[0]).toHaveStyle({ flexGrow: 5 })
+    expect(bands[3]).toHaveStyle({ flexGrow: 5 })
+  })
+
+  it('honours custom labels', () => {
+    render(<FatigueMeter value={5} labels={['A', 'B', 'C', 'D', 'E']} />)
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('E')).toBeInTheDocument()
+  })
+
+  it('honours a needle colour override', () => {
+    render(<FatigueMeter value={10} needleColor="#FF00FF" />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ backgroundColor: '#FF00FF' })
+  })
+
+  // RNW does not map accessibilityValue → aria-valuenow under jsdom (gotcha #11), so the
+  // loss value is verified via the needle position + the accessible name.
+  it('exposes the progressbar role with the loss value in its accessible name', () => {
+    render(<FatigueMeter value={17} />)
+    expect(
+      screen.getByRole('progressbar', { name: 'Fatigue: 17% velocity loss' })
+    ).toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<FatigueMeter value={21} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/FatigueMeter.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.tsx
@@ -1,0 +1,82 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import type { ViewProps } from 'react-native'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { ZoneTrack, type ZoneTrackZone, type ZoneTrackTick } from './ZoneTrack'
+
+const { green, yellow, orange, red } = WORKOUT_TOKENS.scale
+
+/** Canonical fatigue band colours (fresh → stop) — the even effort-scale hue walk. */
+const DEFAULT_ZONE_COLORS: [string, string, string, string] = [green, yellow, orange, red]
+/** Zone boundaries in velocity-loss %, matching the VL10/VL20/VL30 coaching cues. */
+const DEFAULT_THRESHOLDS: [number, number, number] = [10, 20, 30]
+/** Scale labels at [min, ...thresholds, max]. */
+const DEFAULT_LABELS = ['fresh', 'VL10', 'VL20', 'VL30', 'stop']
+const DEFAULT_MAX = 40
+
+export interface FatigueMeterProps extends ViewProps {
+  /** Current velocity-loss percentage (0 = fresh). Drives the needle position. */
+  value: number
+  /** Upper bound of the fatigue scale — the "stop" end, in loss %. Default 40. */
+  max?: number
+  /** Zone boundary thresholds (loss %): green→gold, gold→orange, orange→red. Default [10,20,30]. */
+  thresholds?: [number, number, number]
+  /** Zone band colours low→high (fresh→stop). Default the canonical effort scale. */
+  zoneColors?: [string, string, string, string]
+  /** Tick labels at [min, ...thresholds, max]. Default ['fresh','VL10','VL20','VL30','stop']. */
+  labels?: string[]
+  /** Track height in px. Default 14. */
+  trackHeight?: number
+  /** Needle colour. Default white. */
+  needleColor?: string
+  className?: string
+}
+
+/**
+ * A fatigue meter: a sliding needle over a fixed green→gold→orange→red velocity-loss
+ * gradient with VL10/VL20/VL30/stop scale markers. This is the winning fatigue-visual
+ * lineage (needle-over-zoned-gradient, three independent sources agreed) — it composes
+ * the shared {@link ZoneTrack} primitive, supplying the fatigue domain, zone bands from
+ * the effort-scale tokens, and the coaching-cue tick labels. Prop-driven: `value` plus
+ * overridable `thresholds` / `max` / `zoneColors` / `labels`.
+ *
+ * @example
+ * <FatigueMeter value={21} />           // needle in the VL20 (orange) zone
+ * <FatigueMeter value={8} max={40} thresholds={[10, 20, 30]} />
+ */
+export function FatigueMeter({
+  value,
+  max = DEFAULT_MAX,
+  thresholds = DEFAULT_THRESHOLDS,
+  zoneColors = DEFAULT_ZONE_COLORS,
+  labels = DEFAULT_LABELS,
+  trackHeight = 14,
+  needleColor,
+  className,
+  ...props
+}: FatigueMeterProps) {
+  const [t1, t2, t3] = thresholds
+  const zones: ZoneTrackZone[] = [
+    { upTo: t1, color: zoneColors[0] },
+    { upTo: t2, color: zoneColors[1] },
+    { upTo: t3, color: zoneColors[2] },
+    { upTo: max, color: zoneColors[3] },
+  ]
+
+  const tickValues = [0, t1, t2, t3, max]
+  const ticks: ZoneTrackTick[] = tickValues.map((v, i) => ({ value: v, label: labels[i] }))
+
+  return (
+    <ZoneTrack
+      className={className}
+      zones={zones}
+      min={0}
+      max={max}
+      trackHeight={trackHeight}
+      ticks={ticks}
+      marker={{ type: 'needle', value, color: needleColor }}
+      accessibilityLabel={`Fatigue: ${value}% velocity loss`}
+      testID="fatigue-meter"
+      {...props}
+    />
+  )
+}

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.stories.tsx
@@ -5,36 +5,88 @@ import { getSemanticColors } from '../../../theme/tokens/semantic'
 
 const t = getSemanticColors('dark')
 
-function AuraContent({ caption }: { caption: string }) {
+/** A representative live-workout hero so the full-surface flood reads against real content. */
+function LiveHero({ caption }: { caption: string }) {
   return (
-    <View style={{ padding: 18 }}>
-      <Text
-        style={{
-          fontSize: 11,
-          fontWeight: '800',
-          letterSpacing: 1,
-          textTransform: 'uppercase',
-          color: t['text-tertiary'],
-        }}
-      >
-        Cable Row · Set 4/5
-      </Text>
-      <Text style={{ marginTop: 8, fontSize: 12, color: t['text-secondary'] }}>{caption}</Text>
+    <View style={{ flex: 1, padding: 24, justifyContent: 'space-between' }}>
+      <View>
+        <Text
+          style={{
+            fontSize: 11,
+            fontWeight: '800',
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            color: t['text-tertiary'],
+          }}
+        >
+          Cable Row · Set 4 / 5
+        </Text>
+      </View>
+
+      <View style={{ alignItems: 'center' }}>
+        <Text
+          style={{ fontSize: 96, fontWeight: '800', lineHeight: 100, color: t['text-primary'] }}
+        >
+          8
+        </Text>
+        <Text
+          style={{
+            fontSize: 12,
+            letterSpacing: 2,
+            textTransform: 'uppercase',
+            color: t['text-tertiary'],
+          }}
+        >
+          reps
+        </Text>
+      </View>
+
+      <View>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 }}>
+          {[
+            ['0.42', 'm/s'],
+            ['8.5', 'RPE'],
+            ['−18%', 'vel loss'],
+          ].map(([v, l]) => (
+            <View key={l} style={{ alignItems: 'center' }}>
+              <Text style={{ fontSize: 20, fontWeight: '700', color: t['text-primary'] }}>{v}</Text>
+              <Text
+                style={{
+                  fontSize: 9,
+                  letterSpacing: 1,
+                  textTransform: 'uppercase',
+                  color: t['text-tertiary'],
+                }}
+              >
+                {l}
+              </Text>
+            </View>
+          ))}
+        </View>
+        <Text style={{ fontSize: 12, color: t['text-secondary'], textAlign: 'center' }}>
+          {caption}
+        </Text>
+      </View>
     </View>
   )
 }
+
+const PANEL = { width: 360, height: 620, borderRadius: 24, overflow: 'hidden' as const }
 
 const meta: Meta<typeof LiveAuraFrame> = {
   title: 'Workout/LiveAuraFrame',
   component: LiveAuraFrame,
   tags: ['autodocs'],
   parameters: {
+    layout: 'fullscreen',
     docs: {
       description: {
         component:
           'Full-surface color-flood frame tied to a coaching category. Wraps content on a charcoal ' +
           'base and layers a radial wash — amber at threshold (VL20), red at stop (VL28+, pulsing) — ' +
-          'derived from the semantic warning / error tokens via `alpha()`. Children pass through.',
+          'derived from the semantic warning / error tokens via `alpha()`. Children pass through. ' +
+          'Rendered here at live-screen size so the flood reads (it is meant to tint a whole panel, ' +
+          'not a card).',
       },
     },
   },
@@ -44,20 +96,32 @@ const meta: Meta<typeof LiveAuraFrame> = {
       options: ['productive', 'threshold', 'stop'],
       description: 'Coaching-category flood level',
     },
-    pulse: {
-      control: 'boolean',
-      description: 'Pulse the flood on stop',
-    },
+    pulse: { control: 'boolean', description: 'Pulse the flood on stop' },
   },
+  decorators: [
+    (Story) => (
+      <View
+        style={{
+          minHeight: 700,
+          backgroundColor: '#070707',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 32,
+        }}
+      >
+        <Story />
+      </View>
+    ),
+  ],
   render: (args) => (
-    <LiveAuraFrame {...args} style={{ width: 420 }}>
-      <AuraContent
+    <LiveAuraFrame {...args} style={PANEL}>
+      <LiveHero
         caption={
           args.category === 'stop'
-            ? 'aura: red — VL28+, pulses'
+            ? 'red flood — VL28+, stop the set'
             : args.category === 'threshold'
-              ? 'aura: amber — VL20 threshold reached'
-              : 'aura: none — productive, quiet background'
+              ? 'amber flood — VL20 threshold reached'
+              : 'no flood — productive, quiet background'
         }
       />
     </LiveAuraFrame>
@@ -67,29 +131,22 @@ const meta: Meta<typeof LiveAuraFrame> = {
 export default meta
 type Story = StoryObj<typeof LiveAuraFrame>
 
-export const Productive: Story = {
-  args: { category: 'productive' },
-}
+export const Productive: Story = { args: { category: 'productive' } }
+export const Threshold: Story = { args: { category: 'threshold' } }
+export const Stop: Story = { args: { category: 'stop' } }
 
-export const Threshold: Story = {
-  args: { category: 'threshold' },
-}
-
-export const Stop: Story = {
-  args: { category: 'stop' },
-}
-
+/** All three flood levels side by side at live-screen size. */
 export const AllStates: Story = {
   render: () => (
-    <View style={{ gap: 14 }}>
-      <LiveAuraFrame category="productive" style={{ width: 420 }}>
-        <AuraContent caption="aura: none — productive, quiet background" />
+    <View style={{ flexDirection: 'row', gap: 20, flexWrap: 'wrap', justifyContent: 'center' }}>
+      <LiveAuraFrame category="productive" style={PANEL}>
+        <LiveHero caption="no flood — productive" />
       </LiveAuraFrame>
-      <LiveAuraFrame category="threshold" style={{ width: 420 }}>
-        <AuraContent caption="aura: amber — VL20 threshold reached" />
+      <LiveAuraFrame category="threshold" style={PANEL}>
+        <LiveHero caption="amber flood — VL20 threshold" />
       </LiveAuraFrame>
-      <LiveAuraFrame category="stop" pulse={false} style={{ width: 420 }}>
-        <AuraContent caption="aura: red — VL28+, stop the set" />
+      <LiveAuraFrame category="stop" pulse={false} style={PANEL}>
+        <LiveHero caption="red flood — VL28+, stop" />
       </LiveAuraFrame>
     </View>
   ),

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { LiveAuraFrame } from './LiveAuraFrame'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
+
+function AuraContent({ caption }: { caption: string }) {
+  return (
+    <View style={{ padding: 18 }}>
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '800',
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          color: t['text-tertiary'],
+        }}
+      >
+        Cable Row · Set 4/5
+      </Text>
+      <Text style={{ marginTop: 8, fontSize: 12, color: t['text-secondary'] }}>{caption}</Text>
+    </View>
+  )
+}
+
+const meta: Meta<typeof LiveAuraFrame> = {
+  title: 'Workout/LiveAuraFrame',
+  component: LiveAuraFrame,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Full-surface color-flood frame tied to a coaching category. Wraps content on a charcoal ' +
+          'base and layers a radial wash — amber at threshold (VL20), red at stop (VL28+, pulsing) — ' +
+          'derived from the semantic warning / error tokens via `alpha()`. Children pass through.',
+      },
+    },
+  },
+  argTypes: {
+    category: {
+      control: 'select',
+      options: ['productive', 'threshold', 'stop'],
+      description: 'Coaching-category flood level',
+    },
+    pulse: {
+      control: 'boolean',
+      description: 'Pulse the flood on stop',
+    },
+  },
+  render: (args) => (
+    <LiveAuraFrame {...args} style={{ width: 420 }}>
+      <AuraContent
+        caption={
+          args.category === 'stop'
+            ? 'aura: red — VL28+, pulses'
+            : args.category === 'threshold'
+              ? 'aura: amber — VL20 threshold reached'
+              : 'aura: none — productive, quiet background'
+        }
+      />
+    </LiveAuraFrame>
+  ),
+}
+
+export default meta
+type Story = StoryObj<typeof LiveAuraFrame>
+
+export const Productive: Story = {
+  args: { category: 'productive' },
+}
+
+export const Threshold: Story = {
+  args: { category: 'threshold' },
+}
+
+export const Stop: Story = {
+  args: { category: 'stop' },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <View style={{ gap: 14 }}>
+      <LiveAuraFrame category="productive" style={{ width: 420 }}>
+        <AuraContent caption="aura: none — productive, quiet background" />
+      </LiveAuraFrame>
+      <LiveAuraFrame category="threshold" style={{ width: 420 }}>
+        <AuraContent caption="aura: amber — VL20 threshold reached" />
+      </LiveAuraFrame>
+      <LiveAuraFrame category="stop" pulse={false} style={{ width: 420 }}>
+        <AuraContent caption="aura: red — VL28+, stop the set" />
+      </LiveAuraFrame>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.test.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.test.tsx
@@ -41,11 +41,14 @@ describe('LiveAuraFrame', () => {
   ]
 
   floods.forEach(({ category, token, opacity }) => {
-    it(`floods ${category} with the ${token} token`, () => {
+    it(`floods ${category} with a ${token}-tinted radial wash that fades to transparent`, () => {
       render(<LiveAuraFrame category={category} />)
-      expect(screen.getByTestId('live-aura-flood')).toHaveStyle({
-        backgroundColor: alpha(t[token], opacity),
-      })
+      // Web (the target): a top-down radial gradient tinted with the token color,
+      // fading to transparent — matches R2's .aura-* CSS, NOT a flat surface fill.
+      const flood = screen.getByTestId('live-aura-flood') as HTMLElement
+      expect(flood.style.backgroundImage).toContain(alpha(t[token], opacity))
+      expect(flood.style.backgroundImage).toContain('transparent')
+      expect(flood.style.backgroundColor).toBe('')
     })
   })
 

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.test.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { Text } from 'react-native'
+import { LiveAuraFrame, liveAuraColor, type LiveAuraCategory } from './LiveAuraFrame'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+
+const t = getSemanticColors('dark')
+
+describe('LiveAuraFrame', () => {
+  it('renders the frame and passes children through', () => {
+    render(
+      <LiveAuraFrame category="productive">
+        <Text>Cable Row</Text>
+      </LiveAuraFrame>
+    )
+    expect(screen.getByTestId('live-aura-frame')).toBeInTheDocument()
+    expect(screen.getByText('Cable Row')).toBeInTheDocument()
+  })
+
+  it('sits on the charcoal base surface', () => {
+    render(<LiveAuraFrame category="productive" />)
+    expect(screen.getByTestId('live-aura-frame')).toHaveStyle({
+      backgroundColor: t['background-base'],
+    })
+  })
+
+  it('renders no flood overlay for the productive (quiet) category', () => {
+    render(<LiveAuraFrame category="productive" />)
+    expect(screen.queryByTestId('live-aura-flood')).not.toBeInTheDocument()
+  })
+
+  const floods: Array<{
+    category: LiveAuraCategory
+    token: 'status-warning' | 'status-error'
+    opacity: number
+  }> = [
+    { category: 'threshold', token: 'status-warning', opacity: 0.12 },
+    { category: 'stop', token: 'status-error', opacity: 0.18 },
+  ]
+
+  floods.forEach(({ category, token, opacity }) => {
+    it(`floods ${category} with the ${token} token`, () => {
+      render(<LiveAuraFrame category={category} />)
+      expect(screen.getByTestId('live-aura-flood')).toHaveStyle({
+        backgroundColor: alpha(t[token], opacity),
+      })
+    })
+  })
+
+  it('exposes the resolved flood color via liveAuraColor', () => {
+    expect(liveAuraColor('productive')).toBeNull()
+    expect(liveAuraColor('threshold')).toBe(t['status-warning'])
+    expect(liveAuraColor('stop')).toBe(t['status-error'])
+  })
+
+  it('renders the flood for stop when pulse is disabled', () => {
+    render(<LiveAuraFrame category="stop" pulse={false} />)
+    expect(screen.getByTestId('live-aura-flood')).toBeInTheDocument()
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <LiveAuraFrame category="stop">
+        <Text>Set 4/5</Text>
+      </LiveAuraFrame>
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
@@ -55,6 +55,7 @@ export function LiveAuraFrame({
   pulse = true,
   className,
   children,
+  style,
   ...props
 }: LiveAuraFrameProps) {
   const color = liveAuraColor(category)
@@ -73,14 +74,17 @@ export function LiveAuraFrame({
     <View
       testID="live-aura-frame"
       className={className}
-      style={{
-        position: 'relative',
-        overflow: 'hidden',
-        borderRadius: 10,
-        backgroundColor: t['background-base'],
-        borderWidth: 1,
-        borderColor: t['border-default'],
-      }}
+      style={[
+        {
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: 10,
+          backgroundColor: t['background-base'],
+          borderWidth: 1,
+          borderColor: t['border-default'],
+        },
+        style,
+      ]}
       {...props}
     >
       {color && (

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
@@ -1,0 +1,98 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, StyleSheet, type ViewProps, type ViewStyle } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+
+const t = getSemanticColors('dark')
+
+/**
+ * Coaching-category flood level for the live surface. Mirrors {@link StatusPill}:
+ * - `productive` — quiet, no flood
+ * - `threshold`  — amber wash at VL20
+ * - `stop`       — red wash at VL28+ (optionally pulsing)
+ */
+export type LiveAuraCategory = 'productive' | 'threshold' | 'stop'
+
+export interface LiveAuraFrameProps extends ViewProps {
+  category: LiveAuraCategory
+  /**
+   * Pulse the flood on `stop`. Uses the nativewind `animate-pulse` utility so
+   * it stays static-friendly under test (className→style, no live clock).
+   * Defaults to true.
+   */
+  pulse?: boolean
+  className?: string
+  children?: React.ReactNode
+}
+
+const categoryToken: Record<LiveAuraCategory, 'status-warning' | 'status-error' | null> = {
+  productive: null,
+  threshold: 'status-warning',
+  stop: 'status-error',
+}
+
+const floodOpacity: Record<LiveAuraCategory, number> = {
+  productive: 0,
+  threshold: 0.12,
+  stop: 0.18,
+}
+
+/** Resolved flood color for a category, or `null` when there is no flood. */
+export function liveAuraColor(category: LiveAuraCategory): string | null {
+  const token = categoryToken[category]
+  return token ? t[token] : null
+}
+
+/**
+ * Full-surface color-flood frame tied to a coaching category. Wraps `children`
+ * on a charcoal base and layers a radial wash (amber at threshold, red at stop)
+ * as a decorative, pointer-transparent overlay. The wash uses a solid
+ * `backgroundColor` fallback (native) plus a web-only `backgroundImage` radial
+ * gradient; both derive from the same semantic token via `alpha()`.
+ */
+export function LiveAuraFrame({
+  category,
+  pulse = true,
+  className,
+  children,
+  ...props
+}: LiveAuraFrameProps) {
+  const color = liveAuraColor(category)
+  const tint = color ? alpha(color, floodOpacity[category]) : 'transparent'
+
+  const floodStyle = {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: tint,
+    // react-native-web renders backgroundImage at runtime; not in RN ViewStyle types.
+    backgroundImage: color
+      ? `radial-gradient(130% 95% at 50% 0%, ${tint}, transparent 62%)`
+      : undefined,
+  } as ViewStyle
+
+  return (
+    <View
+      testID="live-aura-frame"
+      className={className}
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        borderRadius: 10,
+        backgroundColor: t['background-base'],
+        borderWidth: 1,
+        borderColor: t['border-default'],
+      }}
+      {...props}
+    >
+      {color && (
+        <View
+          testID="live-aura-flood"
+          accessibilityElementsHidden
+          pointerEvents="none"
+          className={category === 'stop' && pulse ? 'animate-pulse' : undefined}
+          style={floodStyle}
+        />
+      )}
+      {children}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
+++ b/packages/ui/src/components/custom/Workout/LiveAuraFrame.tsx
@@ -1,5 +1,5 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import { View, StyleSheet, type ViewProps, type ViewStyle } from 'react-native'
+import { View, StyleSheet, Platform, type ViewProps, type ViewStyle } from 'react-native'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 
@@ -61,13 +61,16 @@ export function LiveAuraFrame({
   const color = liveAuraColor(category)
   const tint = color ? alpha(color, floodOpacity[category]) : 'transparent'
 
+  // Match R2's canonical aura: a top-down radial wash that FADES TO TRANSPARENT
+  // by ~62%, so the charcoal base shows through the lower panel — NOT a flat
+  // full-surface tint. On web (the target: MCP dashboard + Storybook) render the
+  // gradient only; native has no gradient support, so fall back to a solid tint.
   const floodStyle = {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: tint,
-    // react-native-web renders backgroundImage at runtime; not in RN ViewStyle types.
-    backgroundImage: color
-      ? `radial-gradient(130% 95% at 50% 0%, ${tint}, transparent 62%)`
-      : undefined,
+    ...(Platform.OS === 'web'
+      ? // backgroundImage is a runtime RNW style, not in RN ViewStyle types.
+        { backgroundImage: `radial-gradient(130% 95% at 50% 0%, ${tint}, transparent 62%)` }
+      : { backgroundColor: tint }),
   } as ViewStyle
 
   return (

--- a/packages/ui/src/components/custom/Workout/StatusPill.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusPill.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { StatusPill } from './StatusPill'
+
+const meta: Meta<typeof StatusPill> = {
+  title: 'Workout/StatusPill',
+  component: StatusPill,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Auto-regulation verdict pill — a glowing status dot plus colored verdict text in a ' +
+          'tinted capsule. Composes `StatusDot`; tint, border, text, and dot all derive from the ' +
+          'same semantic status token (success / warning / error).',
+      },
+    },
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['productive', 'threshold', 'stop'],
+      description: 'Auto-regulation verdict',
+    },
+    label: {
+      control: 'text',
+      description: 'Overrides the default verdict text',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StatusPill>
+
+export const Productive: Story = {
+  args: { status: 'productive' },
+}
+
+export const Threshold: Story = {
+  args: { status: 'threshold' },
+}
+
+export const Stop: Story = {
+  args: { status: 'stop' },
+}
+
+export const WithCustomLabel: Story = {
+  args: { status: 'stop', label: 'Stop · velocity loss 31%' },
+}
+
+export const AllStates: Story = {
+  render: () => (
+    <View style={{ gap: 10, alignItems: 'flex-start' }}>
+      <StatusPill status="productive" label="Productive · in the band" />
+      <StatusPill status="threshold" label="Threshold · VL20 reached" />
+      <StatusPill status="stop" label="Stop · velocity loss 31%" />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/StatusPill.test.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusPill.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { StatusPill, statusPillColor, type StatusPillStatus } from './StatusPill'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+
+const t = getSemanticColors('dark')
+
+const cases: Array<{
+  status: StatusPillStatus
+  token: 'status-success' | 'status-warning' | 'status-error'
+  label: string
+}> = [
+  { status: 'productive', token: 'status-success', label: 'Productive' },
+  { status: 'threshold', token: 'status-warning', label: 'Threshold' },
+  { status: 'stop', token: 'status-error', label: 'Stop' },
+]
+
+describe('StatusPill', () => {
+  it('renders the pill container', () => {
+    render(<StatusPill status="productive" />)
+    expect(screen.getByTestId('status-pill')).toBeInTheDocument()
+  })
+
+  it('composes a status dot', () => {
+    render(<StatusPill status="productive" />)
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument()
+  })
+
+  describe('per-status mapping', () => {
+    cases.forEach(({ status, token, label }) => {
+      it(`maps ${status} to the ${token} color and default label`, () => {
+        render(<StatusPill status={status} />)
+        const text = screen.getByTestId('status-pill-label')
+        expect(text).toHaveTextContent(label)
+        expect(text).toHaveStyle({ color: t[token] })
+      })
+
+      it(`tints the ${status} capsule from the ${token} token`, () => {
+        render(<StatusPill status={status} />)
+        expect(screen.getByTestId('status-pill')).toHaveStyle({
+          backgroundColor: alpha(t[token], 0.14),
+          borderTopColor: alpha(t[token], 0.4),
+        })
+      })
+    })
+  })
+
+  it('exposes the resolved color via statusPillColor', () => {
+    expect(statusPillColor('stop')).toBe(t['status-error'])
+  })
+
+  it('renders a custom label override', () => {
+    render(<StatusPill status="stop" label="Stop · velocity loss 31%" />)
+    expect(screen.getByText('Stop · velocity loss 31%')).toBeInTheDocument()
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<StatusPill status="threshold" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/custom/Workout/StatusPill.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusPill.tsx
@@ -1,0 +1,85 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+import { StatusDot, type StatusDotVariant } from './StatusDot'
+
+const t = getSemanticColors('dark')
+
+/**
+ * Auto-regulation verdict — the human-readable read-once summary of a set's
+ * velocity-loss state.
+ * - `productive` — in the band, keep going (success)
+ * - `threshold`  — VL20 reached, approaching fatigue (warning)
+ * - `stop`       — VL28+, terminate the set (error)
+ */
+export type StatusPillStatus = 'productive' | 'threshold' | 'stop'
+
+export interface StatusPillProps extends ViewProps {
+  status: StatusPillStatus
+  /** Overrides the default verdict text for the status. */
+  label?: string
+  className?: string
+}
+
+const statusToken: Record<StatusPillStatus, 'status-success' | 'status-warning' | 'status-error'> =
+  {
+    productive: 'status-success',
+    threshold: 'status-warning',
+    stop: 'status-error',
+  }
+
+const statusDotVariant: Record<StatusPillStatus, StatusDotVariant> = {
+  productive: 'success',
+  threshold: 'warning',
+  stop: 'error',
+}
+
+const defaultLabel: Record<StatusPillStatus, string> = {
+  productive: 'Productive',
+  threshold: 'Threshold',
+  stop: 'Stop',
+}
+
+/** Resolved semantic color for a verdict status. */
+export function statusPillColor(status: StatusPillStatus): string {
+  return t[statusToken[status]]
+}
+
+/**
+ * Verdict pill: a glowing status dot + colored verdict text, in a tinted,
+ * bordered capsule. Composes {@link StatusDot} for the dot so the glow/color
+ * stays consistent with the atom. Tint and border are derived from the same
+ * semantic token via `alpha()` — no per-status raw hex.
+ */
+export function StatusPill({ status, label, className, ...props }: StatusPillProps) {
+  const color = statusPillColor(status)
+  const text = label ?? defaultLabel[status]
+
+  return (
+    <View
+      testID="status-pill"
+      className={className}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 7,
+        alignSelf: 'flex-start',
+        paddingVertical: 7,
+        paddingHorizontal: 13,
+        borderRadius: 9,
+        backgroundColor: alpha(color, 0.14),
+        borderWidth: 1,
+        borderColor: alpha(color, 0.4),
+      }}
+      {...props}
+    >
+      <View accessibilityElementsHidden>
+        <StatusDot variant={statusDotVariant[status]} glow />
+      </View>
+      <Text testID="status-pill-label" style={{ fontSize: 13, fontWeight: '800', color }}>
+        {text}
+      </Text>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/StatusPill.tsx
+++ b/packages/ui/src/components/custom/Workout/StatusPill.tsx
@@ -52,7 +52,7 @@ export function statusPillColor(status: StatusPillStatus): string {
  * stays consistent with the atom. Tint and border are derived from the same
  * semantic token via `alpha()` — no per-status raw hex.
  */
-export function StatusPill({ status, label, className, ...props }: StatusPillProps) {
+export function StatusPill({ status, label, className, style, ...props }: StatusPillProps) {
   const color = statusPillColor(status)
   const text = label ?? defaultLabel[status]
 
@@ -60,18 +60,21 @@ export function StatusPill({ status, label, className, ...props }: StatusPillPro
     <View
       testID="status-pill"
       className={className}
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 7,
-        alignSelf: 'flex-start',
-        paddingVertical: 7,
-        paddingHorizontal: 13,
-        borderRadius: 9,
-        backgroundColor: alpha(color, 0.14),
-        borderWidth: 1,
-        borderColor: alpha(color, 0.4),
-      }}
+      style={[
+        {
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 7,
+          alignSelf: 'flex-start',
+          paddingVertical: 7,
+          paddingHorizontal: 13,
+          borderRadius: 9,
+          backgroundColor: alpha(color, 0.14),
+          borderWidth: 1,
+          borderColor: alpha(color, 0.4),
+        },
+        style,
+      ]}
       {...props}
     >
       <View accessibilityElementsHidden>

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { VolumeLandmarkBar } from './VolumeLandmarkBar'
+
+const meta: Meta<typeof VolumeLandmarkBar> = {
+  title: 'Workout/DataViz/VolumeLandmarkBar',
+  component: VolumeLandmarkBar,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Horizontal weekly-volume bar with MEV / MAV / MRV landmark ticks, a HEAT-scale ' +
+          'fill positioned against the MAV target, and a % readout. Reuses the canonical ' +
+          'BodyMap volume heat scale (under → maintenance → productive → approaching → over).',
+      },
+    },
+  },
+  argTypes: {
+    muscle: { control: 'text', description: 'Muscle group label' },
+    currentSets: {
+      control: { type: 'range', min: 0, max: 30, step: 1 },
+      description: 'Current weekly working sets',
+    },
+    width: { control: 'number', description: 'Track width in px' },
+    trackHeight: { control: 'number', description: 'Track height in px' },
+    scaleMax: { control: 'number', description: 'Upper bound of the track scale (sets)' },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ padding: 24, paddingBottom: 40, backgroundColor: '#101010' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof VolumeLandmarkBar>
+
+const LANDMARKS = { mev: 8, mav: 16, mrv: 22 }
+
+export const UnderMEV: Story = {
+  args: { muscle: 'Rear Delts', currentSets: 5, landmarks: LANDMARKS },
+}
+
+export const Maintenance: Story = {
+  args: { muscle: 'Calves', currentSets: 12, landmarks: LANDMARKS },
+}
+
+export const Optimal: Story = {
+  args: { muscle: 'Quads', currentSets: 17, landmarks: LANDMARKS },
+}
+
+export const ApproachingMRV: Story = {
+  args: { muscle: 'Back', currentSets: 21, landmarks: LANDMARKS },
+}
+
+export const OverMRV: Story = {
+  args: { muscle: 'Biceps', currentSets: 26, landmarks: LANDMARKS },
+}
+
+export const AllZones: Story = {
+  render: () => (
+    <View style={{ gap: 28 }}>
+      <VolumeLandmarkBar muscle="Rear Delts" currentSets={5} landmarks={LANDMARKS} />
+      <VolumeLandmarkBar muscle="Calves" currentSets={12} landmarks={LANDMARKS} />
+      <VolumeLandmarkBar muscle="Quads" currentSets={17} landmarks={LANDMARKS} />
+      <VolumeLandmarkBar muscle="Back" currentSets={21} landmarks={LANDMARKS} />
+      <VolumeLandmarkBar muscle="Biceps" currentSets={26} landmarks={LANDMARKS} />
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { VolumeLandmarkBar, type VolumeLandmarks } from './VolumeLandmarkBar'
+
+// Clean-number geometry: pos(v) = v / scaleMax * width = v * 8.
+const LANDMARKS: VolumeLandmarks = { mev: 5, mav: 15, mrv: 20 }
+const WIDTH = 200
+const SCALE_MAX = 25
+
+// HEAT scale hexes (WORKOUT_TOKENS.heatmap = divergingScale).
+const HEAT = {
+  under: '#2196F3',
+  maintenance: '#22D3EE',
+  productive: '#58F69E',
+  approaching: '#F9B415',
+  over: '#D14343',
+} as const
+
+function renderBar(currentSets: number, muscle = 'Quads') {
+  return render(
+    <VolumeLandmarkBar
+      muscle={muscle}
+      currentSets={currentSets}
+      landmarks={LANDMARKS}
+      width={WIDTH}
+      scaleMax={SCALE_MAX}
+    />
+  )
+}
+
+describe('VolumeLandmarkBar', () => {
+  it('renders the bar, track, and fill', () => {
+    renderBar(10)
+    expect(screen.getByTestId('volume-landmark-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('volume-landmark-track')).toBeInTheDocument()
+    expect(screen.getByTestId('volume-landmark-fill')).toBeInTheDocument()
+  })
+
+  it('renders the muscle label', () => {
+    renderBar(10, 'Hamstrings')
+    expect(screen.getByTestId('volume-landmark-muscle')).toHaveTextContent('Hamstrings')
+  })
+
+  it('has the progressbar accessibility role', () => {
+    renderBar(10)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  describe('percentage readout (relative to MAV target)', () => {
+    it('renders current sets as a percentage of MAV', () => {
+      // 15 sets / 15 MAV = 100%
+      renderBar(15)
+      expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('100%')
+    })
+
+    it('renders below-target percentages under 100', () => {
+      // 3 / 15 = 20%
+      renderBar(3)
+      expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('20%')
+    })
+
+    it('renders over-target percentages above 100', () => {
+      // 24 / 15 = 160%
+      renderBar(24)
+      expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('160%')
+    })
+  })
+
+  describe('landmark ticks and labels', () => {
+    it('renders MEV, MAV, and MRV ticks', () => {
+      renderBar(10)
+      expect(screen.getByTestId('volume-landmark-tick-mev')).toBeInTheDocument()
+      expect(screen.getByTestId('volume-landmark-tick-mav')).toBeInTheDocument()
+      expect(screen.getByTestId('volume-landmark-tick-mrv')).toBeInTheDocument()
+    })
+
+    it('renders the landmark set-count labels', () => {
+      renderBar(10)
+      expect(screen.getByTestId('volume-landmark-label-mev')).toHaveTextContent('MEV')
+      expect(screen.getByTestId('volume-landmark-label-mev')).toHaveTextContent('5')
+      expect(screen.getByTestId('volume-landmark-label-mav')).toHaveTextContent('MAV')
+      expect(screen.getByTestId('volume-landmark-label-mav')).toHaveTextContent('15')
+      expect(screen.getByTestId('volume-landmark-label-mrv')).toHaveTextContent('MRV')
+      expect(screen.getByTestId('volume-landmark-label-mrv')).toHaveTextContent('20')
+    })
+
+    it('positions ticks proportionally: MEV left of MAV left of MRV', () => {
+      renderBar(10)
+      const mev = parseFloat(screen.getByTestId('volume-landmark-tick-mev').style.left)
+      const mav = parseFloat(screen.getByTestId('volume-landmark-tick-mav').style.left)
+      const mrv = parseFloat(screen.getByTestId('volume-landmark-tick-mrv').style.left)
+      expect(mev).toBeLessThan(mav)
+      expect(mav).toBeLessThan(mrv)
+    })
+
+    it('positions each tick at value / scaleMax * width', () => {
+      renderBar(10)
+      // MEV 5 -> 40px, MAV 15 -> 120px, MRV 20 -> 160px
+      expect(screen.getByTestId('volume-landmark-tick-mev')).toHaveStyle({ left: '40px' })
+      expect(screen.getByTestId('volume-landmark-tick-mav')).toHaveStyle({ left: '120px' })
+      expect(screen.getByTestId('volume-landmark-tick-mrv')).toHaveStyle({ left: '160px' })
+    })
+  })
+
+  describe('HEAT zone fill color by landmark position', () => {
+    it('is under (blue) below MEV', () => {
+      renderBar(3)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+        backgroundColor: HEAT.under,
+      })
+    })
+
+    it('is maintenance (cyan) between MEV and MAV', () => {
+      renderBar(10)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+        backgroundColor: HEAT.maintenance,
+      })
+    })
+
+    it('is productive (green) just above MAV', () => {
+      renderBar(16)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+        backgroundColor: HEAT.productive,
+      })
+    })
+
+    it('is approaching (amber) in the upper MAV-MRV band', () => {
+      renderBar(18)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+        backgroundColor: HEAT.approaching,
+      })
+    })
+
+    it('is over (red) at or beyond MRV', () => {
+      renderBar(25)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ backgroundColor: HEAT.over })
+    })
+
+    it('mirrors the fill color in the percentage headline', () => {
+      renderBar(3)
+      expect(screen.getByTestId('volume-landmark-pct')).toHaveStyle({ color: HEAT.under })
+    })
+  })
+
+  describe('fill geometry', () => {
+    it('sizes the fill proportionally to current sets', () => {
+      // 10 / 25 * 200 = 80px
+      renderBar(10)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ width: '80px' })
+    })
+
+    it('clamps the fill to the track for extreme over-volume', () => {
+      renderBar(100)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ width: '200px' })
+    })
+
+    it('applies the productive glow only in the productive zone', () => {
+      renderBar(16)
+      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+        boxShadow: '0 0 5px 1px rgba(88,246,158,0.30), 0 0 10px 3px rgba(88,246,158,0.12)',
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('describes the muscle, sets, and zone in the label', () => {
+      renderBar(3, 'Calves')
+      expect(
+        screen.getByLabelText('Calves weekly volume: 3 sets, 20% of MAV target, below MEV')
+      ).toBeInTheDocument()
+    })
+
+    it('describes the over-MRV state', () => {
+      renderBar(25, 'Quads')
+      expect(
+        screen.getByLabelText('Quads weekly volume: 25 sets, 167% of MAV target, over MRV')
+      ).toBeInTheDocument()
+    })
+
+    it('has no accessibility violations', async () => {
+      const { container } = renderBar(16)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { VolumeLandmarkBar, type VolumeLandmarks } from './VolumeLandmarkBar'
 
-// Clean-number geometry: pos(v) = v / scaleMax * width = v * 8.
+// Clean-number geometry: fraction(v) = v / scaleMax.
 const LANDMARKS: VolumeLandmarks = { mev: 5, mav: 15, mrv: 20 }
 const WIDTH = 200
 const SCALE_MAX = 25
@@ -30,16 +30,18 @@ function renderBar(currentSets: number, muscle = 'Quads') {
 }
 
 describe('VolumeLandmarkBar', () => {
-  it('renders the bar, track, and fill', () => {
+  it('renders the bar, track (ZoneTrack), and fill', () => {
     renderBar(10)
     expect(screen.getByTestId('volume-landmark-bar')).toBeInTheDocument()
     expect(screen.getByTestId('volume-landmark-track')).toBeInTheDocument()
     expect(screen.getByTestId('zone-track-fill')).toBeInTheDocument()
   })
 
-  it('renders the muscle label', () => {
-    renderBar(10, 'Hamstrings')
-    expect(screen.getByTestId('volume-landmark-muscle')).toHaveTextContent('Hamstrings')
+  it('shows the muscle title and % value in the header lockup', () => {
+    renderBar(15, 'Hamstrings')
+    expect(screen.getByText('Hamstrings')).toBeInTheDocument()
+    // 15 sets / 15 MAV = 100%
+    expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('100%')
   })
 
   it('has the progressbar accessibility role', () => {
@@ -48,93 +50,35 @@ describe('VolumeLandmarkBar', () => {
   })
 
   describe('percentage readout (relative to MAV target)', () => {
-    it('renders current sets as a percentage of MAV', () => {
-      // 15 sets / 15 MAV = 100%
-      renderBar(15)
-      expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('100%')
-    })
-
     it('renders below-target percentages under 100', () => {
-      // 3 / 15 = 20%
-      renderBar(3)
+      renderBar(3) // 3 / 15 = 20%
       expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('20%')
     })
-
     it('renders over-target percentages above 100', () => {
-      // 24 / 15 = 160%
-      renderBar(24)
+      renderBar(24) // 24 / 15 = 160%
       expect(screen.getByTestId('volume-landmark-pct')).toHaveTextContent('160%')
     })
   })
 
-  describe('landmark ticks and labels', () => {
-    it('renders MEV, MAV, and MRV ticks', () => {
-      renderBar(10)
-      expect(screen.getByTestId('volume-landmark-tick-mev')).toBeInTheDocument()
-      expect(screen.getByTestId('volume-landmark-tick-mav')).toBeInTheDocument()
-      expect(screen.getByTestId('volume-landmark-tick-mrv')).toBeInTheDocument()
-    })
-
-    it('renders the landmark set-count labels', () => {
-      renderBar(10)
-      expect(screen.getByTestId('volume-landmark-label-mev')).toHaveTextContent('MEV')
-      expect(screen.getByTestId('volume-landmark-label-mev')).toHaveTextContent('5')
-      expect(screen.getByTestId('volume-landmark-label-mav')).toHaveTextContent('MAV')
-      expect(screen.getByTestId('volume-landmark-label-mav')).toHaveTextContent('15')
-      expect(screen.getByTestId('volume-landmark-label-mrv')).toHaveTextContent('MRV')
-      expect(screen.getByTestId('volume-landmark-label-mrv')).toHaveTextContent('20')
-    })
-
-    it('positions ticks proportionally: MEV left of MAV left of MRV', () => {
-      renderBar(10)
-      const mev = parseFloat(screen.getByTestId('volume-landmark-tick-mev').style.left)
-      const mav = parseFloat(screen.getByTestId('volume-landmark-tick-mav').style.left)
-      const mrv = parseFloat(screen.getByTestId('volume-landmark-tick-mrv').style.left)
-      expect(mev).toBeLessThan(mav)
-      expect(mav).toBeLessThan(mrv)
-    })
-
-    it('positions each tick at value / scaleMax * width', () => {
-      renderBar(10)
-      // MEV 5 -> 40px, MAV 15 -> 120px, MRV 20 -> 160px
-      expect(screen.getByTestId('volume-landmark-tick-mev')).toHaveStyle({ left: '40px' })
-      expect(screen.getByTestId('volume-landmark-tick-mav')).toHaveStyle({ left: '120px' })
-      expect(screen.getByTestId('volume-landmark-tick-mrv')).toHaveStyle({ left: '160px' })
-    })
+  it('renders the MEV / MAV / MRV landmark tick labels', () => {
+    renderBar(10)
+    const labels = screen.getAllByTestId('zone-track-tick-label').map((el) => el.textContent)
+    expect(labels).toEqual(['MEV', 'MAV', 'MRV'])
   })
 
   describe('HEAT zone fill color by landmark position', () => {
-    it('is under (blue) below MEV', () => {
-      renderBar(3)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
-        backgroundColor: HEAT.under,
+    const cases: Array<[number, keyof typeof HEAT]> = [
+      [3, 'under'],
+      [10, 'maintenance'],
+      [16, 'productive'],
+      [18, 'approaching'],
+      [25, 'over'],
+    ]
+    cases.forEach(([sets, zone]) => {
+      it(`is ${zone} at ${sets} sets`, () => {
+        renderBar(sets)
+        expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ backgroundColor: HEAT[zone] })
       })
-    })
-
-    it('is maintenance (cyan) between MEV and MAV', () => {
-      renderBar(10)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
-        backgroundColor: HEAT.maintenance,
-      })
-    })
-
-    it('is productive (green) just above MAV', () => {
-      renderBar(16)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
-        backgroundColor: HEAT.productive,
-      })
-    })
-
-    it('is approaching (amber) in the upper MAV-MRV band', () => {
-      renderBar(18)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
-        backgroundColor: HEAT.approaching,
-      })
-    })
-
-    it('is over (red) at or beyond MRV', () => {
-      renderBar(25)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ backgroundColor: HEAT.over })
     })
 
     it('mirrors the fill color in the percentage headline', () => {
@@ -143,16 +87,19 @@ describe('VolumeLandmarkBar', () => {
     })
   })
 
-  describe('fill geometry (delegated to ZoneTrack, expressed as a track fraction)', () => {
-    it('sizes the fill proportionally to current sets', () => {
-      // 10 / 25 = 40% of the track
-      renderBar(10)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ width: '40%' })
-    })
+  it('sizes the fill proportionally (delegated to ZoneTrack)', () => {
+    renderBar(10) // 10 / 25 = 40% of the track
+    expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ width: '40%' })
+  })
 
-    it('clamps the fill to the track for extreme over-volume', () => {
-      renderBar(100)
-      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ width: '100%' })
+  describe('productive-zone glow', () => {
+    it('glows the track in the productive zone', () => {
+      renderBar(16)
+      expect((screen.getByTestId('zone-track-track') as HTMLElement).style.boxShadow).not.toBe('')
+    })
+    it('does not glow outside the productive zone', () => {
+      renderBar(3)
+      expect((screen.getByTestId('zone-track-track') as HTMLElement).style.boxShadow).toBe('')
     })
   })
 
@@ -164,17 +111,9 @@ describe('VolumeLandmarkBar', () => {
       ).toBeInTheDocument()
     })
 
-    it('describes the over-MRV state', () => {
-      renderBar(25, 'Quads')
-      expect(
-        screen.getByLabelText('Quads weekly volume: 25 sets, 167% of MAV target, over MRV')
-      ).toBeInTheDocument()
-    })
-
     it('has no accessibility violations', async () => {
       const { container } = renderBar(16)
-      const results = await axe(container)
-      expect(results).toHaveNoViolations()
+      expect(await axe(container)).toHaveNoViolations()
     })
   })
 })

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.test.tsx
@@ -34,7 +34,7 @@ describe('VolumeLandmarkBar', () => {
     renderBar(10)
     expect(screen.getByTestId('volume-landmark-bar')).toBeInTheDocument()
     expect(screen.getByTestId('volume-landmark-track')).toBeInTheDocument()
-    expect(screen.getByTestId('volume-landmark-fill')).toBeInTheDocument()
+    expect(screen.getByTestId('zone-track-fill')).toBeInTheDocument()
   })
 
   it('renders the muscle label', () => {
@@ -106,35 +106,35 @@ describe('VolumeLandmarkBar', () => {
   describe('HEAT zone fill color by landmark position', () => {
     it('is under (blue) below MEV', () => {
       renderBar(3)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
         backgroundColor: HEAT.under,
       })
     })
 
     it('is maintenance (cyan) between MEV and MAV', () => {
       renderBar(10)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
         backgroundColor: HEAT.maintenance,
       })
     })
 
     it('is productive (green) just above MAV', () => {
       renderBar(16)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
         backgroundColor: HEAT.productive,
       })
     })
 
     it('is approaching (amber) in the upper MAV-MRV band', () => {
       renderBar(18)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({
         backgroundColor: HEAT.approaching,
       })
     })
 
     it('is over (red) at or beyond MRV', () => {
       renderBar(25)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ backgroundColor: HEAT.over })
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ backgroundColor: HEAT.over })
     })
 
     it('mirrors the fill color in the percentage headline', () => {
@@ -143,23 +143,16 @@ describe('VolumeLandmarkBar', () => {
     })
   })
 
-  describe('fill geometry', () => {
+  describe('fill geometry (delegated to ZoneTrack, expressed as a track fraction)', () => {
     it('sizes the fill proportionally to current sets', () => {
-      // 10 / 25 * 200 = 80px
+      // 10 / 25 = 40% of the track
       renderBar(10)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ width: '80px' })
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ width: '40%' })
     })
 
     it('clamps the fill to the track for extreme over-volume', () => {
       renderBar(100)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({ width: '200px' })
-    })
-
-    it('applies the productive glow only in the productive zone', () => {
-      renderBar(16)
-      expect(screen.getByTestId('volume-landmark-fill')).toHaveStyle({
-        boxShadow: '0 0 5px 1px rgba(88,246,158,0.30), 0 0 10px 3px rgba(88,246,158,0.12)',
-      })
+      expect(screen.getByTestId('zone-track-fill')).toHaveStyle({ width: '100%' })
     })
   })
 

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
@@ -1,0 +1,242 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import type { VolumeLandmarks } from './muscleTaxonomy'
+
+const t = getSemanticColors('dark')
+
+// Reuse the canonical BodyMap volume HEAT scale (the `divergingScale` under →
+// optimal → over) rather than reinventing a fill ramp. Same color language as
+// BodyMap / MesoProgressBar so a muscle reads identically across the app.
+const HEAT = WORKOUT_TOKENS.heatmap
+
+const TRACK_BG = '#333333'
+const TICK_COLOR = '#6B7280'
+const MONO = 'monospace'
+// Optimal-zone glow: the fill sits on the MAV productive target.
+const PRODUCTIVE_GLOW = '0 0 5px 1px rgba(88,246,158,0.30), 0 0 10px 3px rgba(88,246,158,0.12)'
+
+export type VolumeZone = 'under' | 'maintenance' | 'productive' | 'approaching' | 'over'
+
+// The MEV/MAV/MRV shape is the canonical one from muscleTaxonomy — reused, not
+// redefined, so there is a single source of truth. Re-exported for convenience.
+export type { VolumeLandmarks }
+
+export interface VolumeLandmarkBarProps extends ViewProps {
+  /** Muscle group label shown above the track. */
+  muscle: string
+  /** Current weekly working sets for this muscle group. */
+  currentSets: number
+  /** MEV / MAV / MRV landmark set counts. */
+  landmarks: VolumeLandmarks
+  /** Track width in px (default 220). */
+  width?: number
+  /** Track height in px (default 10). */
+  trackHeight?: number
+  /**
+   * Upper bound of the track scale in sets. Defaults to `mrv` plus 20% headroom
+   * so an over-MRV fill visibly extends past the MRV tick.
+   */
+  scaleMax?: number
+  className?: string
+}
+
+const HEAT_BY_ZONE: Record<VolumeZone, string> = {
+  under: HEAT.under,
+  maintenance: HEAT.maintenance,
+  productive: HEAT.productive,
+  approaching: HEAT.approaching,
+  over: HEAT.over,
+}
+
+const ZONE_DESCRIPTION: Record<VolumeZone, string> = {
+  under: 'below MEV',
+  maintenance: 'building toward MAV',
+  productive: 'in the productive zone',
+  approaching: 'approaching MRV',
+  over: 'over MRV',
+}
+
+/** Map weekly sets against the three landmarks to a diverging HEAT zone. */
+function zoneForSets(sets: number, { mev, mav, mrv }: VolumeLandmarks): VolumeZone {
+  if (sets < mev) return 'under'
+  if (sets < mav) return 'maintenance'
+  if (sets >= mrv) return 'over'
+  // Between MAV and MRV: lower half is the optimal productive band, upper half
+  // approaches the recoverable ceiling.
+  const midpoint = (mav + mrv) / 2
+  return sets < midpoint ? 'productive' : 'approaching'
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+interface LandmarkTickProps {
+  name: 'MEV' | 'MAV' | 'MRV'
+  value: number
+  left: number
+  trackHeight: number
+  emphasized: boolean
+}
+
+function LandmarkTick({ name, value, left, trackHeight, emphasized }: LandmarkTickProps) {
+  const lineWidth = emphasized ? 2 : 1.5
+  const color = emphasized ? t['brand-primary'] : TICK_COLOR
+  return (
+    <>
+      <View
+        style={{
+          position: 'absolute',
+          left,
+          top: -3,
+          width: lineWidth,
+          height: trackHeight + 6,
+          borderRadius: lineWidth / 2,
+          backgroundColor: color,
+          zIndex: 3,
+        }}
+        testID={`volume-landmark-tick-${name.toLowerCase()}`}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          left: left - 20,
+          top: trackHeight + 8,
+          width: 40,
+          alignItems: 'center',
+        }}
+        accessibilityElementsHidden
+        testID={`volume-landmark-label-${name.toLowerCase()}`}
+      >
+        <Text style={{ fontSize: 8, fontFamily: MONO, color, letterSpacing: 0.5 }}>{name}</Text>
+        <Text style={{ fontSize: 9, fontFamily: MONO, color: t['text-secondary'] }}>{value}</Text>
+      </View>
+    </>
+  )
+}
+
+/**
+ * Horizontal weekly-volume bar with MEV / MAV / MRV landmark ticks, a HEAT-scale
+ * fill positioned against the MAV target, and a % readout. Reuses the canonical
+ * BodyMap volume heat scale so a muscle's training status reads the same here as
+ * in the body map. Richer than DeviationBar / MesoProgressBar, which carry no
+ * landmark markers.
+ *
+ * @example
+ * <VolumeLandmarkBar
+ *   muscle="Quads"
+ *   currentSets={16}
+ *   landmarks={{ mev: 8, mav: 16, mrv: 22 }}
+ * />
+ */
+export function VolumeLandmarkBar({
+  muscle,
+  currentSets,
+  landmarks,
+  width = 220,
+  trackHeight = 10,
+  scaleMax,
+  className,
+  ...props
+}: VolumeLandmarkBarProps) {
+  const { mev, mav, mrv } = landmarks
+  const max = scaleMax ?? mrv * 1.2
+  const zone = zoneForSets(currentSets, landmarks)
+  const fillColor = HEAT_BY_ZONE[zone]
+
+  const posFor = (value: number) => clamp01(value / max) * width
+  const fillWidth = posFor(currentSets)
+
+  const pct = mav > 0 ? Math.round((currentSets / mav) * 100) : 0
+
+  return (
+    <View
+      className={className}
+      style={{ width, gap: 4, overflow: 'visible' }}
+      accessibilityRole="progressbar"
+      accessibilityValue={{ min: 0, max: Math.round(max), now: currentSets }}
+      accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}
+      testID="volume-landmark-bar"
+      {...props}
+    >
+      <View
+        style={{ flexDirection: 'row', alignItems: 'baseline', justifyContent: 'space-between' }}
+        accessibilityElementsHidden
+      >
+        <Text
+          style={{
+            fontSize: 11,
+            fontFamily: '"Nunito Sans", sans-serif',
+            color: t['text-secondary'],
+          }}
+          testID="volume-landmark-muscle"
+        >
+          {muscle}
+        </Text>
+        <Text
+          style={{ fontSize: 15, fontWeight: '700', fontFamily: MONO, color: fillColor }}
+          testID="volume-landmark-pct"
+        >
+          {pct}%
+        </Text>
+      </View>
+
+      <View
+        style={{
+          width,
+          height: trackHeight,
+          borderRadius: trackHeight / 2,
+          backgroundColor: TRACK_BG,
+          position: 'relative',
+          overflow: 'visible',
+        }}
+        accessibilityElementsHidden
+        testID="volume-landmark-track"
+      >
+        <View
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: fillWidth,
+            borderRadius: trackHeight / 2,
+            backgroundColor: fillColor,
+            zIndex: 1,
+            ...(zone === 'productive' ? { boxShadow: PRODUCTIVE_GLOW } : null),
+          }}
+          testID="volume-landmark-fill"
+        />
+
+        <LandmarkTick
+          name="MEV"
+          value={mev}
+          left={posFor(mev)}
+          trackHeight={trackHeight}
+          emphasized={false}
+        />
+        <LandmarkTick
+          name="MAV"
+          value={mav}
+          left={posFor(mav)}
+          trackHeight={trackHeight}
+          emphasized
+        />
+        <LandmarkTick
+          name="MRV"
+          value={mrv}
+          left={posFor(mrv)}
+          trackHeight={trackHeight}
+          emphasized={false}
+        />
+      </View>
+
+      {/* Reserve vertical room for the absolutely-positioned landmark labels. */}
+      <View style={{ height: 22 }} accessibilityElementsHidden />
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
@@ -1,12 +1,10 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { View, Text, type ViewProps } from 'react-native'
-import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { ZoneTrack } from './ZoneTrack'
+import { DataRow } from '../../ui/data-row/DataRow'
 import type { VolumeLandmarks } from './muscleTaxonomy'
-
-const t = getSemanticColors('dark')
 
 // Reuse the canonical BodyMap volume HEAT scale (the `divergingScale` under →
 // optimal → over) rather than reinventing a fill ramp. Same color language as
@@ -16,7 +14,6 @@ const HEAT = WORKOUT_TOKENS.heatmap
 // The muted, un-reached track colour — the same charcoal step ZoneTrack defaults
 // to, so the bar sits on the shared gauge-track surface.
 const NEUTRAL_TRACK = primitiveColors.charcoal[200]
-const TICK_COLOR = t['text-tertiary']
 const MONO = 'monospace'
 
 export type VolumeZone = 'under' | 'maintenance' | 'productive' | 'approaching' | 'over'
@@ -26,7 +23,7 @@ export type VolumeZone = 'under' | 'maintenance' | 'productive' | 'approaching' 
 export type { VolumeLandmarks }
 
 export interface VolumeLandmarkBarProps extends ViewProps {
-  /** Muscle group label shown above the track. */
+  /** Muscle group label shown in the header lockup. */
   muscle: string
   /** Current weekly working sets for this muscle group. */
   currentSets: number
@@ -60,6 +57,12 @@ const ZONE_DESCRIPTION: Record<VolumeZone, string> = {
   over: 'over MRV',
 }
 
+const LANDMARK_NAME: Record<'MEV' | 'MAV' | 'MRV', string> = {
+  MEV: 'Minimum Effective Volume',
+  MAV: 'Maximum Adaptive Volume',
+  MRV: 'Maximum Recoverable Volume',
+}
+
 /** Map weekly sets against the three landmarks to a diverging HEAT zone. */
 function zoneForSets(sets: number, { mev, mav, mrv }: VolumeLandmarks): VolumeZone {
   if (sets < mev) return 'under'
@@ -71,72 +74,17 @@ function zoneForSets(sets: number, { mev, mav, mrv }: VolumeLandmarks): VolumeZo
   return sets < midpoint ? 'productive' : 'approaching'
 }
 
-function clamp01(value: number): number {
-  if (value < 0) return 0
-  if (value > 1) return 1
-  return value
-}
-
-interface LandmarkTickProps {
-  name: 'MEV' | 'MAV' | 'MRV'
-  value: number
-  left: number
-  trackHeight: number
-  emphasized: boolean
-}
-
-/** A full-height landmark line drawn over the track + its label/value below. */
-function LandmarkTick({ name, value, left, trackHeight, emphasized }: LandmarkTickProps) {
-  const lineWidth = emphasized ? 2 : 1.5
-  const color = emphasized ? t['brand-primary'] : TICK_COLOR
-  return (
-    <>
-      <View
-        style={{
-          position: 'absolute',
-          left,
-          top: -3,
-          width: lineWidth,
-          height: trackHeight + 6,
-          borderRadius: lineWidth / 2,
-          backgroundColor: color,
-          zIndex: 3,
-        }}
-        testID={`volume-landmark-tick-${name.toLowerCase()}`}
-      />
-      <View
-        style={{
-          position: 'absolute',
-          left: left - 20,
-          top: trackHeight + 8,
-          width: 40,
-          alignItems: 'center',
-        }}
-        accessibilityElementsHidden
-        testID={`volume-landmark-label-${name.toLowerCase()}`}
-      >
-        <Text style={{ fontSize: 8, fontFamily: MONO, color, letterSpacing: 0.5 }}>{name}</Text>
-        <Text style={{ fontSize: 9, fontFamily: MONO, color: t['text-secondary'] }}>{value}</Text>
-      </View>
-    </>
-  )
-}
-
 /**
- * Horizontal weekly-volume bar with MEV / MAV / MRV landmark ticks, a HEAT-scale
- * fill positioned against the MAV target, and a % readout. Composes the shared
- * {@link ZoneTrack} gauge primitive for the track + fill (so it sits on the same
- * base as FatigueMeter / TrainingLoadGauge rather than hand-rolling a track), and
- * overlays the volume-specific landmark ticks. Reuses the canonical BodyMap
- * volume heat scale so a muscle's status reads the same here as in the body map.
- * Richer than DeviationBar / MesoProgressBar, which carry no landmark markers.
+ * Horizontal weekly-volume bar with MEV / MAV / MRV landmark ticks and a HEAT-scale
+ * fill positioned against the MAV target. Composes the shared {@link ZoneTrack}
+ * gauge primitive (track + active-zone fill + colored/tooltip landmark ticks; glows
+ * when in the productive zone) and a {@link DataRow} header lockup (muscle title +
+ * current % at matched type height). The tick acronyms expand to their full name +
+ * raw set count on hover/long-press, keeping the footer light. Reuses the canonical
+ * BodyMap volume heat scale so a muscle's status reads the same as in the body map.
  *
  * @example
- * <VolumeLandmarkBar
- *   muscle="Quads"
- *   currentSets={16}
- *   landmarks={{ mev: 8, mav: 16, mrv: 22 }}
- * />
+ * <VolumeLandmarkBar muscle="Quads" currentSets={16} landmarks={{ mev: 8, mav: 16, mrv: 22 }} />
  */
 export function VolumeLandmarkBar({
   muscle,
@@ -153,77 +101,54 @@ export function VolumeLandmarkBar({
   const max = scaleMax ?? mrv * 1.2
   const zone = zoneForSets(currentSets, landmarks)
   const fillColor = HEAT_BY_ZONE[zone]
-
-  const posFor = (value: number) => clamp01(value / max) * width
   const pct = mav > 0 ? Math.round((currentSets / mav) * 100) : 0
 
   return (
     <View
       className={className}
-      style={[{ width, gap: 4, overflow: 'visible' }, style]}
+      style={[{ width, gap: 3 }, style]}
       testID="volume-landmark-bar"
       {...props}
     >
-      <View
-        style={{ flexDirection: 'row', alignItems: 'baseline', justifyContent: 'space-between' }}
-        accessibilityElementsHidden
-      >
-        <Text
-          style={{
-            fontSize: 11,
-            fontFamily: '"Nunito Sans", sans-serif',
-            color: t['text-secondary'],
-          }}
-          testID="volume-landmark-muscle"
-        >
-          {muscle}
-        </Text>
-        <Text
-          style={{ fontSize: 15, fontWeight: '700', fontFamily: MONO, color: fillColor }}
-          testID="volume-landmark-pct"
-        >
-          {pct}%
-        </Text>
-      </View>
+      <DataRow
+        label={muscle}
+        value={
+          <Text
+            testID="volume-landmark-pct"
+            style={{ fontSize: 14, fontWeight: '700', fontFamily: MONO, color: fillColor }}
+          >
+            {pct}%
+          </Text>
+        }
+        className="py-0"
+        testID="volume-landmark-header"
+      />
 
-      {/* The shared ZoneTrack primitive carries the track + active-zone fill + the
-          progressbar a11y; the volume landmarks are overlaid on top of it. */}
-      <View style={{ width, position: 'relative' }}>
-        <ZoneTrack
-          zones={[{ upTo: max, color: NEUTRAL_TRACK }]}
-          max={max}
-          marker={{ type: 'fill', value: currentSets, color: fillColor }}
-          trackHeight={trackHeight}
-          trackColor={NEUTRAL_TRACK}
-          accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}
-          testID="volume-landmark-track"
-        />
-
-        <LandmarkTick
-          name="MEV"
-          value={mev}
-          left={posFor(mev)}
-          trackHeight={trackHeight}
-          emphasized={false}
-        />
-        <LandmarkTick
-          name="MAV"
-          value={mav}
-          left={posFor(mav)}
-          trackHeight={trackHeight}
-          emphasized
-        />
-        <LandmarkTick
-          name="MRV"
-          value={mrv}
-          left={posFor(mrv)}
-          trackHeight={trackHeight}
-          emphasized={false}
-        />
-      </View>
-
-      {/* Reserve vertical room for the absolutely-positioned landmark labels. */}
-      <View style={{ height: 22 }} accessibilityElementsHidden />
+      <ZoneTrack
+        zones={[{ upTo: max, color: NEUTRAL_TRACK }]}
+        max={max}
+        marker={{
+          type: 'fill',
+          value: currentSets,
+          color: fillColor,
+          // Glow when in the optimal productive band — the "sweet spot" cue.
+          glow: zone === 'productive',
+        }}
+        trackColor={NEUTRAL_TRACK}
+        trackHeight={trackHeight}
+        ticks={[
+          { value: mev, label: 'MEV', tooltip: `${LANDMARK_NAME.MEV} · ${mev} sets/wk` },
+          {
+            value: mav,
+            label: 'MAV',
+            emphasized: true,
+            tooltip: `${LANDMARK_NAME.MAV} (target) · ${mav} sets/wk`,
+          },
+          { value: mrv, label: 'MRV', tooltip: `${LANDMARK_NAME.MRV} · ${mrv} sets/wk` },
+        ]}
+        accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}
+        testID="volume-landmark-track"
+      />
     </View>
   )
 }

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
@@ -141,6 +141,7 @@ export function VolumeLandmarkBar({
   trackHeight = 10,
   scaleMax,
   className,
+  style,
   ...props
 }: VolumeLandmarkBarProps) {
   const { mev, mav, mrv } = landmarks
@@ -156,7 +157,7 @@ export function VolumeLandmarkBar({
   return (
     <View
       className={className}
-      style={{ width, gap: 4, overflow: 'visible' }}
+      style={[{ width, gap: 4, overflow: 'visible' }, style]}
       accessibilityRole="progressbar"
       accessibilityValue={{ min: 0, max: Math.round(max), now: currentSets }}
       accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.tsx
@@ -2,6 +2,8 @@
 import { View, Text, type ViewProps } from 'react-native'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+import { ZoneTrack } from './ZoneTrack'
 import type { VolumeLandmarks } from './muscleTaxonomy'
 
 const t = getSemanticColors('dark')
@@ -11,11 +13,11 @@ const t = getSemanticColors('dark')
 // BodyMap / MesoProgressBar so a muscle reads identically across the app.
 const HEAT = WORKOUT_TOKENS.heatmap
 
-const TRACK_BG = '#333333'
-const TICK_COLOR = '#6B7280'
+// The muted, un-reached track colour — the same charcoal step ZoneTrack defaults
+// to, so the bar sits on the shared gauge-track surface.
+const NEUTRAL_TRACK = primitiveColors.charcoal[200]
+const TICK_COLOR = t['text-tertiary']
 const MONO = 'monospace'
-// Optimal-zone glow: the fill sits on the MAV productive target.
-const PRODUCTIVE_GLOW = '0 0 5px 1px rgba(88,246,158,0.30), 0 0 10px 3px rgba(88,246,158,0.12)'
 
 export type VolumeZone = 'under' | 'maintenance' | 'productive' | 'approaching' | 'over'
 
@@ -83,6 +85,7 @@ interface LandmarkTickProps {
   emphasized: boolean
 }
 
+/** A full-height landmark line drawn over the track + its label/value below. */
 function LandmarkTick({ name, value, left, trackHeight, emphasized }: LandmarkTickProps) {
   const lineWidth = emphasized ? 2 : 1.5
   const color = emphasized ? t['brand-primary'] : TICK_COLOR
@@ -121,10 +124,12 @@ function LandmarkTick({ name, value, left, trackHeight, emphasized }: LandmarkTi
 
 /**
  * Horizontal weekly-volume bar with MEV / MAV / MRV landmark ticks, a HEAT-scale
- * fill positioned against the MAV target, and a % readout. Reuses the canonical
- * BodyMap volume heat scale so a muscle's training status reads the same here as
- * in the body map. Richer than DeviationBar / MesoProgressBar, which carry no
- * landmark markers.
+ * fill positioned against the MAV target, and a % readout. Composes the shared
+ * {@link ZoneTrack} gauge primitive for the track + fill (so it sits on the same
+ * base as FatigueMeter / TrainingLoadGauge rather than hand-rolling a track), and
+ * overlays the volume-specific landmark ticks. Reuses the canonical BodyMap
+ * volume heat scale so a muscle's status reads the same here as in the body map.
+ * Richer than DeviationBar / MesoProgressBar, which carry no landmark markers.
  *
  * @example
  * <VolumeLandmarkBar
@@ -150,17 +155,12 @@ export function VolumeLandmarkBar({
   const fillColor = HEAT_BY_ZONE[zone]
 
   const posFor = (value: number) => clamp01(value / max) * width
-  const fillWidth = posFor(currentSets)
-
   const pct = mav > 0 ? Math.round((currentSets / mav) * 100) : 0
 
   return (
     <View
       className={className}
       style={[{ width, gap: 4, overflow: 'visible' }, style]}
-      accessibilityRole="progressbar"
-      accessibilityValue={{ min: 0, max: Math.round(max), now: currentSets }}
-      accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}
       testID="volume-landmark-bar"
       {...props}
     >
@@ -186,31 +186,17 @@ export function VolumeLandmarkBar({
         </Text>
       </View>
 
-      <View
-        style={{
-          width,
-          height: trackHeight,
-          borderRadius: trackHeight / 2,
-          backgroundColor: TRACK_BG,
-          position: 'relative',
-          overflow: 'visible',
-        }}
-        accessibilityElementsHidden
-        testID="volume-landmark-track"
-      >
-        <View
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            width: fillWidth,
-            borderRadius: trackHeight / 2,
-            backgroundColor: fillColor,
-            zIndex: 1,
-            ...(zone === 'productive' ? { boxShadow: PRODUCTIVE_GLOW } : null),
-          }}
-          testID="volume-landmark-fill"
+      {/* The shared ZoneTrack primitive carries the track + active-zone fill + the
+          progressbar a11y; the volume landmarks are overlaid on top of it. */}
+      <View style={{ width, position: 'relative' }}>
+        <ZoneTrack
+          zones={[{ upTo: max, color: NEUTRAL_TRACK }]}
+          max={max}
+          marker={{ type: 'fill', value: currentSets, color: fillColor }}
+          trackHeight={trackHeight}
+          trackColor={NEUTRAL_TRACK}
+          accessibilityLabel={`${muscle} weekly volume: ${currentSets} sets, ${pct}% of MAV target, ${ZONE_DESCRIPTION[zone]}`}
+          testID="volume-landmark-track"
         />
 
         <LandmarkTick

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
@@ -1,0 +1,115 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View } from 'react-native'
+import { ZoneTrack, type ZoneTrackZone } from './ZoneTrack'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const { green, yellow, orange, red } = WORKOUT_TOKENS.scale
+
+const FATIGUE_ZONES: ZoneTrackZone[] = [
+  { upTo: 10, color: green },
+  { upTo: 20, color: yellow },
+  { upTo: 30, color: orange },
+  { upTo: 40, color: red },
+]
+
+const FATIGUE_TICKS = [
+  { value: 0, label: 'fresh' },
+  { value: 10, label: 'VL10' },
+  { value: 20, label: 'VL20' },
+  { value: 30, label: 'VL30' },
+  { value: 40, label: 'stop' },
+]
+
+const meta: Meta<typeof ZoneTrack> = {
+  title: 'Workout/DataViz/ZoneTrack',
+  component: ZoneTrack,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**Primitive.** The shared linear-gauge base: a pill track with an N-band zone ' +
+          'gradient, optional tick marks + labels, and a single value marker — a `needle` line ' +
+          'or a left-anchored `fill` (clip-reveal gradient, or solid trend colour). Used-by ↓ ' +
+          '[FatigueMeter](?path=/docs/workout-dataviz-fatiguemeter--docs); the target base for ' +
+          'TrainingLoadGauge (ACWR) + RpeCalibration (band + marker). Zone colours are literal ' +
+          'ramp-token hex.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 360, padding: 20, backgroundColor: '#131313' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof ZoneTrack>
+
+/** Needle over the fatigue gradient with the VL scale — the FatigueMeter shape. */
+export const Needle: Story = {
+  args: {
+    zones: FATIGUE_ZONES,
+    max: 40,
+    marker: { type: 'needle', value: 21 },
+    ticks: FATIGUE_TICKS,
+  },
+}
+
+/** Fill marker without a colour clip-reveals the gradient up to the value. */
+export const GradientFill: Story = {
+  args: {
+    zones: FATIGUE_ZONES,
+    max: 40,
+    marker: { type: 'fill', value: 24 },
+    ticks: FATIGUE_TICKS,
+  },
+}
+
+/** Fill marker with a colour paints a solid trend-coloured bar (FatigueGauge lineage). */
+export const SolidTrendFill: Story = {
+  args: { zones: FATIGUE_ZONES, max: 40, marker: { type: 'fill', value: 24, color: orange } },
+}
+
+/** A range highlight + needle — the RpeCalibration "predicted CI band vs actual" idiom. */
+export const BandWithMarker: Story = {
+  args: {
+    zones: [
+      { upTo: 7, color: green },
+      { upTo: 8.5, color: yellow },
+      { upTo: 10, color: red },
+    ],
+    min: 6,
+    max: 10,
+    band: { from: 7.2, to: 8.4, color: 'rgba(255,255,255,0.22)' },
+    marker: { type: 'needle', value: 8.1 },
+    ticks: [
+      { value: 6, label: '6' },
+      { value: 7, label: '7' },
+      { value: 8, label: '8' },
+      { value: 9, label: '9' },
+      { value: 10, label: '10' },
+    ],
+  },
+}
+
+/** Bare gradient track — no marker, no ticks. */
+export const BareTrack: Story = {
+  args: { zones: FATIGUE_ZONES, max: 40 },
+}
+
+/** Chunky wall-glanceable density via a taller track. */
+export const WallDensity: Story = {
+  args: {
+    zones: FATIGUE_ZONES,
+    max: 40,
+    marker: { type: 'needle', value: 15 },
+    ticks: FATIGUE_TICKS,
+    trackHeight: 22,
+    needleOverhang: 9,
+  },
+}

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
@@ -113,3 +113,28 @@ export const WallDensity: Story = {
     needleOverhang: 9,
   },
 }
+
+/** `marker.glow` haloes the whole track in the marker colour — a "sweet spot" / attention cue. */
+export const Glow: Story = {
+  args: {
+    zones: FATIGUE_ZONES,
+    max: 40,
+    marker: { type: 'fill', value: 20, color: green, glow: true },
+    trackHeight: 12,
+  },
+}
+
+/** Colored + emphasized ticks with tooltips — hover a label to expand the acronym / show the raw value. */
+export const ColoredTooltipTicks: Story = {
+  args: {
+    zones: FATIGUE_ZONES,
+    max: 40,
+    marker: { type: 'needle', value: 22 },
+    trackHeight: 12,
+    ticks: [
+      { value: 10, label: 'VL10', tooltip: '10% velocity loss' },
+      { value: 20, label: 'VL20', emphasized: true, tooltip: '20% velocity loss — threshold' },
+      { value: 30, label: 'STOP', color: red, tooltip: '30% velocity loss — stop the set' },
+    ],
+  },
+}

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { ZoneTrack, type ZoneTrackZone } from './ZoneTrack'
+import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+
+const { green, yellow, orange, red } = WORKOUT_TOKENS.scale
+
+const ZONES: ZoneTrackZone[] = [
+  { upTo: 10, color: green },
+  { upTo: 20, color: yellow },
+  { upTo: 30, color: orange },
+  { upTo: 40, color: red },
+]
+
+describe('ZoneTrack', () => {
+  it('renders one band per zone', () => {
+    render(<ZoneTrack zones={ZONES} max={40} />)
+    expect(screen.getAllByTestId('zone-track-band')).toHaveLength(4)
+  })
+
+  it('colours each band from the supplied zone token (literal hex, not a var ref)', () => {
+    render(<ZoneTrack zones={ZONES} max={40} />)
+    const bands = screen.getAllByTestId('zone-track-band')
+    expect(bands[0]).toHaveStyle({ backgroundColor: green })
+    expect(bands[3]).toHaveStyle({ backgroundColor: red })
+  })
+
+  it('weights each band by its domain span', () => {
+    render(
+      <ZoneTrack
+        zones={[
+          { upTo: 30, color: green },
+          { upTo: 40, color: red },
+        ]}
+        max={40}
+      />
+    )
+    const bands = screen.getAllByTestId('zone-track-band')
+    expect(bands[0]).toHaveStyle({ flexGrow: 30 })
+    expect(bands[1]).toHaveStyle({ flexGrow: 10 })
+  })
+
+  it('renders no marker when none is supplied', () => {
+    render(<ZoneTrack zones={ZONES} max={40} />)
+    expect(screen.queryByTestId('zone-track-needle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('zone-track-fill')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('zone-track-unfilled')).not.toBeInTheDocument()
+  })
+
+  it('positions a needle marker at the value fraction of the domain', () => {
+    render(<ZoneTrack zones={ZONES} max={40} marker={{ type: 'needle', value: 10 }} />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ left: '25%' })
+  })
+
+  it('clamps a needle past the max to the track end', () => {
+    render(<ZoneTrack zones={ZONES} max={40} marker={{ type: 'needle', value: 100 }} />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ left: '100%' })
+  })
+
+  it('clip-reveals the gradient for a fill marker without a colour', () => {
+    render(<ZoneTrack zones={ZONES} max={40} marker={{ type: 'fill', value: 20 }} />)
+    expect(screen.getByTestId('zone-track-unfilled')).toHaveStyle({ left: '50%' })
+    expect(screen.queryByTestId('zone-track-fill')).not.toBeInTheDocument()
+  })
+
+  it('draws a solid trend fill when the fill marker has a colour', () => {
+    render(<ZoneTrack zones={ZONES} max={40} marker={{ type: 'fill', value: 30, color: red }} />)
+    const fill = screen.getByTestId('zone-track-fill')
+    expect(fill).toHaveStyle({ width: '75%', backgroundColor: red })
+  })
+
+  it('renders a tick with its label per entry', () => {
+    render(
+      <ZoneTrack
+        zones={ZONES}
+        max={40}
+        ticks={[
+          { value: 0, label: 'fresh' },
+          { value: 40, label: 'stop' },
+        ]}
+      />
+    )
+    expect(screen.getAllByTestId('zone-track-tick')).toHaveLength(2)
+    expect(screen.getByText('fresh')).toBeInTheDocument()
+    expect(screen.getByText('stop')).toBeInTheDocument()
+  })
+
+  it('draws a range highlight only when a band is supplied', () => {
+    const { rerender } = render(<ZoneTrack zones={ZONES} max={40} />)
+    expect(screen.queryByTestId('zone-track-band-highlight')).not.toBeInTheDocument()
+    rerender(
+      <ZoneTrack
+        zones={ZONES}
+        max={40}
+        band={{ from: 10, to: 20, color: 'rgba(255,255,255,0.2)' }}
+      />
+    )
+    expect(screen.getByTestId('zone-track-band-highlight')).toHaveStyle({
+      left: '25%',
+      width: '25%',
+    })
+  })
+
+  // RNW does not map accessibilityValue → aria-valuenow under jsdom (gotcha #11), so the
+  // value is verified via the marker position + the accessible name, not aria-valuenow.
+  it('exposes the progressbar role with an accessible name', () => {
+    render(
+      <ZoneTrack
+        zones={ZONES}
+        max={40}
+        marker={{ type: 'needle', value: 12 }}
+        accessibilityLabel="Fatigue meter"
+      />
+    )
+    expect(screen.getByRole('progressbar', { name: 'Fatigue meter' })).toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(
+        <ZoneTrack
+          zones={ZONES}
+          max={40}
+          marker={{ type: 'needle', value: 21 }}
+          ticks={[
+            { value: 0, label: 'fresh' },
+            { value: 40, label: 'stop' },
+          ]}
+          accessibilityLabel="Fatigue meter"
+        />
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
@@ -3,8 +3,10 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { ZoneTrack, type ZoneTrackZone } from './ZoneTrack'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
 const { green, yellow, orange, red } = WORKOUT_TOKENS.scale
+const t = getSemanticColors('dark')
 
 const ZONES: ZoneTrackZone[] = [
   { upTo: 10, color: green },
@@ -132,6 +134,67 @@ describe('ZoneTrack', () => {
       )
       const results = await axe(container)
       expect(results).toHaveNoViolations()
+    })
+  })
+
+  describe('glow', () => {
+    it('haloes the track when the marker has glow', () => {
+      render(
+        <ZoneTrack
+          zones={ZONES}
+          max={40}
+          marker={{ type: 'fill', value: 24, color: orange, glow: true }}
+        />
+      )
+      expect((screen.getByTestId('zone-track-track') as HTMLElement).style.boxShadow).not.toBe('')
+    })
+    it('has no glow by default', () => {
+      render(
+        <ZoneTrack zones={ZONES} max={40} marker={{ type: 'fill', value: 24, color: orange }} />
+      )
+      expect((screen.getByTestId('zone-track-track') as HTMLElement).style.boxShadow).toBe('')
+    })
+  })
+
+  describe('ticks (colored lines + labels + tooltip)', () => {
+    it('renders a line and label per tick', () => {
+      render(
+        <ZoneTrack
+          zones={ZONES}
+          max={40}
+          ticks={[
+            { value: 10, label: 'A' },
+            { value: 30, label: 'B' },
+          ]}
+        />
+      )
+      expect(screen.getAllByTestId('zone-track-tick-line')).toHaveLength(2)
+      expect(screen.getAllByTestId('zone-track-tick-label').map((e) => e.textContent)).toEqual([
+        'A',
+        'B',
+      ])
+    })
+    it('colours an emphasized tick line with the brand accent', () => {
+      render(
+        <ZoneTrack zones={ZONES} max={40} ticks={[{ value: 20, label: 'T', emphasized: true }]} />
+      )
+      expect(screen.getByTestId('zone-track-tick-line')).toHaveStyle({
+        backgroundColor: t['brand-primary'],
+      })
+    })
+    it('applies a per-tick color override to the line', () => {
+      render(<ZoneTrack zones={ZONES} max={40} ticks={[{ value: 20, label: 'X', color: red }]} />)
+      expect(screen.getByTestId('zone-track-tick-line')).toHaveStyle({ backgroundColor: red })
+    })
+    it('renders a tooltip label trigger', () => {
+      render(
+        <ZoneTrack
+          zones={ZONES}
+          max={40}
+          ticks={[{ value: 20, label: 'MAV', tooltip: 'Maximum Adaptive Volume' }]}
+        />
+      )
+      expect(screen.getByText('MAV')).toBeInTheDocument()
     })
   })
 })

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
@@ -2,8 +2,15 @@
 import { View, Text, type ViewProps, type DimensionValue } from 'react-native'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { primitiveColors } from '../../../theme/tokens/primitives'
+import { alpha } from '../../../utils/colors'
+import { Tooltip } from '../../ui/tooltip/Tooltip'
 
 const t = getSemanticColors('dark')
+
+/** Soft two-stop glow in `color`, for a marker's optional `glow`. */
+function glowShadow(color: string): string {
+  return `0 0 5px 1px ${alpha(color, 0.3)}, 0 0 10px 3px ${alpha(color, 0.12)}`
+}
 
 /** Muted, un-reached track colour — a charcoal step, matches the IntensityBar track family. */
 const DEFAULT_TRACK_COLOR = primitiveColors.charcoal[200]
@@ -24,12 +31,22 @@ export interface ZoneTrackZone {
   color: string
 }
 
-/** A tick mark with an optional label, positioned at `value` in the domain. */
+/**
+ * A tick at `value`: a colored line over the track + an optional compact label
+ * below, with an optional tooltip (to expand an acronym / show the raw value so
+ * the label footer can stay light). Multiple ticks are supported.
+ */
 export interface ZoneTrackTick {
   /** Position of the tick in domain units. */
   value: number
-  /** Optional label rendered under the tick. */
+  /** Optional compact label rendered under the tick. */
   label?: string
+  /** Line + label colour. Defaults to a muted tick colour (or brand when `emphasized`). */
+  color?: string
+  /** Emphasize this tick (thicker line, brand colour by default) — e.g. a target landmark. */
+  emphasized?: boolean
+  /** Tooltip content shown on hover (web) / long-press (native) — expand the acronym, show the raw value. */
+  tooltip?: string
 }
 
 /**
@@ -39,8 +56,8 @@ export interface ZoneTrackTick {
  *   gradient up to `value`; supply `color` for a solid trend-coloured fill (FatigueGauge-style).
  */
 export type ZoneTrackMarker =
-  | { type: 'needle'; value: number; color?: string }
-  | { type: 'fill'; value: number; color?: string }
+  | { type: 'needle'; value: number; color?: string; glow?: boolean }
+  | { type: 'fill'; value: number; color?: string; glow?: boolean }
 
 /** An optional translucent range highlight (e.g. RpeCalibration's predicted CI band). */
 export interface ZoneTrackBand {
@@ -143,6 +160,11 @@ export function ZoneTrack({
             backgroundColor: trackColor,
             overflow: 'hidden',
             flexDirection: 'row',
+            // The pill's own box-shadow renders outside its overflow:hidden, so
+            // `glow` haloes the whole track in the marker colour.
+            ...(marker?.glow
+              ? { boxShadow: glowShadow(marker.color ?? DEFAULT_MARKER_COLOR) }
+              : null),
           }}
         >
           {bands.map((b, i) => (
@@ -217,41 +239,75 @@ export function ZoneTrack({
             }}
           />
         )}
+
+        {/* Colored tick lines over the track (decorative; the labels below carry the a11y). */}
+        {ticks?.map((tick, i) => {
+          const emphasized = tick.emphasized === true
+          const lineColor = tick.color ?? (emphasized ? t['brand-primary'] : TICK_COLOR)
+          const lineWidth = emphasized ? 2 : 1.5
+          return (
+            <View
+              key={`line-${i}`}
+              testID="zone-track-tick-line"
+              accessibilityElementsHidden
+              style={{
+                position: 'absolute',
+                top: (markerHeight - trackHeight) / 2 - 2,
+                left: pct(fraction(tick.value, min, max)),
+                width: lineWidth,
+                height: trackHeight + 4,
+                borderRadius: lineWidth / 2,
+                backgroundColor: lineColor,
+                transform: [{ translateX: -lineWidth / 2 }],
+                zIndex: 3,
+              }}
+            />
+          )
+        })}
       </View>
 
       {ticks != null && ticks.length > 0 && (
-        <View
-          style={{ position: 'relative', height: 14, marginTop: 4 }}
-          accessibilityElementsHidden
-        >
-          {ticks.map((tick, i) => (
-            <View
-              key={i}
-              testID="zone-track-tick"
-              style={{
-                position: 'absolute',
-                left: pct(fraction(tick.value, min, max)),
-                alignItems: 'center',
-                transform: [{ translateX: -12 }],
-                width: 24,
-              }}
-            >
-              <View style={{ width: 1, height: 3, backgroundColor: TICK_COLOR }} />
-              {tick.label != null && (
-                <Text
-                  testID="zone-track-tick-label"
-                  style={{
-                    fontSize: 8,
-                    color: TICK_COLOR,
-                    fontFamily: '"Nunito Sans", sans-serif',
-                    marginTop: 2,
-                  }}
-                >
-                  {tick.label}
-                </Text>
-              )}
-            </View>
-          ))}
+        <View style={{ position: 'relative', height: 16, marginTop: 5 }}>
+          {ticks.map((tick, i) => {
+            if (tick.label == null) return null
+            const emphasized = tick.emphasized === true
+            const labelColor = tick.color ?? (emphasized ? t['brand-primary'] : TICK_COLOR)
+            const labelNode = (
+              <Text
+                testID="zone-track-tick-label"
+                style={{
+                  fontSize: 9,
+                  letterSpacing: 0.5,
+                  color: labelColor,
+                  fontFamily: 'monospace',
+                  fontWeight: emphasized ? '700' : '400',
+                }}
+              >
+                {tick.label}
+              </Text>
+            )
+            return (
+              <View
+                key={`label-${i}`}
+                testID="zone-track-tick"
+                style={{
+                  position: 'absolute',
+                  left: pct(fraction(tick.value, min, max)),
+                  transform: [{ translateX: -14 }],
+                  width: 28,
+                  alignItems: 'center',
+                }}
+              >
+                {tick.tooltip != null ? (
+                  <Tooltip label={tick.tooltip} placement="top">
+                    {labelNode}
+                  </Tooltip>
+                ) : (
+                  labelNode
+                )}
+              </View>
+            )
+          })}
         </View>
       )}
     </View>

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
@@ -1,0 +1,259 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, Text, type ViewProps, type DimensionValue } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+
+const t = getSemanticColors('dark')
+
+/** Muted, un-reached track colour — a charcoal step, matches the IntensityBar track family. */
+const DEFAULT_TRACK_COLOR = primitiveColors.charcoal[200]
+/** Default needle / fill-marker colour. */
+const DEFAULT_MARKER_COLOR = primitiveColors.white
+/** Tick mark + tick label colour. */
+const TICK_COLOR = t['text-tertiary']
+
+const DEFAULT_TRACK_HEIGHT = 14
+const DEFAULT_NEEDLE_OVERHANG = 6
+const NEEDLE_WIDTH = 4
+
+/** A single colour band of the zone gradient, spanning `[prev.upTo, upTo]` of the domain. */
+export interface ZoneTrackZone {
+  /** Upper bound of this band in domain units. The last band's `upTo` should reach `max`. */
+  upTo: number
+  /** Band fill colour — a literal hex (RNW-safe), sourced from a ramp/effort-scale token. */
+  color: string
+}
+
+/** A tick mark with an optional label, positioned at `value` in the domain. */
+export interface ZoneTrackTick {
+  /** Position of the tick in domain units. */
+  value: number
+  /** Optional label rendered under the tick. */
+  label?: string
+}
+
+/**
+ * The value marker sitting on the track.
+ * - `needle`: a vertical line at `value`, overhanging the track (FatigueMeter / TrainingLoadGauge).
+ * - `fill`: a left-anchored fill from `min` to `value`. Omit `color` to clip-reveal the zone
+ *   gradient up to `value`; supply `color` for a solid trend-coloured fill (FatigueGauge-style).
+ */
+export type ZoneTrackMarker =
+  | { type: 'needle'; value: number; color?: string }
+  | { type: 'fill'; value: number; color?: string }
+
+/** An optional translucent range highlight (e.g. RpeCalibration's predicted CI band). */
+export interface ZoneTrackBand {
+  /** Range start in domain units. */
+  from: number
+  /** Range end in domain units. */
+  to: number
+  /** Highlight colour (typically a translucent token). */
+  color: string
+}
+
+export interface ZoneTrackProps extends ViewProps {
+  /** Ordered zone bands, laid left→right; each covers `[previous.upTo, upTo]` of the domain. */
+  zones: ZoneTrackZone[]
+  /** Domain maximum (right edge). */
+  max: number
+  /** Domain minimum (left edge). Default 0. */
+  min?: number
+  /** The value marker — a needle line or a left-anchored fill. Omit for a bare gradient track. */
+  marker?: ZoneTrackMarker | null
+  /** Optional tick marks with labels below the track. */
+  ticks?: ZoneTrackTick[]
+  /** Optional translucent range highlight drawn over the gradient. */
+  band?: ZoneTrackBand | null
+  /** Track height in px. Default 14. */
+  trackHeight?: number
+  /** How far a needle marker overhangs the track top + bottom, in px. Default 6. */
+  needleOverhang?: number
+  /** Muted colour of the track behind / beyond the fill. Default a charcoal step. */
+  trackColor?: string
+  className?: string
+}
+
+/** Map a domain value to a clamped 0..1 fraction of the track width. */
+function fraction(value: number, min: number, max: number): number {
+  if (max <= min) return 0
+  return Math.max(0, Math.min(1, (value - min) / (max - min)))
+}
+
+function pct(frac: number): DimensionValue {
+  return `${frac * 100}%`
+}
+
+/**
+ * Low-level gauge primitive: a horizontal pill track carrying an N-band zone gradient,
+ * optional tick marks with labels, and a single value marker (a needle line or a
+ * left-anchored fill). The zone bands are weighted by their domain span, so thresholds
+ * need not be evenly spaced. This is the shared visual base for the linear gauge family
+ * (FatigueMeter needle, TrainingLoadGauge zone bar, RpeCalibration band + marker) — pass
+ * the domain (`min`/`max`), the `zones`, and a `marker`; colours are literal hex from the
+ * ramp tokens (never `var()` refs, so they survive the RNW/vitest alias).
+ */
+export function ZoneTrack({
+  zones,
+  max,
+  min = 0,
+  marker = null,
+  ticks,
+  band = null,
+  trackHeight = DEFAULT_TRACK_HEIGHT,
+  needleOverhang = DEFAULT_NEEDLE_OVERHANG,
+  trackColor = DEFAULT_TRACK_COLOR,
+  className,
+  style,
+  accessibilityLabel,
+  ...props
+}: ZoneTrackProps) {
+  const isNeedle = marker?.type === 'needle'
+  const markerHeight = isNeedle ? trackHeight + needleOverhang * 2 : trackHeight
+  const markerFrac = marker != null ? fraction(marker.value, min, max) : 0
+
+  const bands = zones.map((zone, i) => {
+    const prev = i === 0 ? min : zones[i - 1].upTo
+    const start = Math.max(min, Math.min(max, prev))
+    const end = Math.max(min, Math.min(max, zone.upTo))
+    return { color: zone.color, weight: Math.max(0, end - start) }
+  })
+
+  return (
+    <View
+      className={className}
+      style={[{ width: '100%' }, style]}
+      accessibilityRole="progressbar"
+      accessibilityValue={marker != null ? { min, max, now: marker.value } : { min, max, now: min }}
+      accessibilityLabel={accessibilityLabel ?? `Zone track: ${marker?.value ?? min}`}
+      testID="zone-track"
+      {...props}
+    >
+      <View style={{ position: 'relative', height: markerHeight }}>
+        <View
+          testID="zone-track-track"
+          accessibilityElementsHidden
+          style={{
+            position: 'absolute',
+            top: (markerHeight - trackHeight) / 2,
+            left: 0,
+            right: 0,
+            height: trackHeight,
+            borderRadius: trackHeight / 2,
+            backgroundColor: trackColor,
+            overflow: 'hidden',
+            flexDirection: 'row',
+          }}
+        >
+          {bands.map((b, i) => (
+            <View
+              key={i}
+              testID="zone-track-band"
+              style={{
+                flexGrow: b.weight,
+                flexShrink: 1,
+                flexBasis: 0,
+                minWidth: 0,
+                height: '100%',
+                backgroundColor: b.color,
+              }}
+            />
+          ))}
+
+          {band != null && (
+            <View
+              testID="zone-track-band-highlight"
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: pct(fraction(band.from, min, max)),
+                width: pct(fraction(band.to, min, max) - fraction(band.from, min, max)),
+                backgroundColor: band.color,
+              }}
+            />
+          )}
+
+          {marker?.type === 'fill' && (
+            <View
+              testID="zone-track-unfilled"
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: pct(markerFrac),
+                right: 0,
+                backgroundColor: trackColor,
+              }}
+            />
+          )}
+          {marker?.type === 'fill' && marker.color != null && (
+            <View
+              testID="zone-track-fill"
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: pct(markerFrac),
+                backgroundColor: marker.color,
+              }}
+            />
+          )}
+        </View>
+
+        {isNeedle && (
+          <View
+            testID="zone-track-needle"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: pct(markerFrac),
+              width: NEEDLE_WIDTH,
+              height: markerHeight,
+              borderRadius: NEEDLE_WIDTH / 2,
+              backgroundColor: marker.color ?? DEFAULT_MARKER_COLOR,
+              transform: [{ translateX: -NEEDLE_WIDTH / 2 }],
+            }}
+          />
+        )}
+      </View>
+
+      {ticks != null && ticks.length > 0 && (
+        <View
+          style={{ position: 'relative', height: 14, marginTop: 4 }}
+          accessibilityElementsHidden
+        >
+          {ticks.map((tick, i) => (
+            <View
+              key={i}
+              testID="zone-track-tick"
+              style={{
+                position: 'absolute',
+                left: pct(fraction(tick.value, min, max)),
+                alignItems: 'center',
+                transform: [{ translateX: -12 }],
+                width: 24,
+              }}
+            >
+              <View style={{ width: 1, height: 3, backgroundColor: TICK_COLOR }} />
+              {tick.label != null && (
+                <Text
+                  testID="zone-track-tick-label"
+                  style={{
+                    fontSize: 8,
+                    color: TICK_COLOR,
+                    fontFamily: '"Nunito Sans", sans-serif',
+                    marginTop: 2,
+                  }}
+                >
+                  {tick.label}
+                </Text>
+              )}
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -189,3 +189,19 @@ export type {
   WorkoutProgress,
   WorkoutGroup,
 } from './ActiveWorkoutPage'
+export { ZoneTrack } from './ZoneTrack'
+export type {
+  ZoneTrackProps,
+  ZoneTrackZone,
+  ZoneTrackTick,
+  ZoneTrackMarker,
+  ZoneTrackBand,
+} from './ZoneTrack'
+export { FatigueMeter } from './FatigueMeter'
+export type { FatigueMeterProps } from './FatigueMeter'
+export { VolumeLandmarkBar } from './VolumeLandmarkBar'
+export type { VolumeLandmarkBarProps, VolumeZone } from './VolumeLandmarkBar'
+export { StatusPill, statusPillColor } from './StatusPill'
+export type { StatusPillProps, StatusPillStatus } from './StatusPill'
+export { LiveAuraFrame, liveAuraColor } from './LiveAuraFrame'
+export type { LiveAuraFrameProps, LiveAuraCategory } from './LiveAuraFrame'


### PR DESCRIPTION
First build wave off the consolidation map (`sources/deepdive-candidate-consolidation-map.md`) — real hardened components, not specimens.

## Components (5, all `status:review`)
- **ZoneTrack** — shared low-level gauge primitive (zone gradient · ticks · needle/fill marker · optional CI band). Prop API deliberately hosts the deferred `TrainingLoadGauge` (needle over ACWR zones) and `RpeCalibration` (CI band + marker) rewires.
- **FatigueMeter** (§3.3) — the gauge bake-off winner; needle-over-gradient, chosen by a 3-independent-source vote over FatigueGauge's linear fill.
- **VolumeLandmarkBar** (§3.7) — MEV/MAV/MRV landmark bar, reusing the canonical HEAT scale + `muscleTaxonomy`'s `VolumeLandmarks` type.
- **StatusPill** (§1) — auto-reg verdict pill, composes existing `StatusDot`.
- **LiveAuraFrame** (§1) — threshold-tied full-surface color flood.

## Integration notes
- Deduped a `VolumeLandmarks` type collision — the new component reuses `muscleTaxonomy`'s canonical MEV/MAV/MRV type instead of redefining it.
- Fixed a `react-hooks/immutability` lint error in `ZoneTrack` (render-time reassignment → index-based lookup).
- Known minor token-debt: `VolumeLandmarkBar` has 2 raw-hex constants (track bg + tick) — noted, non-blocking, appropriate for the review tier.

## Verification
tsc 0 · eslint + prettier clean · 63 new tests · full stories-smoke green (762).

Part of the staged build track (VW-36). Wave 2 (extend-existing: VelocityStrip hero+overlay, RestTimer ring, Alert fold-in) sequenced next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)