### PR TITLE
Add Alert compact cue variant (absorbs CueFlag)

### DIFF
--- a/packages/ui/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/ui/src/components/ui/alert/Alert.stories.tsx
@@ -1,11 +1,25 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
-import { View } from 'react-native'
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
 import { Alert, AlertTitle, AlertDescription } from './Alert'
 
 const meta: Meta<typeof Alert> = {
   title: 'Components/Molecules/Alert',
   component: Alert,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Status callout across 4 statuses (success/info/warning/error) × 3 variants ' +
+          '(subtle/outline/solid). Two densities via `size`: `default` — the padded ' +
+          'icon + title/description block; `compact` — a single-line **cue pill** (tighter, ' +
+          'center-aligned, hairline status border on `subtle`) that absorbs the R2 `CueFlag` ' +
+          'live-coaching cue. Pass `size="compact"` + `message="…"` for the batteries-included ' +
+          "status-colored one-liner (RN doesn't cascade text color, so the `message` prop " +
+          'colors it for you). Use `<AlertTitle>` / `<AlertDescription>` children for richer content.',
+      },
+    },
+  },
   argTypes: {
     status: {
       control: 'select',
@@ -15,6 +29,11 @@ const meta: Meta<typeof Alert> = {
       control: 'select',
       options: ['subtle', 'outline', 'solid'],
     },
+    size: {
+      control: 'inline-radio',
+      options: ['default', 'compact'],
+    },
+    message: { control: 'text' },
     showIcon: { control: 'boolean' },
   },
 }
@@ -150,5 +169,69 @@ export const DescriptionOnly: Story = {
     <Alert status="info">
       <AlertDescription>Simple alert with description only, no title.</AlertDescription>
     </Alert>
+  ),
+}
+
+// --- Compact cue pill (absorbs CueFlag) --------------------------------------
+// The across-the-room live coaching cue. Rendered on the north-star wall background
+// so the tinted + bordered pill reads the way it will live.
+
+/** Wall-background frame for the compact cue stories. */
+const wall: Decorator = (Story) => (
+  <View style={{ width: 460, padding: 28, backgroundColor: '#0E0E0E' }}>
+    <Story />
+  </View>
+)
+
+/** Compact warning cue — the VL20 approach-threshold flag (batteries-included `message`). */
+export const CompactWarningCue: Story = {
+  args: {
+    status: 'warning',
+    variant: 'subtle',
+    size: 'compact',
+    message: 'VL20 · target reps met — final rep or end the set.',
+  },
+  decorators: [wall],
+}
+
+/** Compact error cue — the stop-now flag. */
+export const CompactErrorCue: Story = {
+  args: {
+    status: 'error',
+    variant: 'subtle',
+    size: 'compact',
+    message: 'Velocity loss 31% — end the set now.',
+  },
+  decorators: [wall],
+}
+
+/** The consumption target: the north-star live cue (interpolated loss). */
+export const CompactLiveCue: Story = {
+  args: {
+    status: 'warning',
+    variant: 'subtle',
+    size: 'compact',
+    message: 'Approaching threshold · 18% velocity loss — one or two reps left.',
+  },
+  decorators: [wall],
+}
+
+/** Default vs compact, side by side, for the density comparison. */
+export const DefaultVsCompact: Story = {
+  render: () => (
+    <View style={{ gap: 16, width: 460, padding: 28, backgroundColor: '#0E0E0E' }}>
+      <Text style={{ color: '#5A5A5A', fontSize: 10, fontWeight: '700' }}>DEFAULT</Text>
+      <Alert status="warning" variant="subtle">
+        <AlertTitle>Approaching threshold</AlertTitle>
+        <AlertDescription>18% velocity loss — one or two reps left in the band.</AlertDescription>
+      </Alert>
+      <Text style={{ color: '#5A5A5A', fontSize: 10, fontWeight: '700' }}>COMPACT (cue pill)</Text>
+      <Alert
+        status="warning"
+        variant="subtle"
+        size="compact"
+        message="Approaching threshold · 18% velocity loss — reps left in band."
+      />
+    </View>
   ),
 }

--- a/packages/ui/src/components/ui/alert/Alert.test.tsx
+++ b/packages/ui/src/components/ui/alert/Alert.test.tsx
@@ -200,3 +200,55 @@ describe('Alert', () => {
     })
   })
 })
+
+describe('Alert compact cue (absorbs CueFlag)', () => {
+  it('renders the message as content (batteries-included cue)', () => {
+    render(<Alert status="warning" size="compact" message="VL20 · end the set" />)
+    expect(screen.getByTestId('alert-message')).toHaveTextContent('VL20 · end the set')
+  })
+
+  it('renders the message alongside a status glyph and the alert role', () => {
+    render(<Alert status="error" size="compact" message="Stop now" />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('✕')).toBeInTheDocument()
+    expect(screen.getByText('Stop now')).toBeInTheDocument()
+  })
+
+  it('renders message in the default size too', () => {
+    render(<Alert status="info" message="Heads up" />)
+    expect(screen.getByTestId('alert-message')).toHaveTextContent('Heads up')
+  })
+
+  it('renders children after the message when both are given', () => {
+    render(
+      <Alert status="warning" size="compact" message="Cue line">
+        <AlertDescription>Extra detail</AlertDescription>
+      </Alert>
+    )
+    expect(screen.getByTestId('alert-message')).toHaveTextContent('Cue line')
+    expect(screen.getByText('Extra detail')).toBeInTheDocument()
+  })
+
+  it('omits the message node when no message is passed', () => {
+    render(
+      <Alert status="warning" size="compact">
+        <AlertDescription>Just children</AlertDescription>
+      </Alert>
+    )
+    expect(screen.queryByTestId('alert-message')).not.toBeInTheDocument()
+    expect(screen.getByText('Just children')).toBeInTheDocument()
+  })
+
+  it('still respects showIcon=false in compact', () => {
+    render(<Alert status="warning" size="compact" message="No icon cue" showIcon={false} />)
+    expect(screen.queryByText('⚠')).not.toBeInTheDocument()
+    expect(screen.getByText('No icon cue')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations as a compact cue', async () => {
+    const { container } = render(
+      <Alert status="warning" size="compact" message="VL20 · target reps met — end the set." />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/ui/src/components/ui/alert/Alert.tsx
+++ b/packages/ui/src/components/ui/alert/Alert.tsx
@@ -4,12 +4,29 @@ import { cn } from '../../../utils/cn'
 
 export type AlertStatus = 'success' | 'info' | 'warning' | 'error'
 export type AlertVariant = 'subtle' | 'outline' | 'solid'
+export type AlertSize = 'default' | 'compact'
 
 export interface AlertProps extends ViewProps {
   /** Alert status type */
   status?: AlertStatus
   /** Visual variant */
   variant?: AlertVariant
+  /**
+   * Density. `default` — the padded callout (icon + title/description block).
+   * `compact` — a single-line **cue pill** (tighter padding, center-aligned, and a
+   * hairline status border on the `subtle` variant): the across-the-room live coaching
+   * cue (absorbs the R2 `CueFlag` — e.g. a velocity-loss threshold warning). Pair with
+   * the {@link message} prop for the batteries-included colored one-liner.
+   */
+  size?: AlertSize
+  /**
+   * Convenience single-line content: renders as **status-colored, bold** text (white on
+   * `solid`) — the batteries-included cue message, so a `compact` cue is just
+   * `<Alert status="warning" size="compact" message="VL20 · …" />` with no need to
+   * hand-color the text (RN doesn't cascade color). Renders before {@link children},
+   * which stay available for richer content.
+   */
+  message?: string
   /** Custom icon element */
   icon?: React.ReactNode
   /** Whether to show the default icon */
@@ -21,17 +38,22 @@ export interface AlertProps extends ViewProps {
   children?: React.ReactNode
 }
 
-const statusColors: Record<AlertStatus, {
-  subtle: string
-  outline: string
-  solid: string
-  icon: string
-  text: string
-}> = {
+const statusColors: Record<
+  AlertStatus,
+  {
+    subtle: string
+    outline: string
+    solid: string
+    border: string
+    icon: string
+    text: string
+  }
+> = {
   success: {
     subtle: 'bg-status-success-subtle',
     outline: 'border-2 border-status-success bg-transparent',
     solid: 'bg-status-success',
+    border: 'border-status-success',
     icon: 'text-status-success',
     text: 'text-status-success',
   },
@@ -39,6 +61,7 @@ const statusColors: Record<AlertStatus, {
     subtle: 'bg-status-info-subtle',
     outline: 'border-2 border-status-info bg-transparent',
     solid: 'bg-status-info',
+    border: 'border-status-info',
     icon: 'text-status-info',
     text: 'text-status-info',
   },
@@ -46,6 +69,7 @@ const statusColors: Record<AlertStatus, {
     subtle: 'bg-status-warning-subtle',
     outline: 'border-2 border-status-warning bg-transparent',
     solid: 'bg-status-warning',
+    border: 'border-status-warning',
     icon: 'text-status-warning',
     text: 'text-status-warning',
   },
@@ -53,6 +77,7 @@ const statusColors: Record<AlertStatus, {
     subtle: 'bg-status-error-subtle',
     outline: 'border-2 border-status-error bg-transparent',
     solid: 'bg-status-error',
+    border: 'border-status-error',
     icon: 'text-status-error',
     text: 'text-status-error',
   },
@@ -82,6 +107,8 @@ const defaultIcons: Record<AlertStatus, string> = {
 export function Alert({
   status = 'info',
   variant = 'subtle',
+  size = 'default',
+  message,
   icon,
   showIcon = true,
   onClose,
@@ -91,23 +118,30 @@ export function Alert({
 }: AlertProps) {
   const colors = statusColors[status]
   const isSolid = variant === 'solid'
+  const isCompact = size === 'compact'
 
   return (
     <View
       accessibilityRole="alert"
       className={cn(
-        'flex-row items-start p-4 rounded-lg',
+        isCompact
+          ? 'flex-row items-center px-3 py-2 rounded-lg'
+          : 'flex-row items-start p-4 rounded-lg',
         colors[variant],
+        // A compact `subtle` pill gets a hairline status border so it reads as a
+        // defined cue on a dark wall (the CueFlag look); other variants carry their own.
+        isCompact && variant === 'subtle' && cn('border', colors.border),
         className
       )}
       {...props}
     >
       {showIcon && (
-        <View className="mr-3 mt-0.5">
+        <View className={isCompact ? 'mr-2' : 'mr-3 mt-0.5'}>
           {icon || (
             <Text
               className={cn(
-                'text-lg font-bold',
+                'font-bold',
+                isCompact ? 'text-base' : 'text-lg',
                 isSolid ? 'text-white' : colors.icon
               )}
             >
@@ -118,6 +152,14 @@ export function Alert({
       )}
 
       <View className="flex-1">
+        {message != null && (
+          <Text
+            className={cn('text-sm font-semibold', isSolid ? 'text-white' : colors.text)}
+            testID="alert-message"
+          >
+            {message}
+          </Text>
+        )}
         {children}
       </View>
 
@@ -146,11 +188,7 @@ export interface AlertTitleProps {
  * Title for Alert component.
  */
 export function AlertTitle({ children, className }: AlertTitleProps) {
-  return (
-    <Text className={cn('font-semibold text-text-primary mb-1', className)}>
-      {children}
-    </Text>
-  )
+  return <Text className={cn('font-semibold text-text-primary mb-1', className)}>{children}</Text>
 }
 
 export interface AlertDescriptionProps {
@@ -162,9 +200,5 @@ export interface AlertDescriptionProps {
  * Description for Alert component.
  */
 export function AlertDescription({ children, className }: AlertDescriptionProps) {
-  return (
-    <Text className={cn('text-sm text-text-secondary', className)}>
-      {children}
-    </Text>
-  )
+  return <Text className={cn('text-sm text-text-secondary', className)}>{children}</Text>
 }


### PR DESCRIPTION
## What

Gives **Alert** a compact **cue pill** form that absorbs the R2 **CueFlag** candidate — the across-the-room live coaching cue for the north-star wall dashboard. Wave-2 titan build #3 for VW-38. No new component (CueFlag was a story-only specimen).

## The change (additive, on the existing Alert atom)

- **`size="compact"`** — a density axis (orthogonal to status/variant): a single-line pill, tighter padding, center-aligned, with a **hairline status border** on the `subtle` variant so it reads as a defined cue on a dark wall.
- **`message` prop** — a batteries-included, **status-colored bold** one-liner. React Native doesn't cascade text color from a container, so a cue's colored text would otherwise be every consumer's job — `message` colors it for you. Children stay available for richer content.

Result: `<Alert status="warning" size="compact" message="VL20 · target reps met — end the set." />` → the CueFlag pill (amber tint + amber hairline border + amber ⚠ + amber bold text; red/✕ for `error`).

Also adds a per-status `border` class (for the pill edge) — a pure addition to the existing `statusColors` map.

## Consolidation

The CueFlag R2 candidate (`feat/TD-r2-s4s5-candidates`) was a static story-only specimen (2 levels amber/red) that map onto Alert's `warning`/`error`. Absorbed into Alert per the consolidation decision; nothing ships separately. The north-star `LiveView` stub (`<Alert status="warning" variant="subtle">…`) can move to `size="compact" message={…}` when it's wired.

## Design decisions (locked with operator, rendered confirmations)

- `size="compact"` **density axis** (not a new variant)
- batteries-included **`message`** (over consumer-styled children text)
- kept Alert's Unicode **⚠/✕ glyphs** (render clean + monochrome status-colored)

## Safety

Default Alert behavior is unchanged — both new props default off (`size="default"`, no `message`) — so Alert's cross-project consumers (arch-graph `dash: 6`) are untouched.

## Tests & gates

- 7 new unit tests (message renders/omits, glyph + role, default-size message, children-after-message, showIcon=false, axe) → **27 total**
- Full titan suite **2556/2556** (incl. the story smoke test rendering the 4 new cue stories) · type-check · eslint · prettier green

## Screenshots

Compact warning/error cues + a default-vs-compact density comparison, on the north-star wall background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)