### PR TITLE
Add DualSessionRail for dual-Voltra bench sessions

### DIFF
--- a/packages/ui/src/components/custom/Workout/DualSessionRail.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/DualSessionRail.stories.tsx
@@ -1,0 +1,170 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { DualSessionRail, type DualSessionRailSlot } from './DualSessionRail'
+
+/**
+ * `DualSessionRail` (shell composition) — two {@link SessionRail} columns side by
+ * side, one per Voltra device slot, for a dual-Voltra bench session (e.g. "Left
+ * Arm" / "Right Arm"). Each column keeps its own exercise list, set progress and
+ * stat tiles; only the session clock is shared. A thin composition — no new
+ * set-marker vocabulary.
+ */
+const meta: Meta<typeof DualSessionRail> = {
+  title: 'Shell/SessionRail/DualSessionRail',
+  component: DualSessionRail,
+  tags: ['autodocs'],
+  argTypes: {
+    stripHeight: { control: { type: 'range', min: 2, max: 16, step: 1 } },
+    onExercisePress: { action: 'exercise-press' },
+  },
+  decorators: [
+    (Story) => (
+      <View className="min-h-screen flex-row" style={{ backgroundColor: '#101010' }}>
+        <Story />
+        <View className="flex-1 items-center justify-center">
+          <Text style={{ color: '#6B7280', fontSize: 12 }}>main viewport</Text>
+        </View>
+      </View>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '**Composition** (shell S3, dual-device). Two independent ' +
+          '[SessionRail](?path=/docs/shell-sessionrail--docs) columns, one per device slot, ' +
+          'separated by a hairline divider. Both share the session clock (`elapsedMs` / ' +
+          '`budgetMs` / `running` / `next`); everything else — exercises, `setsDone`, ' +
+          '`metrics` — is per-slot, since two Voltra devices progress independently.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof DualSessionRail>
+
+const decay = (n: number, start: number, span = 0.4): number[] =>
+  Array.from({ length: n }, (_, r) => +(start - (span * r) / Math.max(1, n - 1)).toFixed(3))
+
+// LEFT ARM — ahead on the shared curl, mid-drop-set on the accessory move.
+// Exercises the flat done/active/todo trio + the `drop` set-type marker.
+const LEFT_SLOT: DualSessionRailSlot = {
+  label: 'Left Arm',
+  setsDone: 2.4,
+  metrics: [
+    { label: 'Volume', value: '54%' },
+    { label: 'Load', value: '3.1k' },
+    { label: 'Fatigue', value: 'MOD' },
+  ],
+  exercises: [
+    {
+      name: 'Standing Cable Curl',
+      summary: { sets: 4, reps: 10, weight: 35, unit: 'lbs' },
+      tempo: [2, 1, 2, 0],
+      indicator: 'pr',
+      setStates: [
+        { status: 'done', velocities: decay(10, 0.95) },
+        { status: 'done', velocities: decay(10, 0.85) },
+        { status: 'active', velocities: decay(5, 0.7), planned: 10 },
+        { status: 'todo', planned: 10 },
+      ],
+    },
+    {
+      name: 'Hammer Curl',
+      summary: { sets: 3, reps: 8, weight: 30, unit: 'lbs' },
+      tempo: [2, 0, 2, 0],
+      upcoming: true,
+      setStates: [
+        { status: 'drop', subloads: [decay(8, 0.8), decay(6, 0.65), decay(5, 0.55)] },
+        { status: 'todo', planned: 8 },
+        { status: 'todo', planned: 8 },
+      ],
+    },
+  ],
+}
+
+// RIGHT ARM — behind pace (velocity-loss flagged), already through a completed
+// myo-rep set, next up is a variable rep-range with a myo-upcoming trail.
+// Exercises the `myo`, `range`, and `myo-upcoming` set-type markers.
+const RIGHT_SLOT: DualSessionRailSlot = {
+  label: 'Right Arm',
+  setsDone: 1.4,
+  metrics: [
+    { label: 'Volume', value: '38%' },
+    { label: 'Load', value: '2.0k' },
+    { label: 'Fatigue', value: 'LOW' },
+  ],
+  exercises: [
+    {
+      name: 'Standing Cable Curl',
+      summary: { sets: 4, reps: 10, weight: 35, unit: 'lbs' },
+      tempo: [2, 1, 2, 0],
+      indicator: 'velocity-loss',
+      setStates: [
+        { status: 'done', velocities: decay(10, 0.78) },
+        { status: 'active', velocities: decay(4, 0.55), planned: 10 },
+        { status: 'todo', planned: 10 },
+        { status: 'todo', planned: 10 },
+      ],
+    },
+    {
+      name: 'Preacher Curl',
+      summary: { sets: 1, reps: 15, weight: 25, unit: 'lbs' },
+      tempo: [2, 0, 2, 0],
+      setStates: [
+        { status: 'myo', activation: decay(15, 0.75), clusters: [decay(5, 0.6), decay(5, 0.5)] },
+      ],
+    },
+    {
+      name: 'Bayesian Curl',
+      summary: { sets: 3, reps: '15-20', weight: 20, unit: 'lbs' },
+      tempo: [2, 1, 2, 0],
+      upcoming: true,
+      setStates: [
+        { status: 'range', floor: 15, max: 20, doneVels: [] },
+        { status: 'todo', planned: 18 },
+        { status: 'myo-upcoming', activationLen: 12 },
+      ],
+    },
+  ],
+}
+
+export const Default: Story = {
+  args: {
+    slots: [LEFT_SLOT, RIGHT_SLOT],
+    elapsedMs: (18 * 60 + 42) * 1000,
+    budgetMs: 45 * 60 * 1000,
+    stripHeight: 8,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A realistic dual-Voltra bench session — Left Arm ahead on the shared curl and mid ' +
+          'drop-set on the accessory move; Right Arm behind pace (velocity-loss flagged), past ' +
+          'a completed myo-rep set, next up a variable rep-range with a myo-upcoming trail. ' +
+          'Both columns share one session clock but progress independently.',
+      },
+    },
+  },
+}
+
+export const Upcoming: Story = {
+  args: {
+    slots: [
+      { ...LEFT_SLOT, setsDone: 0, metrics: undefined },
+      { ...RIGHT_SLOT, setsDone: 0, metrics: undefined },
+    ],
+    budgetMs: 45 * 60 * 1000,
+    next: Date.now() + 2 * 24 * 60 * 60 * 1000,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Upcoming dual session — both columns show the Date/Time/Until glance.',
+      },
+    },
+  },
+}

--- a/packages/ui/src/components/custom/Workout/DualSessionRail.test.tsx
+++ b/packages/ui/src/components/custom/Workout/DualSessionRail.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { DualSessionRail, type DualSessionRailSlot } from './DualSessionRail'
+import type { SessionRailExercise } from './SessionRail'
+
+const leftExercises: SessionRailExercise[] = [
+  {
+    name: 'Standing Cable Curl',
+    summary: { sets: 4, reps: 10, weight: 35, unit: 'lbs' },
+    setStates: [{ status: 'done', velocities: [1, 0.9] }],
+  },
+]
+
+const rightExercises: SessionRailExercise[] = [
+  {
+    name: 'Standing Cable Curl',
+    summary: { sets: 4, reps: 10, weight: 35, unit: 'lbs' },
+    setStates: [{ status: 'active', velocities: [0.7], planned: 10 }],
+  },
+]
+
+const slots: [DualSessionRailSlot, DualSessionRailSlot] = [
+  { label: 'Left Arm', exercises: leftExercises, setsDone: 1 },
+  { label: 'Right Arm', exercises: rightExercises, setsDone: 0 },
+]
+
+describe('DualSessionRail', () => {
+  it('renders one SessionRail column per slot', () => {
+    render(<DualSessionRail slots={slots} />)
+    expect(screen.getByTestId('dual-session-rail-slot-0')).toBeInTheDocument()
+    expect(screen.getByTestId('dual-session-rail-slot-1')).toBeInTheDocument()
+  })
+
+  it('titles each column with its own slot label', () => {
+    render(<DualSessionRail slots={slots} />)
+    const left = screen.getByTestId('dual-session-rail-slot-0')
+    const right = screen.getByTestId('dual-session-rail-slot-1')
+    expect(within(left).getByTestId('session-rail-title')).toHaveTextContent('Left Arm')
+    expect(within(right).getByTestId('session-rail-title')).toHaveTextContent('Right Arm')
+  })
+
+  it('keeps each slot’s set progress independent', () => {
+    render(<DualSessionRail slots={slots} />)
+    const left = screen.getByTestId('dual-session-rail-slot-0')
+    const right = screen.getByTestId('dual-session-rail-slot-1')
+    expect(within(left).getByTestId('session-rail-sets')).toHaveTextContent('1/4 sets')
+    expect(within(right).getByTestId('session-rail-sets')).toHaveTextContent('0/4 sets')
+  })
+
+  it('renders one exercise heading per slot exercise list', () => {
+    render(<DualSessionRail slots={slots} />)
+    const left = screen.getByTestId('dual-session-rail-slot-0')
+    const right = screen.getByTestId('dual-session-rail-slot-1')
+    expect(within(left).getAllByTestId('exercise-card')).toHaveLength(leftExercises.length)
+    expect(within(right).getAllByTestId('exercise-card')).toHaveLength(rightExercises.length)
+  })
+
+  it('fires onExercisePress with the slot index, exercise, and its index', () => {
+    const onExercisePress = vi.fn()
+    render(<DualSessionRail slots={slots} onExercisePress={onExercisePress} />)
+    const right = screen.getByTestId('dual-session-rail-slot-1')
+    fireEvent.click(within(right).getAllByTestId('exercise-card-header')[0])
+    expect(onExercisePress).toHaveBeenCalledWith(1, rightExercises[0], 0)
+  })
+
+  it('shares the session clock across both slots', () => {
+    render(<DualSessionRail slots={slots} elapsedMs={5 * 60 * 1000} budgetMs={20 * 60 * 1000} />)
+    const left = screen.getByTestId('dual-session-rail-slot-0')
+    const right = screen.getByTestId('dual-session-rail-slot-1')
+    expect(within(left).getByText('5:00')).toBeInTheDocument()
+    expect(within(right).getByText('5:00')).toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations', async () => {
+      const { container } = render(<DualSessionRail slots={slots} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/ui/src/components/custom/Workout/DualSessionRail.tsx
+++ b/packages/ui/src/components/custom/Workout/DualSessionRail.tsx
@@ -1,0 +1,99 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+import { View, type ViewProps } from 'react-native'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+import { SessionRail, type SessionRailExercise } from './SessionRail'
+import type { MetricTileData } from './MetricTiles'
+
+// Same row-divider pin SessionRail uses between exercise rows, reused here between
+// the two device columns so the seam reads consistently across the rail family.
+const DIVIDER = primitiveColors.charcoal[300] // #2C2C2C
+
+export interface DualSessionRailSlot {
+  /** Slot identity (e.g. "Left Arm" / "Right Arm") — rendered as this column's rail title. */
+  label: string
+  exercises: SessionRailExercise[]
+  /** Fractional sets completed for THIS slot only — devices progress independently. */
+  setsDone?: number
+  /** Live stat tiles (Volume / Load / Fatigue) for THIS slot only. */
+  metrics?: MetricTileData[]
+}
+
+export interface DualSessionRailProps extends ViewProps {
+  /** Exactly two device slots, rendered left-to-right in array order. */
+  slots: [DualSessionRailSlot, DualSessionRailSlot]
+  /** Shared session clock — both devices run against the same wall-clock timer. */
+  elapsedMs?: number
+  /** Optional shared time budget in ms. */
+  budgetMs?: number
+  /** Shared elapsed-readout live state. Default true (live). */
+  running?: boolean
+  /** When set → both columns render the UPCOMING glance. */
+  next?: number | Date
+  /** Heading strip height in px, forwarded to each column. Default 8. */
+  stripHeight?: number
+  /** Per-slot rail width in px. Default 246 (matches {@link SessionRail}). */
+  width?: number
+  onExercisePress?: (slotIndex: 0 | 1, exercise: SessionRailExercise, index: number) => void
+  className?: string
+}
+
+/**
+ * The dual-Voltra session rail: two independent {@link SessionRail} columns side
+ * by side, one per device slot (e.g. "Left Arm" / "Right Arm"), separated by a
+ * hairline divider. Each slot owns its OWN exercise list, set progress
+ * (`setsDone`), stat tiles, and set markers — only the session clock
+ * (`elapsedMs`/`budgetMs`/`running`/`next`) is shared, since both devices run the
+ * same wall-clock set. A thin composition, not a new organism: no new set-marker
+ * vocabulary is introduced, {@link SetStrip}/{@link SetBar} render exactly as they
+ * do in the single-device rail.
+ */
+export function DualSessionRail({
+  slots,
+  elapsedMs,
+  budgetMs,
+  running,
+  next,
+  stripHeight = 8,
+  width = 246,
+  onExercisePress,
+  className,
+  style,
+  ...props
+}: DualSessionRailProps) {
+  return (
+    <View
+      className={className}
+      style={[{ flexDirection: 'row' }, style]}
+      testID="dual-session-rail"
+      {...props}
+    >
+      {slots.map((slot, i) => (
+        <View
+          key={slot.label}
+          style={{
+            borderRightWidth: i === 0 ? 1 : 0,
+            borderRightColor: DIVIDER,
+          }}
+        >
+          <SessionRail
+            testID={`dual-session-rail-slot-${i}`}
+            title={slot.label}
+            exercises={slot.exercises}
+            setsDone={slot.setsDone}
+            elapsedMs={elapsedMs}
+            budgetMs={budgetMs}
+            running={running}
+            metrics={slot.metrics}
+            next={next}
+            stripHeight={stripHeight}
+            width={width}
+            onExercisePress={(exercise, index) => {
+              const slotIndex = i as 0 | 1
+              onExercisePress?.(slotIndex, exercise, index)
+            }}
+          />
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -66,11 +66,12 @@ type props without pulling the dependency.
      needs the same yellow/green/red "time-to-target" tone (a coach card, a rep-tempo
      summary). It is pure logic, trivially portable.
   3. **`LiveTempoRow` → a `TempoLiveRow` molecule** — only if a consumer wants the running
-     row *without* the chip chrome (label/background/padding). Until then the chrome and the
+     row _without_ the chip chrome (label/background/padding). Until then the chrome and the
      row belong together as one component with a `live` prop, not two.
 
   Not worth splitting today (speculative extraction the workflow warns against); this note
   is the trigger list for when it stops being speculative.
+
 - **S3 session-rail family** — `SessionRail` (organism) composes the standalone
   `ExerciseCardHeading` molecule per exercise, which composes an `ExerciseHeading`
   info block + a `SetStrip`:
@@ -96,7 +97,7 @@ type props without pulling the dependency.
   vs. variable-todo cyan), `drop` (one set, sub-loads split by 2px notches), `myo`
   (done rest-pause — activation + clusters split by 3px cluster gaps), and
   `myo-upcoming` (planned myo, length unknown — grey activation + a fading, right-open
-  cyan "clusters-to-failure" trail). The chunk-size *pattern* carries set-type identity:
+  cyan "clusters-to-failure" trail). The chunk-size _pattern_ carries set-type identity:
   **butted reps (0) < notch (2px) < cluster gap (3px) < set gap (5px)**. `cyan-900`
   (`SET_STRIP_VARIABLE_COLOR`) is the shared "variable / unknown / opportunity" pin.
   `SegmentedBar` carries these via additive `leadingGap` (per-segment left margin) and
@@ -113,6 +114,22 @@ type props without pulling the dependency.
   **Composes** link down the tree — matching the S1/S2 shell families. (The component
   files stay flat on disk in `custom/Workout/`; only the story `title`s build the tree.)
 
+- **`DualSessionRail` — dual-Voltra composition (not a new organism)** — a
+  dual-bench session drives TWO Voltra devices at once (e.g. Left Arm / Right
+  Arm), each with its own exercise list, set progress and set markers.
+  `SessionRail` itself stays single-device (unchanged); `DualSessionRail` is a
+  thin composition of two `SessionRail` columns side by side, separated by the
+  same charcoal-300 hairline the rail uses between exercise rows. Each
+  `DualSessionRailSlot` carries its own `label` (rendered as that column's
+  title), `exercises`, `setsDone`, and `metrics` — devices progress
+  independently. Only the session clock (`elapsedMs`/`budgetMs`/`running`/
+  `next`) is shared, since both devices run against the same wall clock. No new
+  set-marker vocabulary: `SetStrip`/`SetBar`/`SetStripSet` are untouched, so
+  `done`/`active`/`todo`/`range`/`drop`/`myo`/`myo-upcoming` render identically
+  in each column. Each `SessionRail` instance is given a per-slot `testID`
+  (`dual-session-rail-slot-0`/`-1`, via `SessionRail`'s inherited `ViewProps`
+  passthrough — no `SessionRail` code change needed) so slots stay queryable in
+  tests. Story: `Shell/SessionRail/DualSessionRail`.
 - **VelocityStrip set-type modes (`set` prop)** — beyond the flat `velocities`
   array (unchanged, still the source of truth for `SetRow` / `ExerciseCard`), the
   strip accepts an optional structured `VelocitySet` descriptor and renders the
@@ -133,7 +150,7 @@ type props without pulling the dependency.
   active-set spotlight (velocity-height done reps + short grey stubs) and renders
   the advanced types as a short mini-style encoding. Every modality is documented
   with a copy-paste `set` config in **`Workout/DataViz/VelocityStrip/Set
-  Modalities`** (each card carries a `Collapse` accordion; promoted from the
+Modalities`** (each card carries a `Collapse` accordion; promoted from the
   now-deleted `S3SetModalities` Lab specimen).
 - **VelocityStrip `hero` variant** — the across-the-room, single-set **wall**
   treatment (the north-star live page's velocity hero). Tall bars (default 220px
@@ -147,7 +164,7 @@ type props without pulling the dependency.
   left-packed) with a caller-set fixed height; the eyebrow/section title is
   organism chrome, not part of the primitive. **Live-update model:** the plan's
   slots are pre-allocated (`max(done, target)` columns), so a landing rep converts
-  placeholder→bar in the *same* slot with a pop — no reflow within the plan; pair
+  placeholder→bar in the _same_ slot with a pop — no reflow within the plan; pair
   with `scale="fixed"` so heights never rescale either. The one reflow case is
   set-expansion **beyond** `targetReps` (AMRAP overflow adds a column and flex-
   narrows the rest — currently snaps; smooth overflow reflow is a deferred
@@ -174,7 +191,7 @@ type props without pulling the dependency.
   dashboard scale, added as the idiomatic titan `size` union (a JS number-map per
   component; **`default` values are byte-identical** to before, so existing consumers are
   untouched). **ZoneTrack** (the shared gauge primitive) gained `size` that scales track,
-  needle, tick lines and tick labels together; its *other* consumers (TrainingLoadGauge,
+  needle, tick lines and tick labels together; its _other_ consumers (TrainingLoadGauge,
   RpeCalibration) default to `default` and are unaffected. **FatigueMeter** passes `size`
   through and lets `trackHeight` flow from it. `Wall*` / `WallDensity` stories on the wall
   background. (**TempoBar** was retired here — the standalone active-tempo bar is superseded
@@ -187,17 +204,17 @@ type props without pulling the dependency.
   per exercise, six distinct kinds over four tier colors (bound to titan status
   tokens, read as literal hex via `getSemanticColors('dark')`, not `resolveColor`,
   so tests can assert them). Glyph = the specific signal; color = the severity tier. Chips are
-  outlined (border + glyph, no fill) so they never collide with the *filled*
+  outlined (border + glyph, no fill) so they never collide with the _filled_
   velocity strip, and static (no pulse — they are chrome). Precedence, high → low:
 
-  | # | kind | tier | glyph (mirrors lucide) |
-  |---|------|------|------------------------|
-  | 1 | `imbalance` | danger (`status-error`) | `Scale` |
-  | 2 | `overshoot` | danger (`status-error`) | `AlertTriangle` |
-  | 3 | `velocity-loss` | warning (`status-warning`) | `TrendingDown` |
-  | 4 | `missed-reps` | warning (`status-warning`) | `CircleSlash` |
-  | 5 | `pr` | success (`status-success`) | `Award` |
-  | 6 | `info` | info (`status-info`) | `Info` |
+  | #   | kind            | tier                       | glyph (mirrors lucide) |
+  | --- | --------------- | -------------------------- | ---------------------- |
+  | 1   | `imbalance`     | danger (`status-error`)    | `Scale`                |
+  | 2   | `overshoot`     | danger (`status-error`)    | `AlertTriangle`        |
+  | 3   | `velocity-loss` | warning (`status-warning`) | `TrendingDown`         |
+  | 4   | `missed-reps`   | warning (`status-warning`) | `CircleSlash`          |
+  | 5   | `pr`            | success (`status-success`) | `Award`                |
+  | 6   | `info`          | info (`status-info`)       | `Info`                 |
 
   `resolveIndicator(candidates)` collapses the active signals to the single
   highest-precedence kind to show (`undefined` when none). Alerts outrank `pr`. The

--- a/packages/ui/src/components/custom/Workout/index.ts
+++ b/packages/ui/src/components/custom/Workout/index.ts
@@ -70,6 +70,11 @@ export {
   type SessionHeaderPlanEntry,
 } from './SessionHeader'
 export { SessionRail, type SessionRailProps, type SessionRailExercise } from './SessionRail'
+export {
+  DualSessionRail,
+  type DualSessionRailProps,
+  type DualSessionRailSlot,
+} from './DualSessionRail'
 export { SupersetWrapper, type SupersetWrapperProps } from './SupersetWrapper'
 export {
   MesoProgressBar,


### PR DESCRIPTION
## DualSessionRail — dual-Voltra session rail

Composes two `SessionRail` columns for a dual (bilateral) bench session — one per bound Voltra slot (Left Arm / Right Arm), each fully independent (own title, exercises, setsDone, metrics) with a shared session clock. **Pure composition** — no changes to `SessionRail`/`SetBar`/`SetStrip`/`SetRow`/`SetsRepsLoad`; the `SetStripSet` set-marker vocabulary (done/active/todo/range/drop/myo/myo-upcoming) is reused as-is.

### What's in
- `DualSessionRail.tsx` — organism. Props: `slots: [slot, slot]` (label / exercises / setsDone? / metrics? each), shared `elapsedMs? / budgetMs? / running? / next?`, `onExercisePress(slotIndex, exercise, index)`.
- Stories `Shell/SessionRail/DualSessionRail` (Default = realistic asymmetric dual session exercising all 7 set-marker types; Upcoming). 7 unit tests + `index.ts` exports.

### Gates
type-check · eslint · prettier · vitest — all green (7/7 new, 32/32 rail regression).

### Notes
- Built by an agent; diff verified against `main` — **no code deletions** (all `-` lines are README markdown reflow; README is not a hand-aligned token file).
- Not yet operator-validated in Storybook (Gate-2) — review the Default story render before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>