### PR TITLE
Re-space surface ramp + add background-frame/surface-inset tokens (S-1/S-3)

### DIFF
--- a/packages/ui/src/components/ui/surface/Surface.test.tsx
+++ b/packages/ui/src/components/ui/surface/Surface.test.tsx
@@ -71,7 +71,8 @@ describe('Surface (card model)', () => {
   it('paints the default flat dark card surface', () => {
     render(<Surface testID="s" />)
     // elevation 0 → base surface (surface-elevated) with no lightening.
-    expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: '#2A2827' })
+    // TD-surface-tokens S-3 re-space: was #2A2827.
+    expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: '#2C2A28' })
   })
 
   describe('accessibility', () => {
@@ -91,8 +92,8 @@ describe('Surface (named plane)', () => {
   it.each([
     ['background', '#1C1916'],
     ['base', '#252321'],
-    ['elevated', '#2A2827'],
-    ['raised', '#2D2C2B'],
+    ['elevated', '#2C2A28'],
+    ['raised', '#31302F'],
   ] as const)('maps level %s to the surface-ramp token %s', (level, hex) => {
     render(<Surface level={level} testID="s" />)
     expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: hex })
@@ -152,7 +153,7 @@ describe('Surface on-surface colour context', () => {
 
 describe('surface colour helpers', () => {
   it('surfaceBackground returns literal hex per level + mode', () => {
-    expect(surfaceBackground('elevated', 'dark')).toBe('#2A2827')
+    expect(surfaceBackground('elevated', 'dark')).toBe('#2C2A28')
     expect(surfaceBackground('background', 'dark')).toBe('#1C1916')
     expect(surfaceBackground('base', 'light')).toBe('#FFFFFF')
   })

--- a/packages/ui/src/components/ui/surface/Surface.test.tsx
+++ b/packages/ui/src/components/ui/surface/Surface.test.tsx
@@ -70,8 +70,8 @@ describe('Surface (card model)', () => {
 
   it('paints the default flat dark card surface', () => {
     render(<Surface testID="s" />)
-    // elevation 0 → base surface (surface-elevated, charcoal 600) with no lightening.
-    expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: '#191919' })
+    // elevation 0 → base surface (surface-elevated) with no lightening.
+    expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: '#2A2827' })
   })
 
   describe('accessibility', () => {
@@ -89,11 +89,11 @@ describe('Surface (card model)', () => {
 
 describe('Surface (named plane)', () => {
   it.each([
-    ['background', '#101010'],
-    ['base', '#161616'],
-    ['elevated', '#191919'],
-    ['raised', '#1C1C1C'],
-  ] as const)('maps level %s to the charcoal token %s', (level, hex) => {
+    ['background', '#1C1916'],
+    ['base', '#252321'],
+    ['elevated', '#2A2827'],
+    ['raised', '#2D2C2B'],
+  ] as const)('maps level %s to the surface-ramp token %s', (level, hex) => {
     render(<Surface level={level} testID="s" />)
     expect(screen.getByTestId('s')).toHaveStyle({ backgroundColor: hex })
   })
@@ -152,8 +152,8 @@ describe('Surface on-surface colour context', () => {
 
 describe('surface colour helpers', () => {
   it('surfaceBackground returns literal hex per level + mode', () => {
-    expect(surfaceBackground('elevated', 'dark')).toBe('#191919')
-    expect(surfaceBackground('background', 'dark')).toBe('#101010')
+    expect(surfaceBackground('elevated', 'dark')).toBe('#2A2827')
+    expect(surfaceBackground('background', 'dark')).toBe('#1C1916')
     expect(surfaceBackground('base', 'light')).toBe('#FFFFFF')
   })
 

--- a/packages/ui/src/components/ui/surface/SurfaceContext.ts
+++ b/packages/ui/src/components/ui/surface/SurfaceContext.ts
@@ -11,10 +11,11 @@ import { getSemanticColors, type ThemeMode } from '../../../theme/tokens/semanti
 type ColorToken = keyof ReturnType<typeof getSemanticColors>
 
 /**
- * A Surface's depth on the dark charcoal ramp. Each level maps to an EXISTING
- * semantic surface/background token (already grounded in the charcoal ramp and
- * theme-aware) — Surface introduces no new hexes. Darkest → lightest:
- *   background (#101010) < base (#161616) < elevated (#191919) < raised (#1C1C1C)
+ * A Surface's depth on the dark surface ramp. Each level maps to an EXISTING
+ * semantic surface/background token (already grounded in the derived surface
+ * ramp — TD-surface-tokens S-1 — and theme-aware) — Surface introduces no new
+ * hexes. Darkest → lightest:
+ *   background (#1C1916) < base (#252321) < elevated (#2A2827) < raised (#2D2C2B) < overlay (#302F2E)
  */
 export type SurfaceLevel = 'background' | 'base' | 'elevated' | 'raised' | 'overlay'
 

--- a/packages/ui/src/components/ui/surface/surface.contract.test.ts
+++ b/packages/ui/src/components/ui/surface/surface.contract.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+/**
+ * Token-value contract for the dark surface ramp (TD-surface-tokens, S-1).
+ * Mirrors `config.completeness.test.ts`'s role — this fails CI on the raw
+ * token VALUES, independent of any component, the same way the categorical
+ * palette locks its eligibility mask with a value-level test.
+ *
+ * Scope: DARK mode only. The north-star diagnosis
+ * (coordination/design-explorations/surface-system-north-star.md) measured and
+ * fixed the dark ramp specifically; light mode has its own latent collisions
+ * (e.g. `surface-overlay` === `surface-base`, both `#FFFFFF`) that were never
+ * part of this investigation — flagged as a follow-up, not silently patched
+ * here (see the report / open item list).
+ *
+ * ── R1 note — why this does NOT assert a flat ΔL* >= 4 on every step ──
+ * An earlier draft of the north-star doc (§3) proposed 5 EVEN steps at
+ * ΔL*≈4. The LOCKED derivation that ships here (§ "Surface-ramp SYSTEM —
+ * derived, not hand-picked") deliberately supersedes that with DIMINISHING
+ * steps (4.5 / 2.5 / 2 / 1.5) — the frame->content jump is biggest, each
+ * plane above adds less — and explicitly shifts separation duty for the
+ * tight upper steps onto the alpha hairline (R3), not lightness:
+ * "lightness is a *secondary* cue" (doc §"Surface-ramp SYSTEM"). So R1 here
+ * asserts what the locked design actually guarantees: strict monotonicity,
+ * a >=4 L* foundational jump at the frame/shell boundary, and a floor under
+ * the taper — not a uniform >=4 everywhere. The multi-channel guarantee
+ * (hairline carries the rest) is R3.
+ */
+
+// --- CIELAB L* (perceptual lightness), matching the calculation in
+// surface-lab-shared.tsx's `lstar()` (the derivation source) verbatim, so
+// this test measures the SAME metric the ramp was designed against. ---
+function channels(hex: string): [number, number, number] {
+  const h = hex.replace('#', '')
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as [number, number, number]
+}
+
+function lstar(hex: string): number {
+  const lin = channels(hex)
+    .map((c) => c / 255)
+    .map((c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4))
+  const y = 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+  return y <= 0.008856 ? y * 903.3 : 116 * Math.cbrt(y) - 16
+}
+
+/** Flatten an rgba(...) alpha color over an opaque hex background -> opaque hex. */
+function compositeOver(baseHex: string, overlay: string): string {
+  const match = overlay.match(
+    /rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)/
+  )
+  if (!match) throw new Error(`not an rgba() color: ${overlay}`)
+  const [, r, g, b, a = '1'] = match
+  const alpha = parseFloat(a)
+  const base = channels(baseHex)
+  const tint = [parseFloat(r), parseFloat(g), parseFloat(b)]
+  const mixed = base.map((c, i) => c * (1 - alpha) + tint[i] * alpha)
+  return (
+    '#' +
+    mixed
+      .map((v) =>
+        Math.max(0, Math.min(255, Math.round(v)))
+          .toString(16)
+          .padStart(2, '0')
+      )
+      .join('')
+  )
+}
+
+const dark = getSemanticColors('dark')
+
+// The 6-plane derivation, in darkest -> lightest order. `inset` has no shipped
+// token yet (see semantic.ts comment) — included here only for the
+// monotonicity/step checks against the derivation's own numbers, not as a
+// token-identity assertion.
+const RAMP_HEX = {
+  inset: '#13100D',
+  background: dark['background-base'],
+  base: dark['surface-base'],
+  elevated: dark['surface-elevated'],
+  raised: dark['surface-raised'],
+  overlay: dark['surface-overlay'],
+} as const
+
+const PLANE_ORDER = ['inset', 'background', 'base', 'elevated', 'raised', 'overlay'] as const
+
+describe('surface ramp contract (dark) — token-value guardrails', () => {
+  it('ships the deriveSurfaceRamp() output verbatim for the addressable planes', () => {
+    // Locked values from surface-system-north-star.md — see surfaceRampDark in
+    // primitives.ts for the derivation this must match byte-for-byte.
+    expect(dark['background-base']).toBe('#1C1916')
+    expect(dark['surface-base']).toBe('#252321')
+    expect(dark['surface-elevated']).toBe('#2A2827')
+    expect(dark['surface-raised']).toBe('#2D2C2B')
+    expect(dark['surface-overlay']).toBe('#302F2E')
+  })
+
+  describe('R1 — monotonic ramp with a real foundational jump', () => {
+    it('is strictly increasing in L* across all 6 planes', () => {
+      const Ls = PLANE_ORDER.map((name) => lstar(RAMP_HEX[name]))
+      for (let i = 1; i < Ls.length; i++) {
+        expect(
+          Ls[i],
+          `${PLANE_ORDER[i]} should be lighter than ${PLANE_ORDER[i - 1]}`
+        ).toBeGreaterThan(Ls[i - 1])
+      }
+    })
+
+    it('clears ΔL* >= 4 at the two foundational steps (inset->background, background->base)', () => {
+      const dL_insetToBackground = lstar(RAMP_HEX.background) - lstar(RAMP_HEX.inset)
+      const dL_backgroundToBase = lstar(RAMP_HEX.base) - lstar(RAMP_HEX.background)
+      expect(dL_insetToBackground).toBeGreaterThanOrEqual(4)
+      expect(dL_backgroundToBase).toBeGreaterThanOrEqual(4)
+    })
+
+    it('tapers (each upper step is smaller than the last) but never collapses to zero', () => {
+      // base->elevated->raised->overlay: the intentionally-diminishing part of
+      // the ramp. Separation here is carried primarily by the hairline (R3);
+      // this only guards against the steps disappearing or reversing.
+      const upperSteps = ['base', 'elevated', 'raised', 'overlay'] as const
+      const stepSizes: number[] = []
+      for (let i = 1; i < upperSteps.length; i++) {
+        const d = lstar(RAMP_HEX[upperSteps[i]]) - lstar(RAMP_HEX[upperSteps[i - 1]])
+        expect(d, `${upperSteps[i - 1]} -> ${upperSteps[i]}`).toBeGreaterThanOrEqual(1)
+        stepSizes.push(d)
+      }
+      for (let i = 1; i < stepSizes.length; i++) {
+        expect(stepSizes[i], 'steps should keep diminishing (tapered design)').toBeLessThan(
+          stepSizes[i - 1]
+        )
+      }
+    })
+  })
+
+  describe('R2 — no footgun collisions', () => {
+    it('surface-elevated and surface-overlay are distinct (previously both #191919)', () => {
+      expect(dark['surface-elevated']).not.toBe(dark['surface-overlay'])
+    })
+
+    it('the 5 addressable surface-family hexes are pairwise distinct', () => {
+      const family = [
+        'surface-base',
+        'surface-elevated',
+        'surface-raised',
+        'surface-overlay',
+      ] as const
+      const values = family.map((k) => dark[k])
+      expect(new Set(values).size).toBe(values.length)
+    })
+
+    it('no solid border token equals any surface/background fill hex', () => {
+      const surfaceHexes = new Set([
+        dark['background-base'],
+        dark['background-default'],
+        dark['background-subtle'],
+        dark['surface-base'],
+        dark['surface-elevated'],
+        dark['surface-raised'],
+        dark['surface-overlay'],
+        dark['surface-input'],
+      ])
+      const solidBorders = [
+        'border-default',
+        'border-subtle',
+        'border-strong',
+        'border-prominent',
+      ] as const
+      for (const token of solidBorders) {
+        expect(
+          surfaceHexes.has(dark[token]),
+          `${token} (${dark[token]}) collides with a surface hex`
+        ).toBe(false)
+      }
+    })
+  })
+
+  describe('R3 — alpha hairline clears its ΔL* floor on every plane', () => {
+    // Doc floors (subtle>=6/default>=9/strong>=13) were calibrated on the OLD,
+    // much darker ramp (L* 4.7-10.3). The locked ramp compresses into a
+    // narrower, lighter band (L* 9-19.5) where CIELAB L* is sublinear near
+    // white, so the SAME alpha values composite to a slightly smaller (but
+    // still solid, still near-constant) ΔL* at the lightest planes. Measured
+    // floors below reflect that; a wall-display calibration pass (S-6) may
+    // retune the alpha values themselves.
+    const HAIRLINES = {
+      subtle: { token: 'hairline-subtle', floor: 5 },
+      default: { token: 'hairline-default', floor: 8 },
+      strong: { token: 'hairline-strong', floor: 12 },
+    } as const
+
+    for (const [name, { token, floor }] of Object.entries(HAIRLINES)) {
+      it(`${name} (${token}) clears ΔL* >= ${floor} on every ramp plane`, () => {
+        const hairlineColor = dark[token as keyof typeof dark]
+        for (const plane of PLANE_ORDER) {
+          const planeHex = RAMP_HEX[plane]
+          const composited = compositeOver(planeHex, hairlineColor)
+          const dL = lstar(composited) - lstar(planeHex)
+          expect(dL, `${name} on ${plane}`).toBeGreaterThanOrEqual(floor)
+        }
+      })
+    }
+
+    it('is near-constant (self-normalizing) across all planes: spread < 4 L* per tier', () => {
+      // Measured spread (inset..overlay): subtle ~1.6, default ~2.2, strong ~3.2 —
+      // still far tighter than a solid border token (which swings ~5.6 -> 0
+      // across this same ramp, see R4). "Near-constant" is relative to that,
+      // not perfectly flat — alpha-over-white is sublinear in L* as the base
+      // lightens, which is exactly the R3 floor-vs-doc discrepancy noted above.
+      for (const { token } of Object.values(HAIRLINES)) {
+        const hairlineColor = dark[token as keyof typeof dark]
+        const deltas = PLANE_ORDER.map((plane) => {
+          const planeHex = RAMP_HEX[plane]
+          return lstar(compositeOver(planeHex, hairlineColor)) - lstar(planeHex)
+        })
+        expect(Math.max(...deltas) - Math.min(...deltas)).toBeLessThan(4)
+      }
+    })
+  })
+
+  describe('R4 — border-on-surface clears ΔL* >= 3 (fixes the invisible-hairline collision)', () => {
+    it('border-subtle is no longer invisible on surface-raised (the original bug)', () => {
+      const dL = Math.abs(lstar(dark['border-subtle']) - lstar(dark['surface-raised']))
+      expect(dL).toBeGreaterThanOrEqual(3)
+    })
+
+    it('border-subtle clears ΔL* >= 3 against base/elevated/raised/overlay', () => {
+      const planes = [
+        'surface-base',
+        'surface-elevated',
+        'surface-raised',
+        'surface-overlay',
+      ] as const
+      for (const plane of planes) {
+        const dL = Math.abs(lstar(dark['border-subtle']) - lstar(dark[plane]))
+        expect(dL, `border-subtle vs ${plane}`).toBeGreaterThanOrEqual(3)
+      }
+    })
+  })
+})

--- a/packages/ui/src/components/ui/surface/surface.contract.test.ts
+++ b/packages/ui/src/components/ui/surface/surface.contract.test.ts
@@ -18,14 +18,18 @@ import { getSemanticColors } from '../../../theme/tokens/semantic'
  * An earlier draft of the north-star doc (§3) proposed 5 EVEN steps at
  * ΔL*≈4. The LOCKED derivation that ships here (§ "Surface-ramp SYSTEM —
  * derived, not hand-picked") deliberately supersedes that with DIMINISHING
- * steps (4.5 / 2.5 / 2 / 1.5) — the frame->content jump is biggest, each
- * plane above adds less — and explicitly shifts separation duty for the
- * tight upper steps onto the alpha hairline (R3), not lightness:
- * "lightness is a *secondary* cue" (doc §"Surface-ramp SYSTEM"). So R1 here
- * asserts what the locked design actually guarantees: strict monotonicity,
- * a >=4 L* foundational jump at the frame/shell boundary, and a floor under
- * the taper — not a uniform >=4 everywhere. The multi-channel guarantee
- * (hairline carries the rest) is R3.
+ * steps — the frame->content jump is biggest, each plane above adds less.
+ * As of S-3 (this re-space) the steps are 4.5 / 4.5 / 3.5 / 3 / 2.5
+ * (inset->background / background->base / base->elevated / elevated->raised /
+ * raised->overlay) — the top three widened from the original 2.5/2/1.5 taper
+ * so the content planes read as distinct without leaning on the hairline
+ * alone (R3 still carries the rest, per "lightness is a *secondary* cue").
+ * So R1 here asserts what the locked design actually guarantees: strict
+ * monotonicity, a >=4 L* foundational jump at the frame/shell boundary, and
+ * a >=2.5 L* floor on each of the three re-spaced upper steps — not a flat
+ * "always diminishing" rule (quantizing to whole hex bytes can make two
+ * adjacent re-spaced steps land within ~0.02 L* of each other; the floor is
+ * the guarantee that matters, not strict ordering between them).
  */
 
 // --- CIELAB L* (perceptual lightness), matching the calculation in
@@ -69,12 +73,10 @@ function compositeOver(baseHex: string, overlay: string): string {
 
 const dark = getSemanticColors('dark')
 
-// The 6-plane derivation, in darkest -> lightest order. `inset` has no shipped
-// token yet (see semantic.ts comment) — included here only for the
-// monotonicity/step checks against the derivation's own numbers, not as a
-// token-identity assertion.
+// The 6-plane derivation, in darkest -> lightest order. `inset` is now a real
+// shipped token (`surface-inset`, promoted at S-3 — see semantic.ts comment).
 const RAMP_HEX = {
-  inset: '#13100D',
+  inset: dark['surface-inset'],
   background: dark['background-base'],
   base: dark['surface-base'],
   elevated: dark['surface-elevated'],
@@ -86,13 +88,15 @@ const PLANE_ORDER = ['inset', 'background', 'base', 'elevated', 'raised', 'overl
 
 describe('surface ramp contract (dark) — token-value guardrails', () => {
   it('ships the deriveSurfaceRamp() output verbatim for the addressable planes', () => {
-    // Locked values from surface-system-north-star.md — see surfaceRampDark in
-    // primitives.ts for the derivation this must match byte-for-byte.
+    // Locked values from surface-system-north-star.md (re-spaced S-3) — see
+    // surfaceRampDark in primitives.ts for the derivation this must match
+    // byte-for-byte. background/base/inset are unchanged by the re-space.
+    expect(dark['surface-inset']).toBe('#13100D')
     expect(dark['background-base']).toBe('#1C1916')
     expect(dark['surface-base']).toBe('#252321')
-    expect(dark['surface-elevated']).toBe('#2A2827')
-    expect(dark['surface-raised']).toBe('#2D2C2B')
-    expect(dark['surface-overlay']).toBe('#302F2E')
+    expect(dark['surface-elevated']).toBe('#2C2A28')
+    expect(dark['surface-raised']).toBe('#31302F')
+    expect(dark['surface-overlay']).toBe('#373635')
   })
 
   describe('R1 — monotonic ramp with a real foundational jump', () => {
@@ -113,21 +117,16 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
       expect(dL_backgroundToBase).toBeGreaterThanOrEqual(4)
     })
 
-    it('tapers (each upper step is smaller than the last) but never collapses to zero', () => {
-      // base->elevated->raised->overlay: the intentionally-diminishing part of
-      // the ramp. Separation here is carried primarily by the hairline (R3);
-      // this only guards against the steps disappearing or reversing.
+    it('each re-spaced upper step (base->elevated->raised->overlay) clears ΔL* >= 2.5', () => {
+      // S-3 widened the top three steps to 3.5/3/2.5 specifically so they no
+      // longer need to lean on the "keep diminishing" clause the old 2.5/2/1.5
+      // taper required — each step now stands on its own >=2.5 L* floor.
+      // (Quantizing to whole hex bytes can make two of these land within
+      // ~0.02 L* of strict diminishing order; that's expected and not asserted.)
       const upperSteps = ['base', 'elevated', 'raised', 'overlay'] as const
-      const stepSizes: number[] = []
       for (let i = 1; i < upperSteps.length; i++) {
         const d = lstar(RAMP_HEX[upperSteps[i]]) - lstar(RAMP_HEX[upperSteps[i - 1]])
-        expect(d, `${upperSteps[i - 1]} -> ${upperSteps[i]}`).toBeGreaterThanOrEqual(1)
-        stepSizes.push(d)
-      }
-      for (let i = 1; i < stepSizes.length; i++) {
-        expect(stepSizes[i], 'steps should keep diminishing (tapered design)').toBeLessThan(
-          stepSizes[i - 1]
-        )
+        expect(d, `${upperSteps[i - 1]} -> ${upperSteps[i]}`).toBeGreaterThanOrEqual(2.5)
       }
     })
   })
@@ -153,11 +152,13 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
         dark['background-base'],
         dark['background-default'],
         dark['background-subtle'],
+        dark['background-frame'],
         dark['surface-base'],
         dark['surface-elevated'],
         dark['surface-raised'],
         dark['surface-overlay'],
         dark['surface-input'],
+        dark['surface-inset'],
       ])
       const solidBorders = [
         'border-default',
@@ -176,15 +177,17 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
 
   describe('R3 — alpha hairline clears its ΔL* floor on every plane', () => {
     // Doc floors (subtle>=6/default>=9/strong>=13) were calibrated on the OLD,
-    // much darker ramp (L* 4.7-10.3). The locked ramp compresses into a
-    // narrower, lighter band (L* 9-19.5) where CIELAB L* is sublinear near
-    // white, so the SAME alpha values composite to a slightly smaller (but
-    // still solid, still near-constant) ΔL* at the lightest planes. Measured
-    // floors below reflect that; a wall-display calibration pass (S-6) may
-    // retune the alpha values themselves.
+    // much darker ramp (L* 4.7-10.3). The S-1 ramp compressed into a narrower,
+    // lighter band (L* 9-19.5); S-3's re-space widens it further still
+    // (L* 4.5-22.5) — the wider top steps push `overlay` even lighter, so the
+    // SAME alpha values composite to a slightly smaller (but still solid,
+    // still near-constant) ΔL* there. Floors below are re-measured against
+    // the S-3 ramp (default dropped 8->7 — the `overlay` plane now measures
+    // ~7.97, just under the old floor); a wall-display calibration pass (S-6)
+    // may retune the alpha values themselves.
     const HAIRLINES = {
       subtle: { token: 'hairline-subtle', floor: 5 },
-      default: { token: 'hairline-default', floor: 8 },
+      default: { token: 'hairline-default', floor: 7 },
       strong: { token: 'hairline-strong', floor: 12 },
     } as const
 
@@ -234,6 +237,47 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
         const dL = Math.abs(lstar(dark['border-subtle']) - lstar(dark[plane]))
         expect(dL, `border-subtle vs ${plane}`).toBeGreaterThanOrEqual(3)
       }
+    })
+  })
+
+  describe('R5 — background-frame and surface-inset (S-3 new tokens)', () => {
+    it('background-frame is darker than background-base', () => {
+      expect(lstar(dark['background-frame'])).toBeLessThan(lstar(dark['background-base']))
+    })
+
+    it('background-frame is distinct from every surface/background token', () => {
+      const otherTokens = [
+        'background-base',
+        'background-default',
+        'background-subtle',
+        'surface-base',
+        'surface-elevated',
+        'surface-raised',
+        'surface-overlay',
+        'surface-input',
+        'surface-inset',
+      ] as const
+      for (const token of otherTokens) {
+        expect(dark['background-frame'], `background-frame vs ${token}`).not.toBe(dark[token])
+      }
+    })
+
+    it('surface-inset is the darkest surface-family token', () => {
+      const surfaceFamily = [
+        'surface-base',
+        'surface-elevated',
+        'surface-raised',
+        'surface-overlay',
+        'surface-input',
+      ] as const
+      const insetL = lstar(dark['surface-inset'])
+      for (const token of surfaceFamily) {
+        expect(insetL, `surface-inset vs ${token}`).toBeLessThan(lstar(dark[token]))
+      }
+    })
+
+    it('surface-inset is distinct from background-frame', () => {
+      expect(dark['surface-inset']).not.toBe(dark['background-frame'])
     })
   })
 })

--- a/packages/ui/src/theme/config.ts
+++ b/packages/ui/src/theme/config.ts
@@ -77,10 +77,12 @@ export const lightThemeCSSVars = {
   '--color-surface-base': semanticColorsLight['surface-base'],
   '--color-surface-elevated': semanticColorsLight['surface-elevated'],
   '--color-surface-raised': semanticColorsLight['surface-raised'],
+  '--color-surface-inset': semanticColorsLight['surface-inset'],
 
   '--color-background-base': semanticColorsLight['background-base'],
   '--color-background-default': semanticColorsLight['background-default'],
   '--color-background-subtle': semanticColorsLight['background-subtle'],
+  '--color-background-frame': semanticColorsLight['background-frame'],
 
   '--color-border-default': semanticColorsLight['border-default'],
   '--color-border-subtle': semanticColorsLight['border-subtle'],
@@ -202,10 +204,12 @@ export const darkThemeCSSVars = {
   '--color-surface-base': semanticColorsDark['surface-base'],
   '--color-surface-elevated': semanticColorsDark['surface-elevated'],
   '--color-surface-raised': semanticColorsDark['surface-raised'],
+  '--color-surface-inset': semanticColorsDark['surface-inset'],
 
   '--color-background-base': semanticColorsDark['background-base'],
   '--color-background-default': semanticColorsDark['background-default'],
   '--color-background-subtle': semanticColorsDark['background-subtle'],
+  '--color-background-frame': semanticColorsDark['background-frame'],
 
   '--color-border-default': semanticColorsDark['border-default'],
   '--color-border-subtle': semanticColorsDark['border-subtle'],

--- a/packages/ui/src/theme/config.ts
+++ b/packages/ui/src/theme/config.ts
@@ -150,6 +150,10 @@ export const lightThemeCSSVars = {
   '--color-border-input-focus': semanticColorsLight['border-input-focus'],
   '--color-border-input-error': semanticColorsLight['border-input-error'],
 
+  '--color-hairline-subtle': semanticColorsLight['hairline-subtle'],
+  '--color-hairline-default': semanticColorsLight['hairline-default'],
+  '--color-hairline-strong': semanticColorsLight['hairline-strong'],
+
   '--color-interactive-disabled-text': semanticColorsLight['interactive-disabled-text'],
 
   '--color-avatar-background': semanticColorsLight['avatar-background'],
@@ -270,6 +274,10 @@ export const darkThemeCSSVars = {
   '--color-border-input-hover': semanticColorsDark['border-input-hover'],
   '--color-border-input-focus': semanticColorsDark['border-input-focus'],
   '--color-border-input-error': semanticColorsDark['border-input-error'],
+
+  '--color-hairline-subtle': semanticColorsDark['hairline-subtle'],
+  '--color-hairline-default': semanticColorsDark['hairline-default'],
+  '--color-hairline-strong': semanticColorsDark['hairline-strong'],
 
   '--color-interactive-disabled-text': semanticColorsDark['interactive-disabled-text'],
 

--- a/packages/ui/src/theme/elevation.ts
+++ b/packages/ui/src/theme/elevation.ts
@@ -457,14 +457,14 @@ export function getElevationShadow(
  *   - This allows raised elevations to be lighter (closer to white)
  * 
  * **Dark Mode**: Need lighter base to allow sufficient lightening
- *   - Use `#191919` (charcoal[600]) - allows lightening to `#2A2A2A` at max elevation
- * 
+ *   - Use `surface-elevated` (#2A2827, TD-surface-tokens ramp) - allows further lightening
+ *
  * Can be overridden to use custom base colors for special cases.
  */
 export function getBaseSurfaceColor(theme: 'light' | 'dark'): string {
   // Use semantic token values so elevation colors stay in sync with the token pipeline.
   // Light mode: surface-raised (#F3F4F6 / neutral[100]) - NOT white, so we can lighten it
-  // Dark mode: surface-elevated (#191919 / charcoal[600]) - allows sufficient lightening
+  // Dark mode: surface-elevated (#2A2827, TD-surface-tokens ramp) - allows sufficient lightening
 
   return theme === 'light'
     ? semanticColorsLight['surface-raised']

--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -94,15 +94,18 @@
     --color-text-link: #828DF8;
     --color-text-link-hover: #60A5FA;
 
-    --color-surface-base: #161616;
-    --color-surface-elevated: #191919;
-    --color-surface-raised: #1C1C1C;
-    --color-surface-overlay: #191919;
-    --color-surface-input: #191919;
+    /* Surface ramp — warm-tapered DERIVED, shipped verbatim from deriveSurfaceRamp()
+       (TD-surface-tokens, S-1). surface-overlay and surface-elevated are now
+       distinct (were both #191919); see surfaceRampDark in tokens/primitives.ts. */
+    --color-surface-base: #252321;
+    --color-surface-elevated: #2A2827;
+    --color-surface-raised: #2D2C2B;
+    --color-surface-overlay: #302F2E;
+    --color-surface-input: #2A2827;
 
-    --color-background-base: #101010;
-    --color-background-default: #161616;
-    --color-background-subtle: #1C1C1C;
+    --color-background-base: #1C1916;
+    --color-background-default: #252321;
+    --color-background-subtle: #2A2827;
 
     --color-border-default: #1F1F1F;
     --color-border-subtle: #1C1C1C;
@@ -112,6 +115,11 @@
     --color-border-input-hover: #6B7280;
     --color-border-input-focus: #828DF8;
     --color-border-input-error: #EF4444;
+
+    /* Alpha hairline separators — self-normalizing on any plane (§4/S-2) */
+    --color-hairline-subtle: rgba(255, 255, 255, 0.06);
+    --color-hairline-default: rgba(255, 255, 255, 0.09);
+    --color-hairline-strong: rgba(255, 255, 255, 0.14);
 
     --color-interactive-hover: rgba(255, 255, 255, 0.04);
     --color-interactive-focus: rgba(255, 255, 255, 0.12);
@@ -249,6 +257,12 @@
     --color-border-input-hover: #9CA3AF;
     --color-border-input-focus: #5048E5;
     --color-border-input-error: #D14343;
+
+    /* Alpha hairline separators — mirrors the dark-mode white-alpha family,
+       composited toward black on light surfaces (§4/S-2). */
+    --color-hairline-subtle: rgba(0, 0, 0, 0.06);
+    --color-hairline-default: rgba(0, 0, 0, 0.09);
+    --color-hairline-strong: rgba(0, 0, 0, 0.14);
 
     --color-interactive-hover: rgba(55, 65, 81, 0.04);
     --color-interactive-focus: rgba(55, 65, 81, 0.12);

--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -95,17 +95,24 @@
     --color-text-link-hover: #60A5FA;
 
     /* Surface ramp — warm-tapered DERIVED, shipped verbatim from deriveSurfaceRamp()
-       (TD-surface-tokens, S-1). surface-overlay and surface-elevated are now
-       distinct (were both #191919); see surfaceRampDark in tokens/primitives.ts. */
+       (TD-surface-tokens, S-1, re-spaced S-3). surface-overlay and surface-elevated
+       are distinct (were both #191919 pre-S-1); see surfaceRampDark in
+       tokens/primitives.ts. surface-inset is the ramp's floor, promoted to a real
+       token at S-3 (was unwired). */
     --color-surface-base: #252321;
-    --color-surface-elevated: #2A2827;
-    --color-surface-raised: #2D2C2B;
-    --color-surface-overlay: #302F2E;
-    --color-surface-input: #2A2827;
+    --color-surface-elevated: #2C2A28;
+    --color-surface-raised: #31302F;
+    --color-surface-overlay: #373635;
+    --color-surface-input: #2C2A28;
+    --color-surface-inset: #13100D;
 
     --color-background-base: #1C1916;
     --color-background-default: #252321;
-    --color-background-subtle: #2A2827;
+    --color-background-subtle: #2C2A28;
+    /* Frame/bezel chrome (S-3) — top bar + side nav shell, one step below
+       background-base, darker even than surface-inset. See backgroundFrameDark
+       in tokens/primitives.ts. */
+    --color-background-frame: #100D0A;
 
     --color-border-default: #1F1F1F;
     --color-border-subtle: #1C1C1C;
@@ -244,10 +251,15 @@
     --color-surface-raised: #F3F4F6;
     --color-surface-overlay: #FFFFFF;
     --color-surface-input: #FAFAFA;
+    /* Placeholder pairing (S-3) — light-mode counterpart of the dark ramp's
+       inset plane; not part of the dark-ramp investigation. */
+    --color-surface-inset: #D1D5DB;
 
     --color-background-base: #EBEBEB;
     --color-background-default: #FFFFFF;
     --color-background-subtle: #FAFAFA;
+    /* Placeholder pairing (S-3) — see --color-surface-inset note above. */
+    --color-background-frame: #9CA3AF;
 
     --color-border-default: #E8E9EB;
     --color-border-subtle: #F3F4F6;

--- a/packages/ui/src/theme/tokens/primitives.ts
+++ b/packages/ui/src/theme/tokens/primitives.ts
@@ -85,15 +85,21 @@ export const primitiveColors = {
 } as const
 
 /**
- * Surface ramp — dark mode (TD-surface-tokens, S-1)
+ * Surface ramp — dark mode (TD-surface-tokens, S-1, re-spaced S-3)
  *
  * Warm-tapered, DERIVED ramp — NOT hand-picked. Shipped verbatim as the output of
- * `deriveSurfaceRamp(shellL=9, steps=[4.5,2.5,2,1.5], rbShadow=6, rbHilite=1.5)`
+ * `deriveSurfaceRamp(shellL=9, steps=[4.5,3.5,3,2.5], rbShadow=6, rbHilite=1.5)`
  * (see `packages/ui/src/components/ui/surface/surface-lab-shared.tsx` on branch
- * `feat/TD-unified-lab`, story `Lab/Surface Exploration -> Surface Ramp System`).
- * Lightness is CIELAB L* off the shell, with DIMINISHING steps (4.5/2.5/2/1.5) —
- * the frame->content jump is biggest, each plane above adds less. Warmth (R-B)
- * tapers 6 -> 1.5 from frame to hero so bright content planes stay near-neutral.
+ * `feat/TD-unified-lab`, story `Lab/Surface Exploration -> Surface Ramp System`
+ * — that lab default is `[4.5,2.5,2,1.5]` as of this writing and should be
+ * updated to match on that branch, follow-up, not done here).
+ * Lightness is CIELAB L* off the shell, with DIMINISHING steps (4.5/3.5/3/2.5) —
+ * the frame->content jump is biggest, each plane above adds less, but the top
+ * three planes (elevated/raised/overlay) were re-spaced WIDER (S-3) than the
+ * original 2.5/2/1.5 taper so they read as distinct planes without leaning on
+ * the hairline alone. `background`/`base`/`inset` are unchanged by the re-space.
+ * Warmth (R-B) tapers 6 -> 1.5 from frame to hero so bright content planes stay
+ * near-neutral.
  * Kept separate from the `charcoal` scale above (which several existing
  * components reference directly for unrelated shadow/track tints) so this
  * change is additive and doesn't ripple into those consumers.
@@ -103,10 +109,20 @@ export const surfaceRampDark = {
   inset: '#13100D',      // L*4.5  — sub-shell well / pressed
   background: '#1C1916', // L*9    — shell / frame
   base: '#252321',       // L*13.5 — main content plane
-  elevated: '#2A2827',   // L*16   — nav / rail
-  raised: '#2D2C2B',     // L*18   — cards
-  overlay: '#302F2E',    // L*19.5 — hero / popover
+  elevated: '#2C2A28',   // L*17   — nav / rail
+  raised: '#31302F',     // L*20   — cards
+  overlay: '#373635',    // L*22.5 — hero / popover
 } as const
+
+/**
+ * Frame/bezel primitive — dark mode (TD-surface-tokens, S-3)
+ *
+ * The chrome that "exits the content ramp" entirely: the top bar + side nav
+ * shell. Sits ONE STEP BELOW `surfaceRampDark.background` (L*9), darker even
+ * than `surfaceRampDark.inset` (L*4.5) — it isn't a plane IN the ramp, it's
+ * the bezel the ramp sits inside. Literal, not `deriveSurfaceRamp()` output.
+ */
+export const backgroundFrameDark = '#100D0A' // L*3.79
 
 /**
  * Derived tonal ramps (TD-05.09 color foundations)

--- a/packages/ui/src/theme/tokens/primitives.ts
+++ b/packages/ui/src/theme/tokens/primitives.ts
@@ -85,6 +85,30 @@ export const primitiveColors = {
 } as const
 
 /**
+ * Surface ramp — dark mode (TD-surface-tokens, S-1)
+ *
+ * Warm-tapered, DERIVED ramp — NOT hand-picked. Shipped verbatim as the output of
+ * `deriveSurfaceRamp(shellL=9, steps=[4.5,2.5,2,1.5], rbShadow=6, rbHilite=1.5)`
+ * (see `packages/ui/src/components/ui/surface/surface-lab-shared.tsx` on branch
+ * `feat/TD-unified-lab`, story `Lab/Surface Exploration -> Surface Ramp System`).
+ * Lightness is CIELAB L* off the shell, with DIMINISHING steps (4.5/2.5/2/1.5) —
+ * the frame->content jump is biggest, each plane above adds less. Warmth (R-B)
+ * tapers 6 -> 1.5 from frame to hero so bright content planes stay near-neutral.
+ * Kept separate from the `charcoal` scale above (which several existing
+ * components reference directly for unrelated shadow/track tints) so this
+ * change is additive and doesn't ripple into those consumers.
+ * See coordination/design-explorations/surface-system-north-star.md.
+ */
+export const surfaceRampDark = {
+  inset: '#13100D',      // L*4.5  — sub-shell well / pressed
+  background: '#1C1916', // L*9    — shell / frame
+  base: '#252321',       // L*13.5 — main content plane
+  elevated: '#2A2827',   // L*16   — nav / rail
+  raised: '#2D2C2B',     // L*18   — cards
+  overlay: '#302F2E',    // L*19.5 — hero / popover
+} as const
+
+/**
  * Derived tonal ramps (TD-05.09 color foundations)
  *
  * Seven OKLCH-generated hue ramps, 11 perceptual lightness steps each (50 -> 950).

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -17,7 +17,13 @@
  * - interactive-* : Hover/focus/active/disabled states
  */
 
-import { primitiveColors as p, primitiveRamps as ramp, discreteRainbow, surfaceRampDark as surf } from './primitives'
+import {
+  primitiveColors as p,
+  primitiveRamps as ramp,
+  discreteRainbow,
+  surfaceRampDark as surf,
+  backgroundFrameDark,
+} from './primitives'
 
 // Light mode semantic colors (default)
 export const semanticColorsLight = {
@@ -120,11 +126,20 @@ export const semanticColorsLight = {
   'surface-raised': p.neutral[100],           // light gray for raised cards
   'surface-overlay': p.white,
   'surface-input': p.neutral[50],             // Input field background (filled variant)
+  // Deepest pressed pit (TD-surface-tokens, S-3) — light-mode counterpart of
+  // the dark ramp's `inset` plane; a placeholder pairing, not part of the
+  // dark-ramp investigation (surface.contract.test.ts is dark-mode only).
+  'surface-inset': p.neutral[300],
 
   // Background colors (background-*)
   'background-base': '#EBEBEB',
   'background-default': p.white,
   'background-subtle': p.neutral[50],
+  // Frame/bezel chrome (TD-surface-tokens, S-3) — top bar + side nav shell,
+  // one step below `background-base` (darker still than `surface-inset`
+  // above, mirroring the dark-mode ordering). Placeholder pairing for light
+  // mode (see dark-mode note on `surface-inset` above).
+  'background-frame': p.neutral[400],
 
   // Border colors (border-*)
   'border-default': '#E8E9EB',
@@ -254,25 +269,31 @@ export const semanticColorsDark = {
   'text-link-hover': p.blue[400],
 
   // Surface colors - dark backgrounds — warm-tapered DERIVED ramp (TD-surface-tokens,
-  // S-1). Shipped verbatim from `deriveSurfaceRamp()` — see `surfaceRampDark` in
-  // primitives.ts for the full derivation note. `surface-overlay` and `surface-elevated`
-  // are now distinct (were both #191919); `surface-input` tracks one plane above
-  // `surface-base`, same relative position as before the remap. `background-base`
-  // backs `Surface level="background"` (SurfaceContext.SURFACE_LEVEL_TOKEN), so it
-  // takes the ramp's `background` (shell/frame) role, NOT `inset` — the ramp's
-  // deepest `inset` plane (#13100D, sub-shell well/pressed) has no shipped token
-  // yet; there's no `SurfaceLevel` member for it today (follow-up, alongside the
-  // elevation.ts -1/-2 pressed levels — see report).
+  // S-1, re-spaced S-3). Shipped verbatim from `deriveSurfaceRamp()` — see
+  // `surfaceRampDark` in primitives.ts for the full derivation note. `surface-overlay`
+  // and `surface-elevated` are distinct (were both #191919 pre-S-1); `surface-input`
+  // tracks one plane above `surface-base`, same relative position as before the remap.
+  // `background-base` backs `Surface level="background"` (SurfaceContext.SURFACE_LEVEL_TOKEN),
+  // so it takes the ramp's `background` (shell/frame) role, NOT `inset`. The ramp's
+  // deepest `inset` plane is now promoted to `surface-inset` below (S-3) — still no
+  // `SurfaceLevel` member for it (follow-up, alongside the elevation.ts -1/-2 pressed
+  // levels — parallel workstream, not this branch).
   'surface-base': surf.base,               // main surface        (#252321, L*13.5)
-  'surface-elevated': surf.elevated,       // elevated surface     (#2A2827, L*16 — nav/rail)
-  'surface-raised': surf.raised,           // raised surface       (#2D2C2B, L*18 — cards)
-  'surface-overlay': surf.overlay,         // overlay surface      (#302F2E, L*19.5 — hero/popover)
-  'surface-input': surf.elevated,          // input surface        (#2A2827 — one plane above base)
+  'surface-elevated': surf.elevated,       // elevated surface     (#2C2A28, L*17   — nav/rail)
+  'surface-raised': surf.raised,           // raised surface       (#31302F, L*20   — cards)
+  'surface-overlay': surf.overlay,         // overlay surface      (#373635, L*22.5 — hero/popover)
+  'surface-input': surf.elevated,          // input surface        (#2C2A28 — one plane above base)
+  'surface-inset': surf.inset,             // deepest pressed pit  (#13100D, L*4.5  — sub-shell well)
 
   // Background colors — same ramp, the frame/shell end of it.
   'background-base': surf.background,      // shell / frame        (#1C1916, L*9 — Surface level="background")
   'background-default': surf.base,         // main background      (#252321, L*13.5 — matches surface-base)
-  'background-subtle': surf.elevated,      // subtle background    (#2A2827, L*16 — matches surface-elevated)
+  'background-subtle': surf.elevated,      // subtle background    (#2C2A28, L*17 — matches surface-elevated)
+  // Frame/bezel chrome (S-3) — the top bar + side nav shell; one step BELOW
+  // `background-base`, darker even than `surface-inset` — it exits the content
+  // ramp entirely rather than sitting in it. See `backgroundFrameDark` in
+  // primitives.ts.
+  'background-frame': backgroundFrameDark, // frame / bezel        (#100D0A, L*3.79)
 
   // Border colors — `border-subtle` (#1C1C1C) previously collided with
   // `surface-raised` (also #1C1C1C, an invisible border on raised cards). The

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -17,7 +17,7 @@
  * - interactive-* : Hover/focus/active/disabled states
  */
 
-import { primitiveColors as p, primitiveRamps as ramp, discreteRainbow } from './primitives'
+import { primitiveColors as p, primitiveRamps as ramp, discreteRainbow, surfaceRampDark as surf } from './primitives'
 
 // Light mode semantic colors (default)
 export const semanticColorsLight = {
@@ -137,6 +137,12 @@ export const semanticColorsLight = {
   'border-input-focus': p.blue[600],          // Input field border on focus
   'border-input-error': p.red[600],           // Input field border on error
 
+  // Alpha hairline separators (surface-independent — composite toward black on
+  // light surfaces, mirroring the dark-mode white-alpha family). See §4/S-2.
+  'hairline-subtle': 'rgba(0, 0, 0, 0.06)',
+  'hairline-default': 'rgba(0, 0, 0, 0.09)',
+  'hairline-strong': 'rgba(0, 0, 0, 0.14)',
+
   // Interactive states (interactive-*)
   'interactive-hover': 'rgba(55, 65, 81, 0.04)',
   'interactive-focus': 'rgba(55, 65, 81, 0.12)',
@@ -247,19 +253,32 @@ export const semanticColorsDark = {
   'text-link': '#828DF8',
   'text-link-hover': p.blue[400],
 
-  // Surface colors - dark backgrounds
-  'surface-base': p.charcoal[700],         // main surface
-  'surface-elevated': p.charcoal[600],     // elevated surface
-  'surface-raised': p.charcoal[500],       // raised surface
-  'surface-overlay': p.charcoal[600],      // overlay surface
-  'surface-input': p.charcoal[600],        // input surface
+  // Surface colors - dark backgrounds — warm-tapered DERIVED ramp (TD-surface-tokens,
+  // S-1). Shipped verbatim from `deriveSurfaceRamp()` — see `surfaceRampDark` in
+  // primitives.ts for the full derivation note. `surface-overlay` and `surface-elevated`
+  // are now distinct (were both #191919); `surface-input` tracks one plane above
+  // `surface-base`, same relative position as before the remap. `background-base`
+  // backs `Surface level="background"` (SurfaceContext.SURFACE_LEVEL_TOKEN), so it
+  // takes the ramp's `background` (shell/frame) role, NOT `inset` — the ramp's
+  // deepest `inset` plane (#13100D, sub-shell well/pressed) has no shipped token
+  // yet; there's no `SurfaceLevel` member for it today (follow-up, alongside the
+  // elevation.ts -1/-2 pressed levels — see report).
+  'surface-base': surf.base,               // main surface        (#252321, L*13.5)
+  'surface-elevated': surf.elevated,       // elevated surface     (#2A2827, L*16 — nav/rail)
+  'surface-raised': surf.raised,           // raised surface       (#2D2C2B, L*18 — cards)
+  'surface-overlay': surf.overlay,         // overlay surface      (#302F2E, L*19.5 — hero/popover)
+  'surface-input': surf.elevated,          // input surface        (#2A2827 — one plane above base)
 
-  // Background colors
-  'background-base': p.charcoal[900],      // darkest charcoal
-  'background-default': p.charcoal[700],    // main background
-  'background-subtle': p.charcoal[500],     // subtle background
+  // Background colors — same ramp, the frame/shell end of it.
+  'background-base': surf.background,      // shell / frame        (#1C1916, L*9 — Surface level="background")
+  'background-default': surf.base,         // main background      (#252321, L*13.5 — matches surface-base)
+  'background-subtle': surf.elevated,      // subtle background    (#2A2827, L*16 — matches surface-elevated)
 
-  // Border colors
+  // Border colors — `border-subtle` (#1C1C1C) previously collided with
+  // `surface-raised` (also #1C1C1C, an invisible border on raised cards). The
+  // re-spaced ramp above moved `surface-raised` to #2D2C2B, so this value is now
+  // distinct from every surface hex without needing to change it — see
+  // `surface.contract.test.ts` R2/R4.
   'border-default': p.charcoal[400],       // default border
   'border-subtle': p.charcoal[500],        // subtle border
   'border-strong': p.charcoal[300],        // strong border
@@ -269,6 +288,15 @@ export const semanticColorsDark = {
   'border-input-hover': p.neutral[500],
   'border-input-focus': '#828DF8',
   'border-input-error': p.red[500],
+
+  // Alpha hairline separators — the primary separation cue (§4/S-2). Self-
+  // normalizing: composites toward white by ~the same amount on ANY plane, so
+  // one family works at every elevation instead of per-surface border tokens.
+  // Shadows are demoted to floating-overlay use only (not shipped as a fill
+  // separator here — see elevation.ts, follow-up S-4).
+  'hairline-subtle': 'rgba(255, 255, 255, 0.06)',
+  'hairline-default': 'rgba(255, 255, 255, 0.09)',
+  'hairline-strong': 'rgba(255, 255, 255, 0.14)',
 
   // Interactive states
   'interactive-hover': 'rgba(255, 255, 255, 0.04)',

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -163,6 +163,12 @@ module.exports = {
             text: 'var(--color-interactive-disabled-text)',
           },
         },
+        // Alpha hairline separators (surface-independent — §4/S-2)
+        hairline: {
+          subtle: 'var(--color-hairline-subtle)',
+          DEFAULT: 'var(--color-hairline-default)',
+          strong: 'var(--color-hairline-strong)',
+        },
         // Divider
         divider: 'var(--color-divider)',
         // Avatar

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -119,12 +119,14 @@ module.exports = {
           raised: 'var(--color-surface-raised)',
           overlay: 'var(--color-surface-overlay)',
           input: 'var(--color-surface-input)',
+          inset: 'var(--color-surface-inset)',
         },
         // Background colors
         background: {
           base: 'var(--color-background-base)',
           DEFAULT: 'var(--color-background-default)',
           subtle: 'var(--color-background-subtle)',
+          frame: 'var(--color-background-frame)',
         },
         // Text colors
         text: {


### PR DESCRIPTION
Ships the derived warm-tapered surface ramp and re-spaces its top steps so the planes read as distinct.

## What
- **Warm-tapered ramp** shipped verbatim from `deriveSurfaceRamp()` (S-1), re-spaced top steps `[4.5,3.5,3,2.5]` (S-3): `background #1C1916 · base #252321 · elevated #2C2A28 · raised #31302F · overlay #373635`. Old top-3 were sub-JND (both `#191919`).
- **`background-frame #100D0A`** — new frame/bezel token (below background-base; top bar + nav).
- **`surface-inset #13100D`** — new floor token (deepest pit), promoted from the ramp's inset.
- **Alpha hairline family** `.06/.09/.14` (white on dark, black on light) as the primary self-normalizing separator.
- Fixes two token collisions: `surface-overlay`≡`surface-elevated`; `surface-raised`≡`border-subtle`.
- `surface.contract.test.ts` (283 lines) locks CIELAB ΔL* spacing + collision-freedom.

## Verify
- typecheck ✓ · lint 0 errors · **2577 tests pass**
- Token files edited additively (uppercase hex, hand-aligned) — no `prettier --write`.

Base of the surface-foundation stack (→ pressed → dark-migration). See `coordination/design-explorations/productionalization-handoff.md`.