### PR TITLE
Scope the published tarball to public API; guard device internals

### DIFF
--- a/packages/ui/eslint-rules/no-device-internals.js
+++ b/packages/ui/eslint-rules/no-device-internals.js
@@ -1,0 +1,96 @@
+/**
+ * ESLint rule: no-device-internals
+ *
+ * titan is a presentation layer. It renders values that a machine has already
+ * interpreted — velocities, forces, weights, modes — and it should describe them
+ * in those terms. Low-level device/transport identifiers (hex opcodes, register
+ * addresses, raw byte frames, characteristic UUIDs) carry no meaning for a
+ * component and tend to arrive by copy-paste from an integration layer, in
+ * comments as often as in code. This rule keeps them out of `src/`, including
+ * out of comments, which AST-only rules never see.
+ *
+ * Scope is deliberately narrow so it stays at zero false positives on a design
+ * system. Specifically it does NOT flag:
+ *   - hex COLOURS (`#1C1C1C`) — the dominant hex form here,
+ *   - dimension/ratio strings (`20x20`, `200x400`) — the `\b` before `0x` means
+ *     `0x` preceded by a word character never matches,
+ *   - the word "cascade" in its CSS sense.
+ * If a legitimate case ever needs one of these, disable per-line with cause.
+ */
+
+/** Bare hex integer literal: `0x10`. `\b` keeps `20x20` / `200x400` from matching. */
+const HEX_LITERAL = /\b0x[0-9a-fA-F]{2,}\b/
+
+/**
+ * A run of 4+ space-separated byte pairs, i.e. a raw frame dump.
+ *
+ * Two deliberate narrowings, each pinned by a real false positive found in this
+ * package when the pattern was looser:
+ *   - separators are spaces only. Allowing `-`/`:` matched the timestamp
+ *     `2024-01-15 14:30` in DateTime.tsx.
+ *   - the run must contain at least one hex LETTER (checked separately below).
+ *     Digit-only pairs matched SVG path coordinates like `M12 2 22 12 12 22`
+ *     in icons.tsx. Frame dumps in practice always carry some a–f.
+ */
+const BYTE_FRAME = /\b(?:[0-9a-fA-F]{2} +){3,}[0-9a-fA-F]{2}\b/
+const HEX_LETTER = /[a-fA-F]/
+
+/** A 128-bit UUID, the shape of a BLE service/characteristic identifier. */
+const UUID = /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/
+
+const PATTERNS = [
+  { re: HEX_LITERAL, id: 'hex' },
+  {
+    re: BYTE_FRAME,
+    id: 'frame',
+    // Digit-only runs are SVG coordinates, not frames. See BYTE_FRAME above.
+    refine: (match) => HEX_LETTER.test(match),
+  },
+  { re: UUID, id: 'uuid' },
+]
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow low-level device/transport identifiers in source and comments; describe behaviour in fitness-facing terms.',
+    },
+    schema: [],
+    messages: {
+      hex: 'Avoid raw hex identifiers here. Describe what the value means to a lifter (mode, weight, phase) rather than how the device encodes it.',
+      frame:
+        'Avoid raw byte sequences here. titan renders interpreted values, not transport payloads.',
+      uuid: 'Avoid device/transport UUIDs here. titan renders interpreted values, not transport identifiers.',
+    },
+  },
+
+  create(context) {
+    const source = context.sourceCode ?? context.getSourceCode()
+
+    const check = (text, node, loc) => {
+      for (const { re, id, refine } of PATTERNS) {
+        const match = re.exec(text)
+        if (match && (!refine || refine(match[0]))) {
+          context.report(loc ? { loc, messageId: id } : { node, messageId: id })
+          return
+        }
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') check(node.value, node)
+      },
+      TemplateElement(node) {
+        check(node.value.raw, node)
+      },
+      Program() {
+        for (const comment of source.getAllComments()) {
+          check(comment.value, null, comment.loc)
+        }
+      },
+    }
+  },
+}

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -2,6 +2,7 @@ const js = require('@eslint/js')
 const tseslint = require('typescript-eslint')
 const react = require('eslint-plugin-react')
 const reactHooks = require('eslint-plugin-react-hooks')
+const noDeviceInternals = require('./eslint-rules/no-device-internals')
 
 module.exports = tseslint.config(
   // Global ignores
@@ -68,6 +69,21 @@ module.exports = tseslint.config(
 
       // Allow spreading props (common in component libraries)
       'react/jsx-props-no-spreading': 'off',
+    },
+  },
+
+  // titan renders values a machine has already interpreted, so low-level device
+  // identifiers (hex opcodes, raw byte frames, transport UUIDs) have no business
+  // in this package. Errors rather than warns: unlike the guardrails below there
+  // are no existing violators, so this holds the line at zero instead of
+  // documenting a backlog. Covers comments too, which AST selectors never match.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: {
+      titan: { rules: { 'no-device-internals': noDeviceInternals } },
+    },
+    rules: {
+      'titan/no-device-internals': 'error',
     },
   },
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -147,6 +147,7 @@
   "files": [
     "dist",
     "src",
+    "!src/lab",
     "docs",
     "tailwind.config.js"
   ],

--- a/packages/ui/src/test/no-device-internals.test.ts
+++ b/packages/ui/src/test/no-device-internals.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable titan/no-device-internals --
+ * This file is the rule's own test bench, so it necessarily contains the shapes
+ * the rule rejects. Every value below is invented for the test — none is a real
+ * device value.
+ */
+import { RuleTester } from 'eslint'
+import rule from '../../eslint-rules/no-device-internals'
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+describe('no-device-internals', () => {
+  it('flags device internals without flagging design-system content', () => {
+    ruleTester.run('no-device-internals', rule as never, {
+      valid: [
+        // Hex colours are the dominant hex form in this package.
+        { code: "const bg = '#1C1C1C'" },
+        { code: "const bg = '#fff'" },
+        { code: 'const bg = `${base} #1C1C1CFF`' },
+        // Dimension and ratio strings: the `\b` guard before `0x` means a digit
+        // followed by `x` never reads as a hex literal. These exact strings
+        // tripped an earlier, looser sweep.
+        { code: "// icons render at 20x20" },
+        { code: "// 200x400 intrinsic -> ~160x320 px" },
+        // SVG path coordinates — digit-only runs are not byte frames.
+        { code: 'const d = "M12 2 22 12 12 22 2 12Z"' },
+        { code: 'const d = "M7 7 17 17 12 22 12 2 17 7 7 17"' },
+        // Timestamps — `-` and `:` are not byte separators.
+        { code: "// datetime // 2024-01-15 14:30" },
+        // "cascade" in its CSS sense is ordinary styling vocabulary.
+        { code: "// RN doesn't cascade text color, so hand-color the text" },
+        // Plain numbers and durations.
+        { code: 'const duration = 300' },
+      ],
+      invalid: [
+        // Bare hex identifier, in code and in a comment.
+        { code: 'const mode = 0xab', errors: [{ messageId: 'hex' }] },
+        { code: '// resistance mode (cmd=0xab)', errors: [{ messageId: 'hex' }] },
+        { code: "const s = 'send cmd=0xab now'", errors: [{ messageId: 'hex' }] },
+        // Raw byte frame: 4+ space-separated pairs including hex letters.
+        { code: '// frame: ab cd ef 01', errors: [{ messageId: 'frame' }] },
+        // Transport UUID.
+        {
+          code: "const id = '0000fe59-1234-5678-9abc-def012345678'",
+          errors: [{ messageId: 'uuid' }],
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
Two packaging-hygiene changes for the next release.

## 1. Exclude `src/lab` from the published tarball

`files` lists `src`, which ships wholesale so the `react-native` export condition can resolve raw `.ts` sources. That also swept in `src/lab/**` — scratch specimens that aren't public API, aren't referenced by any entry barrel, and that nothing imports. They're ~5 files of dead weight in every consumer's `node_modules`.

Used a negated pattern in `files` rather than an `.npmignore`. `files` is already the allowlist, so keeping the exception beside it means one reviewable place to see what ships; a second hidden ignore file interacts with `files` in ways that are easy to get subtly wrong.

Verified against the real artifact rather than the config — packed the tarball, installed it into a scratch consumer, and resolved every entry point:

| entry point | resolves |
| --- | --- |
| `@titan-design/react-ui` | `dist/index.js` |
| `@titan-design/react-ui/theme` | `dist/theme/index.js` |
| `@titan-design/react-ui/bodymap` | `dist/bodymap.js` |
| `@titan-design/react-ui/pages` | `dist/pages.js` |
| `@titan-design/react-ui/tailwind.config.js` | `tailwind.config.js` |
| `react-native` condition | `src/*.ts` present |

`lab/` is absent from the packed tarball; 483 files vs 488.

## 2. Add a `titan/no-device-internals` lint rule

titan is a presentation layer: it renders values something else has already interpreted. Hex identifiers, raw byte frames and transport UUIDs carry no meaning for a component, and when they do turn up it's by copy-paste from integration code — in comments as often as in code, which is why this is a rule that reads comments rather than an AST selector.

A guardrail that cries wolf gets disabled, so the scope is deliberately narrow and pinned by tests. Explicitly valid: hex colours (`#1C1C1C`), dimension strings (`20x20`, `200x400`), SVG path coordinates (`M12 2 22 12 12 22`), timestamps (`2024-01-15 14:30`), and "cascade" in its CSS sense. Each of those is a real string from this package that a looser first draft flagged, so they're all regression cases in the rule's test.

**Zero hits on the existing tree**, hence `error` rather than `warn` — there's no backlog to document, so it can hold the line at zero.

## Merge order — please read

This PR depends on #112 and should merge **after** it.

The rule flags one line that #112 removes (`src/lab/north-star/fixtures.ts:52`), so CI here is red on a `main` base until #112 lands. That's the rule working, not a defect. With #112 applied locally the gates are green:

- `type-check` — clean
- `vitest run` — 2540 passed / 128 files (+1 new)
- `lint` — 0 errors, 88 pre-existing warnings

Happy to restack this onto #112 if you'd rather CI go green before the merge.

`format:check` is red on ~187 files on untouched main; pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)