### PR TITLE
Add VelocityStrip hero variant (wall live-set treatment)

### DIFF
--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -112,6 +112,24 @@ type props without pulling the dependency.
   with a copy-paste `set` config in **`Workout/DataViz/VelocityStrip/Set
   Modalities`** (each card carries a `Collapse` accordion; promoted from the
   now-deleted `S3SetModalities` Lab specimen).
+- **VelocityStrip `hero` variant** — the across-the-room, single-set **wall**
+  treatment (the north-star live page's velocity hero). Tall bars (default 220px
+  plot) with a per-bar velocity value label, a dashed **running-best reference
+  line** (unlabeled — the tallest bar already shows the number, and the container
+  a11y label carries it), and dashed **placeholders for the reps still to come**
+  driven by a new `targetReps` prop. Absorbs the R2 `HeroVelocityBars` candidate
+  into the atom rather than shipping a parallel component. Reuses the shared zone
+  scale (`barColorFor`) and the extracted `useLiveRepPop` entrance (now shared with
+  the framed `expanded` chart). **Layout:** width-fluid (flex bars, capped at 52px,
+  left-packed) with a caller-set fixed height; the eyebrow/section title is
+  organism chrome, not part of the primitive. **Live-update model:** the plan's
+  slots are pre-allocated (`max(done, target)` columns), so a landing rep converts
+  placeholder→bar in the *same* slot with a pop — no reflow within the plan; pair
+  with `scale="fixed"` so heights never rescale either. The one reflow case is
+  set-expansion **beyond** `targetReps` (AMRAP overflow adds a column and flex-
+  narrows the rest — currently snaps; smooth overflow reflow is a deferred
+  follow-up). Documented by the `HeroPlayground` / `Hero*` stories on the wall
+  background.
 - Badge icons (WeightBadge's dumbbell, PrBadge / PrHistoryModal's star) are inline
   SVGs (`./icons.tsx`), not `lucide-react` — that dependency was dropped in 0.5.0
   to keep the root barrel light. The SVG paths mirror lucide's glyphs so rendering

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { VelocityStrip } from './VelocityStrip'
 
@@ -11,12 +11,15 @@ const meta: Meta<typeof VelocityStrip> = {
     docs: {
       description: {
         component:
-          'Per-rep velocity strip. Two variants: `mini` (a flat 3px static strip) and `expanded` ' +
-          '(the velocity-HEIGHT bar chart, rounded tops). The `expanded` chrome is prop-driven — ' +
-          'with `showNumbers`/`showInfo` on it is the framed chart (raised surface, per-bar m/s ' +
-          'labels, mean/loss info row, interactive tap-to-expand); with both off it is a bare strip, ' +
+          'Per-rep velocity strip. Three variants: `mini` (a flat 3px static strip), `expanded` ' +
+          '(the velocity-HEIGHT bar chart, rounded tops), and `hero` (the across-the-room, single-set ' +
+          'wall treatment — tall bars, per-bar value labels, a dashed running-best reference line, and ' +
+          'dashed placeholders for the reps still to come via `targetReps`). The `expanded` chrome is ' +
+          'prop-driven — with `showNumbers`/`showInfo` on it is the framed chart (raised surface, per-bar ' +
+          'm/s labels, mean/loss info row, interactive tap-to-expand); with both off it is a bare strip, ' +
           'the active-set spotlight. `height` sets the plot height; `scale` is `peak` (to the set max) ' +
-          'or `fixed` (a fixed ceiling, cross-set-comparable). Feed either `velocities` or a `set` ' +
+          'or `fixed` (a fixed ceiling, cross-set-comparable — recommended for the live `hero` so bar ' +
+          'heights never reflow as reps land). Feed either `velocities` or a `set` ' +
           'descriptor (set-type aware — see the ' +
           '[modalities](?path=/docs/workout-dataviz-velocitystrip-modalities--docs) sheet).',
       },
@@ -25,8 +28,12 @@ const meta: Meta<typeof VelocityStrip> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['mini', 'expanded'],
+      options: ['mini', 'expanded', 'hero'],
       description: 'Display variant',
+    },
+    targetReps: {
+      control: 'number',
+      description: 'hero: planned rep count — reps beyond `velocities` draw as dashed placeholders',
     },
     expanded: {
       control: 'boolean',
@@ -41,8 +48,8 @@ const meta: Meta<typeof VelocityStrip> = {
       description: 'expanded framed chart: the mean/loss info row (default true)',
     },
     height: {
-      control: { type: 'number', min: 12, max: 96, step: 2 },
-      description: 'expanded plot height in px (bars scale to this). Default 60.',
+      control: { type: 'number', min: 12, max: 260, step: 2 },
+      description: 'expanded/hero plot height in px (bars scale to this). Default 60 / 220 (hero).',
     },
     scale: {
       control: 'inline-radio',
@@ -115,6 +122,142 @@ export const ExpandedBareSpotlight: Story = {
     scale: 'fixed',
     set: { type: 'straight', velocities: [0.95, 0.9, 0.86, 0.8, 0.72], planned: 10 },
   },
+}
+
+// --- Hero variant ------------------------------------------------------------
+// The across-the-room, single-set wall treatment. Rendered on the north-star wall
+// background so the dashed reference line + placeholders read the way they will live.
+
+/**
+ * Wall-background frame for the hero stories. The eyebrow label is ORGANISM chrome
+ * (the north-star live page renders it), NOT part of the primitive — it sits here only
+ * to show the component in the context it will live in. The `VelocityStrip` hero variant
+ * itself renders no title.
+ */
+const heroDecorator: Decorator = (Story) => (
+  <View style={{ width: 560, padding: 28, backgroundColor: '#0E0E0E' }}>
+    <Text
+      style={{
+        color: '#5A5A5A',
+        fontSize: 10,
+        fontWeight: '700',
+        letterSpacing: 1,
+        marginBottom: 12,
+      }}
+    >
+      CONCENTRIC VELOCITY · THIS SET · (organism chrome — not the component)
+    </Text>
+    <Story />
+  </View>
+)
+
+const heroMidSet = [0.82, 0.79, 0.81, 0.76]
+const heroNearComplete = [0.82, 0.79, 0.81, 0.76, 0.74, 0.71, 0.68]
+const heroFatigue = [0.96, 0.91, 0.83, 0.72, 0.61, 0.5]
+
+/** Controls-driven hero: flip `velocities` / `targetReps` / `liveRepIndex` / `scale` / `height`. */
+export const HeroPlayground: Story = {
+  args: {
+    velocities: heroMidSet,
+    variant: 'hero',
+    targetReps: 8,
+    liveRepIndex: 3,
+    scale: 'fixed',
+    height: 220,
+  },
+  decorators: [heroDecorator],
+}
+
+/** Mid-set: 4 of 8 reps done, the newest bar popping, 4 dashed reps still to come. */
+export const HeroMidSet: Story = {
+  args: { velocities: heroMidSet, variant: 'hero', targetReps: 8, liveRepIndex: 3, scale: 'fixed' },
+  decorators: [heroDecorator],
+}
+
+/** Near complete: 7 of 8, one placeholder left; the running-best line sits at rep 3. */
+export const HeroNearComplete: Story = {
+  args: {
+    velocities: heroNearComplete,
+    variant: 'hero',
+    targetReps: 8,
+    liveRepIndex: 6,
+    scale: 'fixed',
+  },
+  decorators: [heroDecorator],
+}
+
+/** Fatigue decline: velocity falling rep over rep — the shape you read across the room. */
+export const HeroFatigueDecline: Story = {
+  args: {
+    velocities: heroFatigue,
+    variant: 'hero',
+    targetReps: 8,
+    liveRepIndex: 5,
+    scale: 'fixed',
+  },
+  decorators: [heroDecorator],
+}
+
+/** Ends on the best rep: the running-best line lands on the last (live) bar's top. */
+export const HeroEndsOnBest: Story = {
+  args: {
+    velocities: [0.7, 0.76, 0.83, 0.9],
+    variant: 'hero',
+    targetReps: 4,
+    liveRepIndex: 3,
+    scale: 'peak',
+  },
+  decorators: [heroDecorator],
+}
+
+/**
+ * Set expansion — reps performed BEYOND `targetReps` (11 done vs 8 planned). Placeholders
+ * are gone (target met) and the extra reps just render as more bars; `flex` bars narrow to
+ * fit, so the chart absorbs the overflow with no clipping. The AMRAP "keep going" case.
+ */
+export const HeroExceedsTarget: Story = {
+  args: {
+    velocities: [0.9, 0.87, 0.84, 0.8, 0.77, 0.74, 0.71, 0.68, 0.64, 0.6, 0.55],
+    variant: 'hero',
+    targetReps: 8,
+    liveRepIndex: 10,
+    scale: 'fixed',
+  },
+  decorators: [heroDecorator],
+}
+
+/** Set complete: 8 of 8, no placeholders. */
+export const HeroComplete: Story = {
+  args: {
+    velocities: [0.96, 0.91, 0.83, 0.79, 0.76, 0.72, 0.68, 0.61],
+    variant: 'hero',
+    targetReps: 8,
+    scale: 'fixed',
+  },
+  decorators: [heroDecorator],
+}
+
+/** The same set at three container widths — the hero is width-fluid (flex bars, capped width, fixed height). */
+export const HeroResponsive: Story = {
+  render: () => (
+    <View style={{ gap: 24, padding: 24, backgroundColor: '#0E0E0E' }}>
+      {[360, 560, 900].map((w) => (
+        <View key={w} style={{ width: w }}>
+          <Text style={{ color: '#5A5A5A', fontSize: 10, fontWeight: '700', marginBottom: 8 }}>
+            {w}px
+          </Text>
+          <VelocityStrip
+            velocities={heroFatigue}
+            variant="hero"
+            targetReps={8}
+            liveRepIndex={5}
+            scale="fixed"
+            height={180}
+          />
+        </View>
+      ))}
+    </View>
+  ),
 }
 
 /** A structured set descriptor (a drop set): the mini variant carries the set-type gap/color encoding. */

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.test.tsx
@@ -564,3 +564,67 @@ describe('VelocityStrip expanded bare strip (spotlight: numbers + info off)', ()
     expect(await axe(container)).toHaveNoViolations()
   })
 })
+
+describe('VelocityStrip hero variant', () => {
+  const heroSet = [0.9, 0.86, 0.82, 0.78]
+
+  it('renders one bar per performed rep, each with a value label', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" targetReps={8} />)
+    expect(screen.getByTestId('velocity-strip-hero')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(heroSet.length)
+    expect(screen.getAllByTestId(/^velocity-label-\d+$/)).toHaveLength(heroSet.length)
+    expect(screen.getByTestId('velocity-label-0')).toHaveTextContent('0.90')
+  })
+
+  it('draws a dashed placeholder for each rep still to come (target − done)', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" targetReps={8} />)
+    expect(screen.getAllByTestId('velocity-slot-todo')).toHaveLength(4)
+  })
+
+  it('draws no placeholders when the target is met exactly', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" targetReps={heroSet.length} />)
+    expect(screen.queryByTestId('velocity-slot-todo')).not.toBeInTheDocument()
+  })
+
+  it('set expansion: reps beyond target render as bars with no negative placeholders', () => {
+    const overflow = [0.9, 0.86, 0.82, 0.78, 0.74, 0.7, 0.66, 0.62, 0.58]
+    render(<VelocityStrip velocities={overflow} variant="hero" targetReps={8} />)
+    expect(screen.getAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(overflow.length)
+    expect(screen.queryByTestId('velocity-slot-todo')).not.toBeInTheDocument()
+  })
+
+  it('draws no placeholders when targetReps is omitted', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" />)
+    expect(screen.getAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(heroSet.length)
+    expect(screen.queryByTestId('velocity-slot-todo')).not.toBeInTheDocument()
+  })
+
+  it('renders the running-best reference line when there is a positive best', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" targetReps={8} />)
+    expect(screen.getByTestId('velocity-hero-reference')).toBeInTheDocument()
+  })
+
+  it('omits the reference line when every velocity is zero (NaN / no-best guard)', () => {
+    render(<VelocityStrip velocities={[0, 0, 0]} variant="hero" targetReps={4} />)
+    expect(screen.queryByTestId('velocity-hero-reference')).not.toBeInTheDocument()
+  })
+
+  it('summarizes reps done, target and best in the accessibility label', () => {
+    render(<VelocityStrip velocities={heroSet} variant="hero" targetReps={8} />)
+    expect(
+      screen.getByLabelText('Velocity chart, 4 of 8 reps, best 0.90 meters per second')
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when neither velocities nor set is provided', () => {
+    render(<VelocityStrip variant="hero" targetReps={8} />)
+    expect(screen.queryByTestId('velocity-strip-hero')).not.toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <VelocityStrip velocities={heroSet} variant="hero" targetReps={8} liveRepIndex={3} />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -84,15 +84,24 @@ export interface VelocityStripProps extends ViewProps {
    * HEIGHT bar chart (rounded tops), whose chrome is prop-driven: with
    * {@link showNumbers} or {@link showInfo} on it's the framed chart (raised surface,
    * padding, per-bar m/s labels, mean/loss info row, interactive collapse); with both
-   * off it's a bare strip — the active-set "spotlight" of {@link ExerciseCard}.
+   * off it's a bare strip — the active-set "spotlight" of {@link ExerciseCard}. `hero`
+   * — the across-the-room, single-set wall treatment: tall bars, a per-bar m/s value
+   * label, a dashed running-best reference line, and dashed placeholders for the reps
+   * still to come (see {@link targetReps}). Reuses the zone scale and the live-rep pop.
    */
-  variant?: 'mini' | 'expanded'
-  /** `expanded` plot height in px (bars scale to this). Default 60. */
+  variant?: 'mini' | 'expanded' | 'hero'
+  /** `expanded` / `hero` plot height in px (bars scale to this). Default 60 (`expanded`) / 220 (`hero`). */
   height?: number
   /**
-   * `expanded` bar scaling. `peak` (default) scales to the set's own max (+15%
-   * headroom). `fixed` scales to a fixed velocity ceiling so bar heights read the
-   * same absolute velocity across sets (the spotlight).
+   * `hero` only: the set's planned rep count. Reps beyond {@link velocities} draw as
+   * dashed placeholder stubs so the wall reads "3 of 8 done" at a glance. Ignored
+   * (and no placeholders drawn) when absent or ≤ the performed-rep count.
+   */
+  targetReps?: number
+  /**
+   * `expanded` / `hero` bar scaling. `peak` (default) scales to the set's own max
+   * (+15% headroom). `fixed` scales to a fixed velocity ceiling so bar heights read
+   * the same absolute velocity across sets (the spotlight).
    */
   scale?: 'peak' | 'fixed'
   /** `expanded` framed chart: per-bar m/s labels. Default true. */
@@ -372,6 +381,28 @@ const FIXED_MAX_VELOCITY = 1.15
 /** Minimum bare-strip bar height (px) — a planned / variable / continue stub, or a near-zero rep. */
 const BARE_STUB_HEIGHT = 3
 
+// --- Hero variant ------------------------------------------------------------
+// The across-the-room, single-set wall treatment. Absorbs the R2 "HeroVelocityBars"
+// candidate into VelocityStrip: tall bars + per-bar value labels + a dashed
+// running-best reference line + dashed placeholders for the reps still to come.
+
+/** Default `hero` plot height (px) — tall enough to read a set's velocity shape across a room. */
+const HERO_HEIGHT = 220
+/** Vertical band reserved above the tallest bar for its value label (px). */
+const HERO_LABEL_HEADROOM = 20
+/** Gap between hero bars (px) — a group-notch-free even rhythm at wall scale. */
+const HERO_BAR_GAP = 8
+/** Cap on a single hero bar's width so a 2–3 rep set doesn't render slab-wide bars (px). */
+const HERO_BAR_MAX_WIDTH = 52
+/** Top-corner radius on hero bars (px). */
+const HERO_BAR_RADIUS = 5
+/** Minimum drawn height of a performed hero bar (px) — a near-zero rep still reads as a rep. */
+const HERO_MIN_BAR_HEIGHT = 4
+/** Dashed-stub border for a planned-but-unperformed hero rep (charcoal, reads on a dark wall). */
+const HERO_PENDING_COLOR = primitiveColors.charcoal[100]
+/** The dashed running-best reference line + its label (the lightest charcoal step). */
+const HERO_REFERENCE_COLOR = primitiveColors.charcoal[0]
+
 /** The bar-height scaling denominator for the given `scale` (guarded ≥ 0 by callers). */
 function scaleDenominator(scale: 'peak' | 'fixed', maxVelocity: number): number {
   return scale === 'fixed' ? FIXED_MAX_VELOCITY : maxVelocity * 1.15
@@ -407,6 +438,229 @@ const ANIMATION_DURATION = 400
 const ANIMATION_EASING = Easing.bezier(0.22, 1, 0.36, 1)
 const POP_EASING = Easing.bezier(0.34, 1.56, 0.64, 1)
 
+/**
+ * The newest-rep entrance shared by the framed `expanded` chart and `hero`: a
+ * bounce when the rep is a new set peak, a pop otherwise. Honors reduced motion.
+ * Returns the scale `Animated.Value` for the live bar; inert while `active` is
+ * false or no live rep is present.
+ */
+function useLiveRepPop(
+  active: boolean,
+  liveRepIndex: number | undefined,
+  liveVelocity: number | undefined,
+  isNewPeak: boolean
+): Animated.Value {
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const [liveScale] = useState(() => new Animated.Value(1))
+  useEffect(() => {
+    if (!active || liveRepIndex == null || liveVelocity == null) return
+    if (prefersReducedMotion) {
+      liveScale.setValue(1)
+      return
+    }
+    if (isNewPeak) {
+      liveScale.setValue(1)
+      Animated.sequence([
+        Animated.timing(liveScale, {
+          toValue: 1.25,
+          duration: 150,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.spring(liveScale, {
+          toValue: 1,
+          friction: 3,
+          tension: 140,
+          useNativeDriver: true,
+        }),
+      ]).start()
+    } else {
+      liveScale.setValue(0.8)
+      Animated.timing(liveScale, {
+        toValue: 1,
+        duration: 300,
+        easing: POP_EASING,
+        useNativeDriver: true,
+      }).start()
+    }
+  }, [active, liveRepIndex, liveVelocity, isNewPeak, prefersReducedMotion, liveScale])
+  return liveScale
+}
+
+interface HeroVelocityChartProps {
+  /** Performed per-rep mean concentric velocities (m/s). */
+  doneVelocities: number[]
+  /** Zone → color resolver, shared with the other variants (single-sources the scale). */
+  barColorFor: (velocity: number) => string
+  /** Bar-height scaling denominator (`peak` set-max or `fixed` ceiling). */
+  scaleDenom: number
+  /** Running-best velocity (the set peak) — drives the dashed reference line. */
+  referenceVelocity: number
+  liveRepIndex?: number
+  isNewPeak: boolean
+  targetReps?: number
+  height: number
+  className?: string
+  viewProps: ViewProps
+}
+
+/**
+ * The `hero` render: the across-the-room, single-set wall treatment. Tall bars +
+ * a per-bar value label + a dashed running-best reference line + dashed placeholders
+ * for the reps still to come. Reuses {@link barColorFor} (zone scale) and the
+ * {@link useLiveRepPop} entrance so it stays consistent with the framed chart.
+ */
+function HeroVelocityChart({
+  doneVelocities,
+  barColorFor,
+  scaleDenom,
+  referenceVelocity,
+  liveRepIndex,
+  isNewPeak,
+  targetReps,
+  height,
+  className,
+  viewProps,
+}: HeroVelocityChartProps) {
+  const liveVelocity = liveRepIndex != null ? doneVelocities[liveRepIndex] : undefined
+  const liveScale = useLiveRepPop(true, liveRepIndex, liveVelocity, isNewPeak)
+
+  // Reserve a band above the tallest bar for its value label so a peak bar never clips.
+  const plotHeight = Math.max(0, height - HERO_LABEL_HEADROOM)
+  const barHeight = (velocity: number): number =>
+    scaleDenom > 0
+      ? Math.max(HERO_MIN_BAR_HEIGHT, Math.min(1, velocity / scaleDenom) * plotHeight)
+      : HERO_MIN_BAR_HEIGHT
+
+  const pendingCount = Math.max(0, (targetReps ?? 0) - doneVelocities.length)
+  const referencePx =
+    referenceVelocity > 0 && scaleDenom > 0
+      ? Math.min(plotHeight, (referenceVelocity / scaleDenom) * plotHeight)
+      : 0
+
+  const repCount = doneVelocities.length
+  const total = Math.max(repCount, targetReps ?? repCount)
+  const label =
+    referenceVelocity > 0
+      ? `Velocity chart, ${repCount} of ${total} reps, best ${formatVelocity(referenceVelocity)} meters per second`
+      : `Velocity chart, ${repCount} of ${total} reps`
+
+  const { style: externalStyle, ...restProps } = viewProps
+
+  return (
+    <View
+      className={className}
+      style={[{ height }, externalStyle]}
+      accessibilityRole="image"
+      accessibilityLabel={label}
+      testID="velocity-strip-hero"
+      {...restProps}
+    >
+      <View
+        style={{
+          flex: 1,
+          flexDirection: 'row',
+          alignItems: 'flex-end',
+          gap: HERO_BAR_GAP,
+          position: 'relative',
+          borderBottomWidth: 2,
+          borderBottomColor: HERO_PENDING_COLOR,
+        }}
+      >
+        {/*
+         * Running-best reference line. Deliberately unlabeled: it sits at the tallest
+         * bar's top, and that bar already displays its velocity as its own value label,
+         * so a "best X.XX" tag would duplicate it — and would collide with that label
+         * whenever the peak bar is on the same side (declines peak-left, ends-on-best
+         * peak-right). The line alone reads as "how far has velocity fallen from best".
+         * The numeric best is in the container's accessibility label.
+         */}
+        {referencePx > 0 && (
+          <View
+            accessibilityElementsHidden
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: referencePx,
+              borderTopWidth: 1,
+              borderStyle: 'dashed',
+              borderColor: HERO_REFERENCE_COLOR,
+              pointerEvents: 'none',
+            }}
+            testID="velocity-hero-reference"
+          />
+        )}
+
+        {doneVelocities.map((velocity, i) => {
+          const isLive = liveRepIndex === i
+          return (
+            <View
+              key={i}
+              accessibilityElementsHidden
+              style={{
+                flex: 1,
+                maxWidth: HERO_BAR_MAX_WIDTH,
+                height: '100%',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Text
+                className="text-text-primary"
+                style={{ fontSize: 12, fontWeight: '800', marginBottom: 4 }}
+                testID={`velocity-label-${i}`}
+              >
+                {formatVelocity(velocity)}
+              </Text>
+              <Animated.View
+                style={[
+                  {
+                    width: '100%',
+                    height: barHeight(velocity),
+                    borderTopLeftRadius: HERO_BAR_RADIUS,
+                    borderTopRightRadius: HERO_BAR_RADIUS,
+                    backgroundColor: barColorFor(velocity),
+                  },
+                  isLive ? { transform: [{ scale: liveScale }] } : null,
+                ]}
+                testID={`velocity-bar-${i}`}
+              />
+            </View>
+          )
+        })}
+
+        {Array.from({ length: pendingCount }, (_, i) => (
+          <View
+            key={`pending-${i}`}
+            accessibilityElementsHidden
+            style={{
+              flex: 1,
+              maxWidth: HERO_BAR_MAX_WIDTH,
+              height: '100%',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <View
+              style={{
+                width: '100%',
+                height: HERO_MIN_BAR_HEIGHT * 3,
+                borderWidth: 1,
+                borderStyle: 'dashed',
+                borderColor: HERO_PENDING_COLOR,
+                borderTopLeftRadius: HERO_BAR_RADIUS,
+                borderTopRightRadius: HERO_BAR_RADIUS,
+              }}
+              testID="velocity-slot-todo"
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}
+
 export function VelocityStrip({
   velocities,
   set,
@@ -417,6 +671,7 @@ export function VelocityStrip({
   onRepPress,
   variant = 'expanded',
   height = EXPANDED_HEIGHT,
+  targetReps,
   scale = 'peak',
   showNumbers = true,
   showInfo = true,
@@ -456,47 +711,19 @@ export function VelocityStrip({
     ? (classifyBand(meanVelocity, zones)?.label ?? '')
     : getVelocityZoneName(meanVelocity)
 
-  const prefersReducedMotion = usePrefersReducedMotion()
   const [heightAnim] = useState(() => new Animated.Value(expanded ? height : 3))
   const [labelOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
   const [infoOpacity] = useState(() => new Animated.Value(expanded ? 1 : 0))
-  const [liveScale] = useState(() => new Animated.Value(1))
 
   // Newest-rep animation: pop for a normal rep, bounce when it sets a new peak.
   const liveVelocity = liveRepIndex != null ? doneVelocities[liveRepIndex] : undefined
   const isNewPeak = liveVelocity != null && maxVelocity > 0 && liveVelocity === maxVelocity
-  useEffect(() => {
-    if (variant !== 'expanded' || !framed || liveRepIndex == null || liveVelocity == null) return
-    if (prefersReducedMotion) {
-      liveScale.setValue(1)
-      return
-    }
-    if (isNewPeak) {
-      liveScale.setValue(1)
-      Animated.sequence([
-        Animated.timing(liveScale, {
-          toValue: 1.25,
-          duration: 150,
-          easing: Easing.out(Easing.quad),
-          useNativeDriver: true,
-        }),
-        Animated.spring(liveScale, {
-          toValue: 1,
-          friction: 3,
-          tension: 140,
-          useNativeDriver: true,
-        }),
-      ]).start()
-    } else {
-      liveScale.setValue(0.8)
-      Animated.timing(liveScale, {
-        toValue: 1,
-        duration: 300,
-        easing: POP_EASING,
-        useNativeDriver: true,
-      }).start()
-    }
-  }, [variant, framed, liveRepIndex, liveVelocity, isNewPeak, prefersReducedMotion, liveScale])
+  const liveScale = useLiveRepPop(
+    variant === 'expanded' && framed,
+    liveRepIndex,
+    liveVelocity,
+    isNewPeak
+  )
 
   useEffect(() => {
     if (variant !== 'expanded' || !framed) return
@@ -528,6 +755,26 @@ export function VelocityStrip({
 
   const repCount = doneVelocities.length
   const miniLabel = set ? setAccessibilityLabel(set, repCount) : `Velocity strip, ${repCount} reps`
+
+  if (variant === 'hero') {
+    // Hero's plot is far taller than the expanded chart; apply its own default when
+    // the caller left `height` at the shared 60px default.
+    const heroHeight = height === EXPANDED_HEIGHT ? HERO_HEIGHT : height
+    return (
+      <HeroVelocityChart
+        doneVelocities={doneVelocities}
+        barColorFor={barColorFor}
+        scaleDenom={scaleDenom}
+        referenceVelocity={maxVelocity}
+        liveRepIndex={liveRepIndex}
+        isNewPeak={isNewPeak}
+        targetReps={targetReps}
+        height={heroHeight}
+        className={className}
+        viewProps={props}
+      />
+    )
+  }
 
   if (variant === 'mini') {
     const { style: externalStyle, ...restProps } = props


### PR DESCRIPTION
## What

Adds `variant="hero"` + a `targetReps` prop to **VelocityStrip** — the across-the-room, single-set **wall** treatment for the north-star live page's velocity hero. It **absorbs the R2 `HeroVelocityBars` candidate into the existing atom** rather than shipping a parallel component (the consolidation decision: VelocityStrip-hero > HeroVelocityBars).

Wave-2 titan build #1 for VW-38 (MCP dashboard live view). Built through the titan two-gate DoD pipeline; Gate 1 (invest + overlap survey) and Gate 2 (operator Storybook validation) both cleared.

## The variant

- Tall bars (default 220px plot), per-bar velocity value labels, zone-colored via the **shared** `barColorFor` scale
- **Dashed running-best reference line** — deliberately *unlabeled*: the tallest bar already shows the number, and the container a11y label carries `best X.XX`. (Dropped the fork's `best 0.96` text — it duplicated the peak bar's label and collided with it whenever the peak was on that side.)
- **Dashed placeholders** for reps still to come, via the new `targetReps` prop
- Reuses the extracted **`useLiveRepPop`** hook (now shared with the framed `expanded` chart — behavior-preserving refactor, all 62 prior tests pass)

## Live-update / animation model

- **Within the plan (done ≤ target): reflow-free.** `max(done, target)` columns are pre-allocated, so a landing rep converts placeholder→bar *in the same slot* with a pop — nothing else moves.
- Pair with **`scale="fixed"`** (what North Star passes) so bar heights never rescale as reps land.
- **The one reflow case** is set-expansion *beyond* `targetReps` (AMRAP overflow adds a column and flex-narrows the rest). It **snaps** today — smooth overflow reflow is a deferred follow-up (below).

## Layout / responsiveness

Width-fluid (flex bars, capped at 52px, left-packed), caller-set fixed height, fixed label size. The eyebrow/section title is **organism chrome**, not part of the primitive (the story decorator makes this explicit).

## Tests & gates

- **10 new unit tests** (bars/labels, placeholder count, target-met, set-expansion, no-target, reference line, zero-velocity guard, a11y label, empty render, axe) → **72/72 pass**
- `type-check` · `eslint` · `prettier` · `vitest` all green
- Token-pure (charcoal refs, no raw hex)

## Deferred follow-ups (documented, not blockers)

- **Smooth beyond-target reflow animation** (AMRAP overflow width transition) — decided to ship the pop model now
- **Seed VelocityStrip visual-regression baselines** — the family isn't in the Playwright `stories.spec.ts` scope yet (scope is `shell-`/`icons-`); seeding needs the pinned Linux container
- **`size='wall'` font-density** — the separate Wave-2 item (TempoBar/FatigueMeter)

## Screenshots

Rendered on the wall background across states: mid-set (4/8), near-complete (7/8), fatigue-decline (zone transition), ends-on-best (line at peak, no collision), exceeds-target (11 vs 8, overflow absorbed), and the same set at 360/560/900px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)