### PR TITLE
Add size="wall" density to TempoBar, FatigueMeter and ZoneTrack

### DIFF
--- a/packages/ui/src/components/custom/Workout/FatigueMeter.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.stories.tsx
@@ -42,8 +42,8 @@ export const Vl20: Story = { args: { value: 21 } }
 /** Stop zone — deep into the red. */
 export const StopZone: Story = { args: { value: 34 } }
 
-/** Chunky wall-glanceable density via a taller track. */
-export const WallDensity: Story = { args: { value: 21, trackHeight: 22 } }
+/** The across-the-room wall scale — `size="wall"` grows the track, needle and tick labels together. */
+export const WallDensity: Story = { args: { value: 21, size: 'wall' } }
 
 /** Custom scale — a tighter 0..30 domain with earlier thresholds. */
 export const CustomScale: Story = {

--- a/packages/ui/src/components/custom/Workout/FatigueMeter.test.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.test.tsx
@@ -71,3 +71,15 @@ describe('FatigueMeter', () => {
     })
   })
 })
+
+describe('FatigueMeter size="wall"', () => {
+  it('passes wall density through to the composed ZoneTrack (thicker needle)', () => {
+    render(<FatigueMeter value={20} size="wall" />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ width: '7px' })
+  })
+
+  it('keeps the compact needle by default', () => {
+    render(<FatigueMeter value={20} />)
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ width: '4px' })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/FatigueMeter.tsx
+++ b/packages/ui/src/components/custom/Workout/FatigueMeter.tsx
@@ -1,7 +1,7 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import type { ViewProps } from 'react-native'
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
-import { ZoneTrack, type ZoneTrackZone, type ZoneTrackTick } from './ZoneTrack'
+import { ZoneTrack, type ZoneTrackZone, type ZoneTrackTick, type ZoneTrackSize } from './ZoneTrack'
 
 const { green, yellow, orange, red } = WORKOUT_TOKENS.scale
 
@@ -24,7 +24,9 @@ export interface FatigueMeterProps extends ViewProps {
   zoneColors?: [string, string, string, string]
   /** Tick labels at [min, ...thresholds, max]. Default ['fresh','VL10','VL20','VL30','stop']. */
   labels?: string[]
-  /** Track height in px. Default 14. */
+  /** Density: `default` (compact) or `wall` (the across-the-room dashboard scale — bigger track, needle and tick labels). */
+  size?: ZoneTrackSize
+  /** Track height in px. Overrides the `size` default (14 default / 24 wall). */
   trackHeight?: number
   /** Needle colour. Default white. */
   needleColor?: string
@@ -49,7 +51,8 @@ export function FatigueMeter({
   thresholds = DEFAULT_THRESHOLDS,
   zoneColors = DEFAULT_ZONE_COLORS,
   labels = DEFAULT_LABELS,
-  trackHeight = 14,
+  size = 'default',
+  trackHeight,
   needleColor,
   className,
   ...props
@@ -71,6 +74,7 @@ export function FatigueMeter({
       zones={zones}
       min={0}
       max={max}
+      size={size}
       trackHeight={trackHeight}
       ticks={ticks}
       marker={{ type: 'needle', value, color: needleColor }}

--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -147,6 +147,18 @@ type props without pulling the dependency.
   `size` (default 180) sets the diameter; the eyebrow/section title is organism
   chrome. Web/RNW-only (like `CircularProgress`) — the wall variant; mobile keeps
   `bar`. `Ring*` (RestTimer) + `Custom/CircularTimer` stories on the wall background.
+- **`size="wall"` density (TempoBar · FatigueMeter · ZoneTrack)** — the across-the-room
+  dashboard scale, added as the idiomatic titan `size` union (a JS number-map per
+  component; **`default` values are byte-identical** to before, so existing consumers are
+  untouched). **TempoBar** scales its bar/labels/durations and at wall spells out the full
+  phase words (Concentric / Hold / Eccentric); its completed segments are **colour-coded**
+  (a missed target reads red, not just a ✗), and the **active** segment shows a **delta
+  countdown** (`activeDisplay`) — remaining time to target counting to `0.0` then negative
+  (red) once over — **tap to toggle** delta ↔ elapsed/target. **ZoneTrack** (the shared
+  gauge primitive) gained `size` that scales track, needle, tick lines and tick labels
+  together; its *other* consumers (TrainingLoadGauge, RpeCalibration) default to `default`
+  and are unaffected. **FatigueMeter** passes `size` through and lets `trackHeight` flow
+  from it. `Wall*` / `WallDensity` stories on the wall background.
 - Badge icons (WeightBadge's dumbbell, PrBadge / PrHistoryModal's star) are inline
   SVGs (`./icons.tsx`), not `lucide-react` — that dependency was dropped in 0.5.0
   to keep the root barrel light. The SVG paths mirror lucide's glyphs so rendering

--- a/packages/ui/src/components/custom/Workout/TempoBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.stories.tsx
@@ -15,6 +15,16 @@ const meta: Meta<typeof TempoBar> = {
     phaseElapsedMs: { control: 'number', description: 'Elapsed ms in the active phase' },
     completed: { control: 'object', description: 'Completed phase durations (ms)' },
     target: { control: 'object', description: 'Per-phase target durations (seconds)' },
+    size: {
+      control: 'inline-radio',
+      options: ['default', 'wall'],
+      description: 'Density: default (compact) or wall (across-the-room dashboard scale)',
+    },
+    activeDisplay: {
+      control: 'inline-radio',
+      options: ['time', 'delta'],
+      description: 'Active readout: time (elapsed/target) or delta (countdown). Tap to toggle.',
+    },
   },
   decorators: [
     (Story) => (
@@ -92,4 +102,63 @@ export const AllStates: Story = {
       />
     </View>
   ),
+}
+
+/**
+ * The across-the-room wall scale — bigger bar, full phase words, and colour-coded
+ * pacing (a missed target reads red). Here the eccentric ran long → red.
+ */
+export const Wall: Story = {
+  args: {
+    activePhase: null,
+    phaseElapsedMs: 0,
+    completed: { concentric: 950, hold: 1000, eccentric: 4200 },
+    target: TARGET,
+    size: 'wall',
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 460, padding: 28, backgroundColor: '#0E0E0E' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+/** Wall, mid-rep — the eccentric is active, showing the delta countdown (1.5s to target). Tap to switch to elapsed/target. */
+export const WallActiveDelta: Story = {
+  args: {
+    activePhase: 'eccentric',
+    phaseElapsedMs: 1500,
+    completed: { concentric: 950, hold: 1000 },
+    target: TARGET,
+    size: 'wall',
+    activeDisplay: 'delta',
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 460, padding: 28, backgroundColor: '#0E0E0E' }}>
+        <Story />
+      </View>
+    ),
+  ],
+}
+
+/** Wall, over target — the eccentric ran 1.2s past its target, so the delta is negative and red. */
+export const WallActiveOver: Story = {
+  args: {
+    activePhase: 'eccentric',
+    phaseElapsedMs: 4200,
+    completed: { concentric: 950, hold: 1000 },
+    target: TARGET,
+    size: 'wall',
+    activeDisplay: 'delta',
+  },
+  decorators: [
+    (Story) => (
+      <View style={{ width: 460, padding: 28, backgroundColor: '#0E0E0E' }}>
+        <Story />
+      </View>
+    ),
+  ],
 }

--- a/packages/ui/src/components/custom/Workout/TempoBar.test.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.test.tsx
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import {
   TempoBar,
   getTempoPacingState,
   getTempoFillPct,
+  formatTempoDelta,
   TEMPO_PACING,
 } from './TempoBar'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 
+const t = getSemanticColors('dark')
 const TARGET = { concentric: 1, hold: 1, eccentric: 3 }
 
 describe('getTempoPacingState', () => {
@@ -70,7 +73,7 @@ describe('TempoBar', () => {
         phaseElapsedMs={100}
         completed={{ concentric: 950 }}
         target={TARGET}
-      />,
+      />
     )
     expect(screen.getByTestId('tempo-segment-completed-Con')).toBeInTheDocument()
     expect(screen.getByText('0.9 ✓')).toBeInTheDocument()
@@ -83,7 +86,7 @@ describe('TempoBar', () => {
         phaseElapsedMs={100}
         completed={{ eccentric: 4000 }}
         target={TARGET}
-      />,
+      />
     )
     // eccentric target 3s, 4s elapsed => behind => cross
     expect(screen.getByText('4.0 ✗')).toBeInTheDocument()
@@ -96,8 +99,120 @@ describe('TempoBar', () => {
         phaseElapsedMs={1500}
         completed={{ concentric: 900, hold: 1000 }}
         target={TARGET}
-      />,
+      />
     )
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('TempoBar size="wall"', () => {
+  const TARGET_W = { concentric: 1, hold: 1, eccentric: 3 }
+
+  it('scales the active label up at wall density', () => {
+    render(<TempoBar activePhase="concentric" phaseElapsedMs={600} target={TARGET_W} size="wall" />)
+    expect(screen.getByText('0.6 / 1.0')).toHaveStyle({ fontSize: 22 })
+  })
+
+  it('keeps the compact label size by default', () => {
+    render(<TempoBar activePhase="concentric" phaseElapsedMs={600} target={TARGET_W} />)
+    expect(screen.getByText('0.6 / 1.0')).toHaveStyle({ fontSize: 12 })
+  })
+
+  it('preserves the segment testIDs at wall density', () => {
+    render(
+      <TempoBar
+        activePhase="eccentric"
+        phaseElapsedMs={1500}
+        completed={{ concentric: 900 }}
+        target={TARGET_W}
+        size="wall"
+      />
+    )
+    expect(screen.getByTestId('tempo-segment-active-Ecc')).toBeInTheDocument()
+    expect(screen.getByTestId('tempo-segment-completed-Con')).toBeInTheDocument()
+  })
+
+  it('spells out the full phase words at wall density', () => {
+    render(<TempoBar activePhase={null} phaseElapsedMs={0} target={TARGET_W} size="wall" />)
+    expect(screen.getByText('Concentric')).toBeInTheDocument()
+    expect(screen.getByText('Eccentric')).toBeInTheDocument()
+    expect(screen.queryByText('Con')).not.toBeInTheDocument()
+  })
+})
+
+describe('formatTempoDelta', () => {
+  it('shows remaining time to target as a positive value', () => {
+    expect(formatTempoDelta(1500)).toBe('1.5')
+  })
+
+  it('shows over-target time as negative', () => {
+    expect(formatTempoDelta(-1200)).toBe('-1.2')
+  })
+
+  it('shows 0.0 at the target (no -0.0)', () => {
+    expect(formatTempoDelta(0)).toBe('0.0')
+    expect(formatTempoDelta(-10)).toBe('0.0')
+  })
+})
+
+describe('TempoBar activeDisplay (delta countdown + toggle)', () => {
+  it('counts the remaining time down to the target in delta mode', () => {
+    render(
+      <TempoBar
+        activePhase="eccentric"
+        phaseElapsedMs={1800}
+        target={TARGET}
+        activeDisplay="delta"
+      />
+    )
+    // eccentric target 3.0s, elapsed 1.8s → 1.2s remaining
+    expect(screen.getByText('1.2')).toBeInTheDocument()
+  })
+
+  it('goes negative once the phase runs past its target', () => {
+    render(
+      <TempoBar
+        activePhase="eccentric"
+        phaseElapsedMs={4200}
+        target={TARGET}
+        activeDisplay="delta"
+      />
+    )
+    expect(screen.getByText('-1.2')).toBeInTheDocument()
+  })
+
+  it('tapping the active segment toggles time ↔ delta', () => {
+    render(
+      <TempoBar
+        activePhase="concentric"
+        phaseElapsedMs={600}
+        target={TARGET}
+        activeDisplay="time"
+      />
+    )
+    expect(screen.getByText('0.6 / 1.0')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('tempo-segment-active-Con'))
+    // concentric target 1.0s, elapsed 0.6s → 0.4s remaining
+    expect(screen.getByText('0.4')).toBeInTheDocument()
+    expect(screen.queryByText('0.6 / 1.0')).not.toBeInTheDocument()
+  })
+
+  it('defaults to the time readout', () => {
+    render(<TempoBar activePhase="concentric" phaseElapsedMs={600} target={TARGET} />)
+    expect(screen.getByText('0.6 / 1.0')).toBeInTheDocument()
+  })
+})
+
+describe('TempoBar completed pacing colour', () => {
+  it('colours a missed completed phase red', () => {
+    render(
+      <TempoBar
+        activePhase="hold"
+        phaseElapsedMs={100}
+        completed={{ eccentric: 4000 }}
+        target={TARGET}
+      />
+    )
+    expect(screen.getByText('4.0 ✗')).toHaveStyle({ color: t['status-error'] })
   })
 })

--- a/packages/ui/src/components/custom/Workout/TempoBar.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoBar.tsx
@@ -1,5 +1,6 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
-import { View, Text, type ViewProps } from 'react-native'
+import { useState } from 'react'
+import { View, Text, Pressable, type ViewProps } from 'react-native'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 
@@ -19,15 +20,23 @@ export const TEMPO_PACING = {
 
 export type TempoPacingState = 'none' | 'on-pace' | 'behind'
 
+/** Active-phase readout mode: elapsed/target `time`, or a `delta` countdown to the target. */
+export type TempoActiveDisplay = 'time' | 'delta'
+
+/** Signed seconds to one decimal — the delta countdown (`+` remaining, `-` over target). */
+export function formatTempoDelta(remainingMs: number): string {
+  const s = remainingMs / 1000
+  // Guard `-0.0`; show a leading minus only once past target.
+  const rounded = Math.abs(s) < 0.05 ? 0 : s
+  return rounded.toFixed(1)
+}
+
 /**
  * Classify how a phase's elapsed time tracks against its target duration.
  * `none` when there is no meaningful target; `behind` once elapsed exceeds the
  * target by more than the behind threshold; `on-pace` otherwise.
  */
-export function getTempoPacingState(
-  elapsedMs: number,
-  targetMs: number | null,
-): TempoPacingState {
+export function getTempoPacingState(elapsedMs: number, targetMs: number | null): TempoPacingState {
   if (!targetMs || targetMs < TEMPO_PACING.minPhaseDurationMs) return 'none'
   const ratio = elapsedMs / targetMs
   if (ratio > 1 + TEMPO_PACING.behindThresholdPct) return 'behind'
@@ -41,7 +50,10 @@ export function getTempoFillPct(elapsedMs: number, targetMs: number | null): num
 }
 
 interface PhaseConfig {
+  /** Compact label + the stable testID suffix. */
   label: string
+  /** Full phase word, spelled out at `wall` density where there's room to read it. */
+  wallLabel: string
   color: string
   flex: number
 }
@@ -49,9 +61,27 @@ interface PhaseConfig {
 const PHASE_ORDER: TempoPhaseKey[] = ['concentric', 'hold', 'eccentric']
 
 const PHASE_CONFIG: Record<TempoPhaseKey, PhaseConfig> = {
-  concentric: { label: 'Con', color: t['status-success'], flex: 2 },
-  hold: { label: 'Hold', color: t['brand-primary'], flex: 1 },
-  eccentric: { label: 'Ecc', color: t['status-warning'], flex: 3 },
+  concentric: { label: 'Con', wallLabel: 'Concentric', color: t['status-success'], flex: 2 },
+  hold: { label: 'Hold', wallLabel: 'Hold', color: t['brand-primary'], flex: 1 },
+  eccentric: { label: 'Ecc', wallLabel: 'Eccentric', color: t['status-warning'], flex: 3 },
+}
+
+/** Density. `default` — the compact card/rail treatment. `wall` — the across-the-room dashboard scale. */
+export type TempoBarSize = 'default' | 'wall'
+
+interface TempoBarSizing {
+  labelMargin: number
+  labelFont: number
+  barGap: number
+  barHeight: number
+  radius: number
+  segFont: number
+}
+
+/** Per-density magnitudes. `default` reproduces the original compact values exactly. */
+const TEMPO_SIZES: Record<TempoBarSize, TempoBarSizing> = {
+  default: { labelMargin: 4, labelFont: 10, barGap: 2, barHeight: 20, radius: 4, segFont: 12 },
+  wall: { labelMargin: 8, labelFont: 15, barGap: 4, barHeight: 40, radius: 6, segFont: 22 },
 }
 
 export interface TempoBarProps extends ViewProps {
@@ -63,6 +93,14 @@ export interface TempoBarProps extends ViewProps {
   completed?: Partial<Record<TempoPhaseKey, number>>
   /** Optional per-phase target durations (seconds) for pacing feedback. */
   target?: Partial<Record<TempoPhaseKey, number>>
+  /** Density: `default` (compact) or `wall` (the across-the-room dashboard scale). */
+  size?: TempoBarSize
+  /**
+   * Active-phase readout. `time` (default) — `elapsed / target`. `delta` — a countdown
+   * of the remaining time to target (`1.5` → `0.0` → `-1.2` once over), colour-coded like
+   * the bar. Tapping the active segment toggles between the two at runtime.
+   */
+  activeDisplay?: TempoActiveDisplay
   className?: string
 }
 
@@ -79,25 +117,33 @@ export function TempoBar({
   phaseElapsedMs,
   completed,
   target,
+  size = 'default',
+  activeDisplay = 'time',
   className,
   ...props
 }: TempoBarProps) {
+  const s = TEMPO_SIZES[size]
+  // Runtime toggle of the active readout, seeded from `activeDisplay`.
+  const [display, setDisplay] = useState<TempoActiveDisplay>(activeDisplay)
+  const toggleDisplay = () => setDisplay((d) => (d === 'time' ? 'delta' : 'time'))
   return (
     <View className={className} testID="tempo-bar" {...props}>
       {/* Phase labels */}
-      <View style={{ flexDirection: 'row', marginBottom: 4 }}>
+      <View style={{ flexDirection: 'row', marginBottom: s.labelMargin }}>
         {PHASE_ORDER.map((phase) => {
           const config = PHASE_CONFIG[phase]
           return (
             <View key={phase} style={{ flex: config.flex, alignItems: 'center' }}>
-              <Text style={{ fontSize: 10, color: t['text-disabled'] }}>{config.label}</Text>
+              <Text numberOfLines={1} style={{ fontSize: s.labelFont, color: t['text-disabled'] }}>
+                {size === 'wall' ? config.wallLabel : config.label}
+              </Text>
             </View>
           )
         })}
       </View>
 
       {/* Segmented bar */}
-      <View style={{ flexDirection: 'row', gap: 2, height: 20 }}>
+      <View style={{ flexDirection: 'row', gap: s.barGap, height: s.barHeight }}>
         {PHASE_ORDER.map((phase) => {
           const config = PHASE_CONFIG[phase]
           const isActive = activePhase === phase
@@ -111,7 +157,7 @@ export function TempoBar({
               style={{
                 flex: config.flex,
                 backgroundColor: alpha('#ffffff', 0.06),
-                borderRadius: 4,
+                borderRadius: s.radius,
                 overflow: 'hidden',
               }}
             >
@@ -120,9 +166,18 @@ export function TempoBar({
                   config={config}
                   phaseElapsedMs={phaseElapsedMs}
                   targetMs={targetMs}
+                  radius={s.radius}
+                  font={s.segFont}
+                  display={display}
+                  onToggleDisplay={toggleDisplay}
                 />
               ) : completedMs != null ? (
-                <CompletedSegment config={config} completedMs={completedMs} targetMs={targetMs} />
+                <CompletedSegment
+                  config={config}
+                  completedMs={completedMs}
+                  targetMs={targetMs}
+                  font={s.segFont}
+                />
               ) : null}
             </View>
           )
@@ -136,21 +191,40 @@ function ActiveSegment({
   config,
   phaseElapsedMs,
   targetMs,
+  radius,
+  font,
+  display,
+  onToggleDisplay,
 }: {
   config: PhaseConfig
   phaseElapsedMs: number
   targetMs: number | null
+  radius: number
+  font: number
+  display: TempoActiveDisplay
+  onToggleDisplay: () => void
 }) {
   const pacing = getTempoPacingState(phaseElapsedMs, targetMs)
   const barColor = pacing === 'behind' ? t['status-error'] : config.color
   const fillPct = getTempoFillPct(phaseElapsedMs, targetMs)
 
-  const label = targetMs
-    ? `${formatDuration(phaseElapsedMs)} / ${formatDuration(targetMs)}`
-    : formatDuration(phaseElapsedMs)
+  // `delta`: count the remaining time to target down to 0.0, then negative once over.
+  // Falls back to elapsed when there's no target. `time`: the elapsed / target readout.
+  const label =
+    display === 'delta' && targetMs != null
+      ? formatTempoDelta(targetMs - phaseElapsedMs)
+      : targetMs != null
+        ? `${formatDuration(phaseElapsedMs)} / ${formatDuration(targetMs)}`
+        : formatDuration(phaseElapsedMs)
 
   return (
-    <View style={{ height: '100%', position: 'relative' }} testID={`tempo-segment-active-${config.label}`}>
+    <Pressable
+      onPress={onToggleDisplay}
+      style={{ height: '100%', position: 'relative' }}
+      accessibilityRole="button"
+      accessibilityLabel={`Tempo readout: ${display === 'delta' ? 'delta' : 'time'} — tap to switch`}
+      testID={`tempo-segment-active-${config.label}`}
+    >
       <View
         style={{
           position: 'absolute',
@@ -159,7 +233,7 @@ function ActiveSegment({
           bottom: 0,
           width: `${fillPct}%`,
           backgroundColor: alpha(barColor, 0.3),
-          borderRadius: 4,
+          borderRadius: radius,
         }}
       />
       <View
@@ -170,9 +244,9 @@ function ActiveSegment({
           justifyContent: 'center',
         }}
       >
-        <Text style={{ fontSize: 12, fontWeight: '700', color: barColor }}>{label}</Text>
+        <Text style={{ fontSize: font, fontWeight: '700', color: barColor }}>{label}</Text>
       </View>
-    </View>
+    </Pressable>
   )
 }
 
@@ -180,15 +254,20 @@ function CompletedSegment({
   config,
   completedMs,
   targetMs,
+  font,
 }: {
   config: PhaseConfig
   completedMs: number
   targetMs: number | null
+  font: number
 }) {
   const pacing = getTempoPacingState(completedMs, targetMs)
   const hitTarget = pacing !== 'behind'
   const indicator =
     targetMs && targetMs >= TEMPO_PACING.minPhaseDurationMs ? (hitTarget ? ' ✓' : ' ✗') : ''
+  // A missed target reads by COLOUR first (red fill + red duration), the ✓/✗ second —
+  // glanceable across a room; a hit keeps the phase's own colour.
+  const cueColor = hitTarget ? config.color : t['status-error']
 
   return (
     <View
@@ -197,11 +276,17 @@ function CompletedSegment({
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: alpha(config.color, 0.15),
+        backgroundColor: alpha(cueColor, 0.15),
       }}
       testID={`tempo-segment-completed-${config.label}`}
     >
-      <Text style={{ fontSize: 12, fontWeight: '500', color: alpha(config.color, 0.7) }}>
+      <Text
+        style={{
+          fontSize: font,
+          fontWeight: '500',
+          color: hitTarget ? alpha(config.color, 0.7) : cueColor,
+        }}
+      >
         {formatDuration(completedMs)}
         {indicator}
       </Text>

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.stories.tsx
@@ -102,15 +102,14 @@ export const BareTrack: Story = {
   args: { zones: FATIGUE_ZONES, max: 40 },
 }
 
-/** Chunky wall-glanceable density via a taller track. */
+/** The across-the-room wall scale — `size="wall"` grows track, needle, tick lines and labels together. */
 export const WallDensity: Story = {
   args: {
     zones: FATIGUE_ZONES,
     max: 40,
     marker: { type: 'needle', value: 15 },
     ticks: FATIGUE_TICKS,
-    trackHeight: 22,
-    needleOverhang: 9,
+    size: 'wall',
   },
 }
 

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.test.tsx
@@ -198,3 +198,37 @@ describe('ZoneTrack', () => {
     })
   })
 })
+
+describe('ZoneTrack size="wall"', () => {
+  const TICKS = [
+    { value: 0, label: 'fresh' },
+    { value: 40, label: 'stop' },
+  ]
+
+  it('scales the needle and tick labels up together', () => {
+    render(
+      <ZoneTrack
+        zones={ZONES}
+        max={40}
+        size="wall"
+        marker={{ type: 'needle', value: 20 }}
+        ticks={TICKS}
+      />
+    )
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ width: '7px' })
+    expect(screen.getAllByTestId('zone-track-tick-label')[0]).toHaveStyle({ fontSize: 14 })
+  })
+
+  it('defaults to the compact scale (needle 4 / label 9) when size is omitted', () => {
+    render(
+      <ZoneTrack zones={ZONES} max={40} marker={{ type: 'needle', value: 20 }} ticks={TICKS} />
+    )
+    expect(screen.getByTestId('zone-track-needle')).toHaveStyle({ width: '4px' })
+    expect(screen.getAllByTestId('zone-track-tick-label')[0]).toHaveStyle({ fontSize: 9 })
+  })
+
+  it('still lets an explicit trackHeight override the size default', () => {
+    render(<ZoneTrack zones={ZONES} max={40} size="wall" trackHeight={30} />)
+    expect(screen.getByTestId('zone-track-track')).toHaveStyle({ height: '30px' })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
+++ b/packages/ui/src/components/custom/Workout/ZoneTrack.tsx
@@ -19,9 +19,59 @@ const DEFAULT_MARKER_COLOR = primitiveColors.white
 /** Tick mark + tick label colour. */
 const TICK_COLOR = t['text-tertiary']
 
-const DEFAULT_TRACK_HEIGHT = 14
-const DEFAULT_NEEDLE_OVERHANG = 6
-const NEEDLE_WIDTH = 4
+/** Density. `default` — the compact card/rail gauge. `wall` — the across-the-room dashboard scale. */
+export type ZoneTrackSize = 'default' | 'wall'
+
+interface ZoneTrackSizing {
+  trackHeight: number
+  needleOverhang: number
+  needleWidth: number
+  tickLineNormal: number
+  tickLineEmphasized: number
+  tickLineHeightPad: number
+  tickLineTopPad: number
+  labelRowHeight: number
+  labelMarginTop: number
+  tickFont: number
+  tickLetterSpacing: number
+  tickCellWidth: number
+}
+
+/**
+ * Per-density magnitudes. `default` reproduces the original compact values exactly;
+ * `wall` scales the track, needle, tick lines and tick labels up together so the gauge
+ * reads across a room. `trackHeight` / `needleOverhang` remain overridable per call.
+ */
+const ZONE_SIZES: Record<ZoneTrackSize, ZoneTrackSizing> = {
+  default: {
+    trackHeight: 14,
+    needleOverhang: 6,
+    needleWidth: 4,
+    tickLineNormal: 1.5,
+    tickLineEmphasized: 2,
+    tickLineHeightPad: 4,
+    tickLineTopPad: 2,
+    labelRowHeight: 16,
+    labelMarginTop: 5,
+    tickFont: 9,
+    tickLetterSpacing: 0.5,
+    tickCellWidth: 28,
+  },
+  wall: {
+    trackHeight: 24,
+    needleOverhang: 9,
+    needleWidth: 7,
+    tickLineNormal: 2.5,
+    tickLineEmphasized: 3.5,
+    tickLineHeightPad: 6,
+    tickLineTopPad: 3,
+    labelRowHeight: 24,
+    labelMarginTop: 8,
+    tickFont: 14,
+    tickLetterSpacing: 0.5,
+    tickCellWidth: 48,
+  },
+}
 
 /** A single colour band of the zone gradient, spanning `[prev.upTo, upTo]` of the domain. */
 export interface ZoneTrackZone {
@@ -82,9 +132,11 @@ export interface ZoneTrackProps extends ViewProps {
   ticks?: ZoneTrackTick[]
   /** Optional translucent range highlight drawn over the gradient. */
   band?: ZoneTrackBand | null
-  /** Track height in px. Default 14. */
+  /** Density: `default` (compact) or `wall` (the across-the-room dashboard scale). Scales track, needle, ticks and labels together. */
+  size?: ZoneTrackSize
+  /** Track height in px. Overrides the `size` default (14 default / 24 wall). */
   trackHeight?: number
-  /** How far a needle marker overhangs the track top + bottom, in px. Default 6. */
+  /** How far a needle marker overhangs the track top + bottom, in px. Overrides the `size` default (6 default / 9 wall). */
   needleOverhang?: number
   /** Muted colour of the track behind / beyond the fill. Default a charcoal step. */
   trackColor?: string
@@ -117,14 +169,18 @@ export function ZoneTrack({
   marker = null,
   ticks,
   band = null,
-  trackHeight = DEFAULT_TRACK_HEIGHT,
-  needleOverhang = DEFAULT_NEEDLE_OVERHANG,
+  size = 'default',
+  trackHeight: trackHeightProp,
+  needleOverhang: needleOverhangProp,
   trackColor = DEFAULT_TRACK_COLOR,
   className,
   style,
   accessibilityLabel,
   ...props
 }: ZoneTrackProps) {
+  const s = ZONE_SIZES[size]
+  const trackHeight = trackHeightProp ?? s.trackHeight
+  const needleOverhang = needleOverhangProp ?? s.needleOverhang
   const isNeedle = marker?.type === 'needle'
   const markerHeight = isNeedle ? trackHeight + needleOverhang * 2 : trackHeight
   const markerFrac = marker != null ? fraction(marker.value, min, max) : 0
@@ -231,11 +287,11 @@ export function ZoneTrack({
               position: 'absolute',
               top: 0,
               left: pct(markerFrac),
-              width: NEEDLE_WIDTH,
+              width: s.needleWidth,
               height: markerHeight,
-              borderRadius: NEEDLE_WIDTH / 2,
+              borderRadius: s.needleWidth / 2,
               backgroundColor: marker.color ?? DEFAULT_MARKER_COLOR,
-              transform: [{ translateX: -NEEDLE_WIDTH / 2 }],
+              transform: [{ translateX: -s.needleWidth / 2 }],
             }}
           />
         )}
@@ -244,7 +300,7 @@ export function ZoneTrack({
         {ticks?.map((tick, i) => {
           const emphasized = tick.emphasized === true
           const lineColor = tick.color ?? (emphasized ? t['brand-primary'] : TICK_COLOR)
-          const lineWidth = emphasized ? 2 : 1.5
+          const lineWidth = emphasized ? s.tickLineEmphasized : s.tickLineNormal
           return (
             <View
               key={`line-${i}`}
@@ -252,10 +308,10 @@ export function ZoneTrack({
               accessibilityElementsHidden
               style={{
                 position: 'absolute',
-                top: (markerHeight - trackHeight) / 2 - 2,
+                top: (markerHeight - trackHeight) / 2 - s.tickLineTopPad,
                 left: pct(fraction(tick.value, min, max)),
                 width: lineWidth,
-                height: trackHeight + 4,
+                height: trackHeight + s.tickLineHeightPad,
                 borderRadius: lineWidth / 2,
                 backgroundColor: lineColor,
                 transform: [{ translateX: -lineWidth / 2 }],
@@ -267,7 +323,9 @@ export function ZoneTrack({
       </View>
 
       {ticks != null && ticks.length > 0 && (
-        <View style={{ position: 'relative', height: 16, marginTop: 5 }}>
+        <View
+          style={{ position: 'relative', height: s.labelRowHeight, marginTop: s.labelMarginTop }}
+        >
           {ticks.map((tick, i) => {
             if (tick.label == null) return null
             const emphasized = tick.emphasized === true
@@ -276,8 +334,8 @@ export function ZoneTrack({
               <Text
                 testID="zone-track-tick-label"
                 style={{
-                  fontSize: 9,
-                  letterSpacing: 0.5,
+                  fontSize: s.tickFont,
+                  letterSpacing: s.tickLetterSpacing,
                   color: labelColor,
                   fontFamily: 'monospace',
                   fontWeight: emphasized ? '700' : '400',
@@ -293,8 +351,8 @@ export function ZoneTrack({
                 style={{
                   position: 'absolute',
                   left: pct(fraction(tick.value, min, max)),
-                  transform: [{ translateX: -14 }],
-                  width: 28,
+                  transform: [{ translateX: -s.tickCellWidth / 2 }],
+                  width: s.tickCellWidth,
                   alignItems: 'center',
                 }}
               >


### PR DESCRIPTION
## What

Adds the across-the-room **wall-dashboard density** (`size="wall"`) to **TempoBar** and **FatigueMeter** (via the shared **ZoneTrack** primitive) — the last Wave-2 titan build for VW-38. Implemented as the idiomatic titan `size` union (a JS number-map per component); **`default` values are byte-identical** to before, so existing consumers and tests are untouched.

## Per component

**TempoBar**
- Scales bar height (20→40), labels (10→15), durations (12→22), gaps/radii
- At wall it **spells out the full phase words** — Concentric / Hold / Eccentric
- Completed segments are now **colour-coded**: a missed target reads **red** (fill + duration), not just a `✗`
- The active segment gains a **`delta` countdown** (`activeDisplay`): the remaining time to target counting down to `0.0`, then **negative and red** once over — **tap the segment to toggle** delta ↔ elapsed/target

**ZoneTrack** (the shared gauge primitive)
- Gains `size`, which scales the **track, needle, tick lines and tick labels together** (not just track height)
- Its *other* consumers (TrainingLoadGauge, RpeCalibration) default to `default` and are **unaffected** — same pattern as CircularProgress gaining `fill`/`children` in #106

**FatigueMeter**
- Passes `size` through to ZoneTrack; `trackHeight` now flows from the size default (14 default / 24 wall) instead of a hard-coded 14

## Design decisions (locked with operator, rendered confirmations)

- `size="wall"` density union (JS number-map), mirroring the Alert/TempoDisplay `size` precedent
- Full phase words at wall
- Pass/fail **colour-coding** (miss = red) for completed phases
- Active **delta countdown** with **tap-to-toggle** between delta and elapsed/target

## Tests & gates

New unit tests: TempoBar delta countdown + toggle + full-words + miss-colour + `formatTempoDelta`; ZoneTrack + FatigueMeter wall-scale (needle/label/track) assertions; `default`-identical guards. Full suite **2576/2576** · type-check · eslint · prettier green.

Note (jsdom/RNW): `toHaveStyle` matches `fontSize` as a bare number but `width`/`height` as `px` strings — the wall tests use each accordingly.

## Screenshots

TempoBar wall (full words; completed hit=green/miss=red; active delta countdown, negative-over in red) and FatigueMeter wall (tall gradient, thick needle, big tick labels) on the wall background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)