### PR TITLE
North-star: make tempo optional, hide when absent

### DIFF
--- a/packages/ui/src/lab/north-star/LiveView.tsx
+++ b/packages/ui/src/lab/north-star/LiveView.tsx
@@ -322,10 +322,21 @@ export function LiveView({
     contentW === 0 || contentW >= ALERT_ICON
       ? TEMPO_BASE_FONT
       : Math.round(clampLerp(contentW, TEMPO_SHRINK_FLOOR, ALERT_ICON, 14, TEMPO_BASE_FONT))
+  // Tempo is optional: a set may have no prescribed tempo — then the card is hidden entirely
+  // and the alert takes the whole row.
+  const hasTempo = session.tempo != null
   // Width the alert may take — measured off the ROW (inside the panel padding) so a long
-  // message ellipsises at the side margin rather than running to the panel edge.
+  // message ellipsises at the side margin rather than running to the panel edge. With no tempo
+  // card the alert gets the full row; otherwise it's the row minus the (measured) tempo + gap.
   const CONTROLS_GAP = 16
-  const alertAvail = rowW > 0 && tempoW > 0 ? Math.max(0, rowW - tempoW - CONTROLS_GAP) : undefined
+  const alertAvail =
+    rowW > 0
+      ? hasTempo
+        ? tempoW > 0
+          ? Math.max(0, rowW - tempoW - CONTROLS_GAP)
+          : undefined
+        : rowW
+      : undefined
 
   const [heroH, setHeroH] = useState(0)
   const onHeroLayout = (e: LayoutChangeEvent) => setHeroH(e.nativeEvent.layout.height)
@@ -344,36 +355,39 @@ export function LiveView({
           onLayout={onContentLayout}
           style={{ flex: 1, padding: dual ? 18 : 24, gap: dual ? 8 : 10 }}
         >
-          {/* controls row: tempo pinned upper-left, alert pinned upper-right (justify-between). */}
+          {/* controls row: tempo upper-left (when prescribed), alert upper-right. With no tempo
+              the alert simply pins right (flex-end); otherwise they split (space-between). */}
           <View
             onLayout={onRowLayout}
-            className="flex-row items-center justify-between"
-            style={{ gap: CONTROLS_GAP }}
+            className="flex-row items-center"
+            style={{ gap: CONTROLS_GAP, justifyContent: hasTempo ? 'space-between' : 'flex-end' }}
           >
             {/* tempo card — locked to the alert's height (this view only); the inner TempoDisplay
                 shrinks its font but stays centred on the shared charcoal ground so it reads seamless. */}
-            <View
-              onLayout={onTempoLayout}
-              style={{
-                height: CONTROL_HEIGHT,
-                justifyContent: 'center',
-                alignItems: 'flex-start',
-                backgroundColor: TEMPO_GROUND,
-                borderRadius: 9,
-                overflow: 'hidden',
-                ...CARD_SHADOW,
-              }}
-            >
-              <TempoDisplay
-                tempo={session.tempo}
-                fontSize={tempoFont}
-                live={
-                  activePhase ? { activePhase, phaseElapsedMs: live.phaseElapsedMs } : undefined
-                }
-                showLabel={false}
-                showInfo={false}
-              />
-            </View>
+            {session.tempo != null && (
+              <View
+                onLayout={onTempoLayout}
+                style={{
+                  height: CONTROL_HEIGHT,
+                  justifyContent: 'center',
+                  alignItems: 'flex-start',
+                  backgroundColor: TEMPO_GROUND,
+                  borderRadius: 9,
+                  overflow: 'hidden',
+                  ...CARD_SHADOW,
+                }}
+              >
+                <TempoDisplay
+                  tempo={session.tempo}
+                  fontSize={tempoFont}
+                  live={
+                    activePhase ? { activePhase, phaseElapsedMs: live.phaseElapsedMs } : undefined
+                  }
+                  showLabel={false}
+                  showInfo={false}
+                />
+              </View>
+            )}
             <AlertCue status={verdict} message={message} mode={alertMode} availWidth={alertAvail} />
           </View>
 

--- a/packages/ui/src/lab/north-star/LiveWallDashboard.stories.tsx
+++ b/packages/ui/src/lab/north-star/LiveWallDashboard.stories.tsx
@@ -2,6 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View } from 'react-native'
 import { DashboardShell, type Device } from '../../components'
 import { LivePage, type LivePageVariant } from './LivePage'
+import { dashboardFixture } from './fixtures'
+
+/** The fixture with its prescribed tempo stripped — a set with no tempo (hidden readout). */
+const noTempoModel = {
+  ...dashboardFixture,
+  session: { ...dashboardFixture.session, tempo: undefined },
+}
 
 /**
  * `Lab/North Star/Live Wall Dashboard` — the north-star wall-dashboard specimen.
@@ -21,15 +28,18 @@ const DEVICES: Device[] = [
 
 interface WallArgs {
   variant: LivePageVariant
+  /** Whether the current set has a prescribed tempo; off hides the tempo readout. */
+  tempo: boolean
 }
 
 const meta: Meta<WallArgs> = {
   title: 'Lab/North Star/Live Wall Dashboard',
-  args: { variant: 'live' },
+  args: { variant: 'live', tempo: true },
   argTypes: {
     variant: { control: 'inline-radio', options: ['live', 'live-dual', 'rest'] },
+    tempo: { control: 'boolean' },
   },
-  render: ({ variant }) => (
+  render: ({ variant, tempo }) => (
     <DashboardShell
       activeKey="live"
       state={variant === 'rest' ? 'rest' : 'live'}
@@ -37,7 +47,7 @@ const meta: Meta<WallArgs> = {
       devices={DEVICES}
       subtitle="wall dashboard"
     >
-      <LivePage variant={variant} />
+      <LivePage variant={variant} model={tempo ? dashboardFixture : noTempoModel} />
     </DashboardShell>
   ),
   decorators: [
@@ -71,6 +81,21 @@ export const Live: Story = {
   parameters: {
     docs: {
       description: { story: 'The live (mid-set) stage — ~22% velocity loss, threshold verdict.' },
+    },
+  },
+}
+
+/** Mid-set with NO prescribed tempo — the tempo readout is hidden; the alert takes the row. */
+export const LiveNoTempo: Story = {
+  args: { variant: 'live', tempo: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The live stage for a set with no prescribed tempo (coach left it unset and no ' +
+          'exercise default). The tempo card is hidden entirely — no invented placeholder — ' +
+          'and the alert cue simply pins to the right of the row.',
+      },
     },
   },
 }

--- a/packages/ui/src/lab/north-star/fixtures.ts
+++ b/packages/ui/src/lab/north-star/fixtures.ts
@@ -62,8 +62,12 @@ export interface SessionModel {
   title: string
   weightLbs: number
   unit: 'lbs' | 'kg'
-  /** Prescribed tempo tuple [ecc, pauseBottom, con, pauseTop]. */
-  tempo: [number, number, number, number]
+  /**
+   * Prescribed tempo tuple [ecc, pauseBottom, con, pauseTop]. OPTIONAL — a set may carry no
+   * prescribed tempo (coach left it unset and no exercise default); the live view then hides
+   * the tempo readout entirely rather than inventing one.
+   */
+  tempo?: [number, number, number, number]
   completedSets: CompletedSet[]
   plannedSets: number
 }


### PR DESCRIPTION
Makes the north-star live view treat a prescribed **tempo as optional** and hide the readout when a set has none — instead of inventing a placeholder.

## Why
Store-wiring scoping (VW-41) found the voltras-mcp store has no tempo field. Rather than block, tempo becomes optional end-to-end so the resolver can fall back **coach-set → exercise default → none (hidden)**.

## Changes
- **fixtures:** `DashboardModel.session.tempo` is now optional.
- **LiveView:** the tempo card renders only when `session.tempo` is set. The controls row pins the alert right (`flex-end`) with no tempo, splits (`space-between`) with it; the alert's available-width falls back to the full row when the card is absent (so the ellipsis still respects the margin).
- **Story:** a `tempo` boolean control + a permanent `LiveNoTempo` story validating the hidden state.

## Verify
type-check ✅ · eslint ✅ · prettier ✅ · vitest **2539** ✅. Hidden-tempo state screenshotted (tempo card gone, alert pinned right, active rail exercise drops its tempo chip, no empty gap).

Follow-up (separate, in voltras-mcp): VW-41 tempo store field + the exercise-default/prescription design — async research proposal in flight (VW-41..45).
🤖 Generated with [Claude Code](https://claude.com/claude-code)