### PR TITLE
Tidy an implementation-detail comment in north-star lab fixtures

### DIFF
--- a/packages/ui/src/lab/north-star/fixtures.ts
+++ b/packages/ui/src/lab/north-star/fixtures.ts
@@ -49,7 +49,11 @@ export interface LiveModel {
 /** A logged set on the session read-model. */
 export interface CompletedSet {
   weightLbs: number
-  /** Resistance mode (cascade echo, cmd=0x10). */
+  /**
+   * Resistance mode as echoed back from the requested-settings cascade — i.e. the mode the
+   * machine confirms it is applying, NOT the lazily-updated state-dump fields (which can lag
+   * or report stale values mid-set).
+   */
   mode: 'weight' | 'chains' | 'eccentric' | 'isokinetic'
   repCount: number
   /** Per-rep mean-concentric velocities (m/s). */


### PR DESCRIPTION
Expands the `mode` field doc on `CompletedSet` in the north-star lab fixtures so it describes the field in fitness-facing terms — the resistance mode is the one echoed back from the requested-settings cascade, rather than the lazily-updated state-dump fields, which can lag or report stale values mid-set. That distinction matters to anyone mapping these read-models onto a real store, so it's worth stating in prose.

Comment-only; no behaviour change.

## Gates
- `type-check` clean
- `vitest run` — 2539 passed / 127 files
- `lint` — 0 errors (88 pre-existing warnings, unchanged)

`format:check` is red on ~187 files on untouched main; pre-existing and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)