### PR TITLE
fix(north-star): label force readout as lbs not N (VW-55)

### DIFF
--- a/packages/ui/src/lab/north-star/RestView.tsx
+++ b/packages/ui/src/lab/north-star/RestView.tsx
@@ -98,7 +98,7 @@ export function RestView({ model }: { model: DashboardModel }) {
           </MetricGroup>
           <MetricGroup>
             <Metric size="md" value={String(session.weightLbs)} unit="lbs" label="Load" />
-            <Metric size="md" value={String(live.peakForce)} unit="N" label="Peak force" />
+            <Metric size="md" value={String(live.peakForce)} unit="lbs" label="Peak force" />
           </MetricGroup>
           <MetricGroup>
             <Metric

--- a/packages/ui/src/lab/north-star/fixtures.ts
+++ b/packages/ui/src/lab/north-star/fixtures.ts
@@ -30,7 +30,7 @@ export interface RepModel {
 export interface LiveModel {
   /** Instantaneous cable velocity (m/s). */
   velocity: number
-  /** Instantaneous cable force (N). */
+  /** Instantaneous cable force (lbs). */
   force: number
   /** Current movement phase. */
   phase: 'concentric' | 'hold' | 'eccentric' | 'idle'
@@ -42,7 +42,7 @@ export interface LiveModel {
   repVelocities: number[]
   /** Velocity loss vs the set's best rep (%). Drives verdict + aura + fatigue. */
   velocityLossPct: number
-  /** Peak concentric force this set (N). */
+  /** Peak concentric force this set (lbs). */
   peakForce: number
 }
 


### PR DESCRIPTION
## VW-55: Relabel force unit N → lbs (no conversion)

The north-star live/rest views labeled the force readout as `N` (Newtons), but the value is **lbs end-to-end**. The voltras-mcp force pipeline carries lbs from the device through WA (`Phase.peakForce` inherits lbs with zero conversion) to the SSE (`live-signal.ts` documents "force in lbs"). With VW-45 now streaming a real `peakForce`, the Rest-view tile would render e.g. "542 N" for 542 lb — a silent numeric misrepresentation.

This relabels the **unit only**. No numeric conversion: the pipeline's contract is fitness units with no unit-math at render time, so a lbs→N conversion would be wrong.

### Changes (unit labels + doc comments; zero numbers)
- `RestView.tsx:101` — Peak-force `Metric` `unit="N"` → `unit="lbs"`
- `fixtures.ts:33` — `LiveModel.force` doc `(N)` → `(lbs)`
- `fixtures.ts:45` — `LiveModel.peakForce` doc `(N)` → `(lbs)`

### Verification
- `tsc --noEmit`: clean (exit 0)
- `eslint` on both changed files: clean (exit 0)
- No north-star unit test files exist; velocity (m/s), ROM (m), and weight (lbs/kg) units left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)