### PR TITLE
Release @titan-design/react-ui 0.9.2

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-design/react-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Cross-platform design system built on Gluestack UI",
   "author": "Henry Jewkes",
   "license": "MIT",


### PR DESCRIPTION
Patch release cutting **0.9.2** so the VW-55 force-unit fix (#114, `N`→`lbs`) reaches consumers.

## Contents since v0.9.1
- #114 — north-star live-force readout labeled `lbs` not `N` (label + doc comments only, zero numeric change).

## Release mechanics
Version bump `0.9.1` → `0.9.2` on `packages/ui/package.json`. After merge, pushing tag `v0.9.2` triggers `publish.yml` (OIDC provenance). No local `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)