### PR TITLE
Add relative-inset `<Surface pressed>` well API

### DIFF
--- a/packages/ui/src/components/ui/surface/Surface.stories.tsx
+++ b/packages/ui/src/components/ui/surface/Surface.stories.tsx
@@ -15,8 +15,12 @@ const meta: Meta<typeof Surface> = {
     },
     level: {
       control: 'select',
-      options: ['background', 'base', 'elevated', 'raised', 'overlay'],
+      options: ['inset', 'background', 'base', 'elevated', 'raised', 'overlay'],
       description: 'Named charcoal plane (flat background from a semantic token)',
+    },
+    pressed: {
+      control: 'boolean',
+      description: 'Sunken well: one ramp step DOWN from the parent level + inner-shadow recess',
     },
     theme: {
       control: 'select',
@@ -95,6 +99,62 @@ export const NamedPlanes: Story = {
           <Text style={{ color: '#fff' }}>level=&quot;{level}&quot;</Text>
         </Surface>
       ))}
+    </View>
+  ),
+}
+
+// The pressed (sunken well) model: a `<Surface pressed>` renders ONE ramp step
+// DOWN from its parent's level — the symmetric twin of a raised surface stepping
+// up — plus an inner-shadow recess. It's RELATIVE: the same `pressed` well reads
+// as a consistent recess on every host plane (base → background, raised →
+// elevated, overlay → raised), not a single fixed black hole. It clamps at the
+// `inset` floor so a well in `background` bottoms out at the ramp's pit.
+function WellCard({ level }: { level: SurfaceLevel }) {
+  return (
+    <Surface level={level} style={{ padding: 16, gap: 12, flex: 1, borderRadius: 14 }}>
+      <Eyebrow>HOST · LEVEL = {level.toUpperCase()}</Eyebrow>
+      <Surface pressed style={{ padding: 16, gap: 4 }}>
+        <Eyebrow>PRESSED WELL</Eyebrow>
+        <OnSurfaceBody title="Sunken panel" sub="one step down + inner recess" />
+      </Surface>
+    </Surface>
+  )
+}
+
+export const PressedWells: Story = {
+  render: () => (
+    <Surface level="background" style={{ flexDirection: 'row', gap: 16, padding: 24 }}>
+      {(['base', 'raised', 'overlay'] as SurfaceLevel[]).map((level) => (
+        <WellCard key={level} level={level} />
+      ))}
+    </Surface>
+  ),
+}
+
+// Clamp + nesting — a well in `background` bottoms out at the inset floor
+// (#13100D), and pressing again inside it stays at the floor (no underflow),
+// while a well in a lighter plane still steps down normally.
+export const PressedClampAndNesting: Story = {
+  render: () => (
+    <View style={{ flexDirection: 'row', gap: 16, padding: 24 }}>
+      <Surface level="background" style={{ padding: 16, gap: 12, flex: 1, borderRadius: 14 }}>
+        <Eyebrow>HOST · LEVEL = BACKGROUND</Eyebrow>
+        <Surface pressed style={{ padding: 16, gap: 10 }}>
+          <Eyebrow>PRESSED → INSET FLOOR</Eyebrow>
+          <Surface pressed style={{ padding: 12 }}>
+            <Eyebrow>PRESSED AGAIN → CLAMPED</Eyebrow>
+          </Surface>
+        </Surface>
+      </Surface>
+      <Surface level="raised" style={{ padding: 16, gap: 12, flex: 1, borderRadius: 14 }}>
+        <Eyebrow>HOST · LEVEL = RAISED</Eyebrow>
+        <Surface pressed style={{ padding: 16, gap: 10 }}>
+          <Eyebrow>PRESSED → ELEVATED</Eyebrow>
+          <Surface pressed style={{ padding: 12 }}>
+            <Eyebrow>PRESSED AGAIN → BASE</Eyebrow>
+          </Surface>
+        </Surface>
+      </Surface>
     </View>
   ),
 }

--- a/packages/ui/src/components/ui/surface/Surface.test.tsx
+++ b/packages/ui/src/components/ui/surface/Surface.test.tsx
@@ -6,9 +6,12 @@ import { Surface } from './Surface'
 import {
   onSurfaceColors,
   surfaceBackground,
+  pressedLevel,
   useOnSurfaceColor,
+  useSurface,
   useSurfaceMode,
 } from './SurfaceContext'
+import { getPressedRecessShadow } from '../../../theme/elevation'
 
 // A descendant probe that renders the on-surface colour + mode it resolves from
 // context, so tests can assert what a nested consumer would actually paint.
@@ -110,6 +113,137 @@ describe('Surface (named plane)', () => {
   })
 })
 
+// A descendant probe that reports the surface LEVEL it resolves from context,
+// so tests can assert what a nested Surface publishes to its children.
+function LevelProbe({ label = 'lvl' }) {
+  const { level } = useSurface()
+  return <Text testID={label}>{level}</Text>
+}
+
+// CIELAB L* (perceptual lightness) — same calc as surface.contract.test, so the
+// "darker" assertions measure the metric the ramp was designed against.
+function lstar(hex: string): number {
+  const h = hex.replace('#', '')
+  const lin = [0, 2, 4]
+    .map((i) => parseInt(h.slice(i, i + 2), 16) / 255)
+    .map((c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4))
+  const y = 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+  return y <= 0.008856 ? y * 903.3 : 116 * Math.cbrt(y) - 16
+}
+
+describe('Surface (pressed well)', () => {
+  it.each([
+    // TD-surface-tokens S-3 re-space: top steps widened (elevated #2C2A28,
+    // raised #31302F, overlay #373635); base/background unchanged.
+    ['overlay', '#373635', '#31302F'], // → raised
+    ['raised', '#31302F', '#2C2A28'], // → elevated
+    ['elevated', '#2C2A28', '#252321'], // → base
+    ['base', '#252321', '#1C1916'], // → background
+  ] as const)(
+    'in a %s parent renders one ramp step down (%s → %s), darker than its parent',
+    (parent, parentHex, pressedHex) => {
+      render(
+        <Surface level={parent}>
+          <Surface pressed testID="well" />
+        </Surface>
+      )
+      expect(screen.getByTestId('well')).toHaveStyle({ backgroundColor: pressedHex })
+      expect(lstar(pressedHex)).toBeLessThan(lstar(parentHex))
+    }
+  )
+
+  it('with no enclosing Surface (default base) presses to the background plane', () => {
+    render(<Surface pressed testID="well" />)
+    expect(screen.getByTestId('well')).toHaveStyle({ backgroundColor: '#1C1916' })
+  })
+
+  it('clamps at the inset floor: pressed directly in background does not underflow', () => {
+    render(
+      <Surface level="background">
+        <Surface pressed testID="well" />
+      </Surface>
+    )
+    // background (#1C1916) steps down to the inset floor (#13100D), the pit.
+    expect(screen.getByTestId('well')).toHaveStyle({ backgroundColor: '#13100D' })
+  })
+
+  it('does not step below the floor: pressed within a floor-pressed well stays at inset', () => {
+    render(
+      <Surface level="background">
+        <Surface pressed>
+          <Surface pressed testID="deeper" />
+        </Surface>
+      </Surface>
+    )
+    expect(screen.getByTestId('deeper')).toHaveStyle({ backgroundColor: '#13100D' })
+  })
+
+  it('publishes the stepped-down level to descendants so a nested press steps again', () => {
+    render(
+      <Surface level="raised">
+        <Surface pressed>
+          <LevelProbe label="lvl" />
+        </Surface>
+      </Surface>
+    )
+    // raised → elevated; descendants read the well's own level.
+    expect(screen.getByTestId('lvl')).toHaveTextContent('elevated')
+  })
+
+  it('adds an inner-shadow recess composed with the darker fill (web path)', () => {
+    render(
+      <Surface level="base">
+        <Surface pressed testID="well" />
+      </Surface>
+    )
+    const boxShadow = screen.getByTestId('well').style.boxShadow
+    expect(boxShadow).toContain('inset')
+  })
+
+  it('reads recessed via the darker fill alone when the shadow path is absent (no-shadow/native)', () => {
+    // The recess is carried by BOTH fill + shadow; strip the shadow and the fill
+    // still darkens one ramp step, so a pressed surface never becomes invisible.
+    render(
+      <Surface level="base">
+        <Surface pressed testID="well" style={{ boxShadow: undefined }} />
+      </Surface>
+    )
+    expect(screen.getByTestId('well')).toHaveStyle({ backgroundColor: '#1C1916' })
+    expect(lstar('#1C1916')).toBeLessThan(lstar('#252321'))
+  })
+
+  it('rounds the well by default and honours an explicit rounded override', () => {
+    render(
+      <Surface level="base">
+        <Surface pressed testID="rounded" />
+        <Surface pressed rounded={false} testID="flat" />
+      </Surface>
+    )
+    expect(screen.getByTestId('rounded')).toBeInTheDocument()
+    expect(screen.getByTestId('flat')).toBeInTheDocument()
+  })
+})
+
+describe('pressedLevel helper', () => {
+  it.each([
+    ['overlay', 'raised'],
+    ['raised', 'elevated'],
+    ['elevated', 'base'],
+    ['base', 'background'],
+    ['background', 'inset'],
+    ['inset', 'inset'],
+  ] as const)('steps %s down to %s (clamped at inset)', (parent, expected) => {
+    expect(pressedLevel(parent)).toBe(expected)
+  })
+})
+
+describe('getPressedRecessShadow', () => {
+  it('returns an inset recess tuned to the fill colour on the web path', () => {
+    const style = getPressedRecessShadow('#1C1916', 'dark') as { boxShadow?: string }
+    expect(style.boxShadow).toContain('inset')
+  })
+})
+
 describe('Surface on-surface colour context', () => {
   it('gives descendants literal-hex dark text colours', () => {
     render(
@@ -156,6 +290,10 @@ describe('surface colour helpers', () => {
     expect(surfaceBackground('elevated', 'dark')).toBe('#2C2A28')
     expect(surfaceBackground('background', 'dark')).toBe('#1C1916')
     expect(surfaceBackground('base', 'light')).toBe('#FFFFFF')
+  })
+
+  it('resolves the inset floor from the surfaceRampDark.inset primitive (no token yet)', () => {
+    expect(surfaceBackground('inset', 'dark')).toBe('#13100D')
   })
 
   it('onSurfaceColors returns the neutral text ramp as literal hex', () => {

--- a/packages/ui/src/components/ui/surface/Surface.tsx
+++ b/packages/ui/src/components/ui/surface/Surface.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react'
-import { View, type ViewProps } from 'react-native'
+import { View, type ViewProps, type ViewStyle } from 'react-native'
 import { cn } from '../../../utils/cn'
 import { type ThemeMode } from '../../../theme/tokens/semantic'
 import {
   type ElevationLevel,
   getElevationSurface,
   getElevationShadow,
+  getPressedRecessShadow,
   getBaseSurfaceColor,
   type GlowIntensity,
   getGlowShadow,
@@ -13,6 +14,7 @@ import {
 import {
   SurfaceContext,
   surfaceBackground,
+  pressedLevel,
   useSurface,
   type SurfaceContextValue,
   type SurfaceLevel,
@@ -32,6 +34,14 @@ export interface SurfaceProps extends ViewProps {
    * plane reads full-bleed. Composable with `elevation`'s glow.
    */
   level?: SurfaceLevel
+  /**
+   * Sunken "well": render ONE ramp step DOWN from the parent surface's level —
+   * the symmetric twin of a raised surface stepping up — and add an inner-shadow
+   * recess so the surface reads pressed (darker fill + inset shadow). Relative to
+   * the enclosing Surface's level (not this surface's own `level`), and clamped
+   * at the ramp's `inset` floor so it never underflows. One level of depth only.
+   */
+  pressed?: boolean
   glowColor?: string
   glowIntensity?: GlowIntensity
   /**
@@ -59,6 +69,7 @@ export interface SurfaceProps extends ViewProps {
 export function Surface({
   elevation = 0,
   level,
+  pressed = false,
   glowColor,
   glowIntensity,
   theme,
@@ -72,18 +83,35 @@ export function Surface({
   const mode = theme ?? inherited.mode
   const isPlane = level != null
 
+  // Three grounded ways to own a background, in precedence order:
+  //  - pressed: a well ONE ramp step DOWN from the parent level (relative),
+  //    with an inner-shadow recess — clamps at the `inset` floor.
+  //  - level (named plane): a flat charcoal plane straight from a token.
+  //  - elevation (numeric): the raised-card model — lighten-from-base + shadow.
   const baseColor = getBaseSurfaceColor(mode)
-  const backgroundColor = isPlane
-    ? surfaceBackground(level, mode)
-    : getElevationSurface(baseColor, elevation, mode)
-  // Planes own a flat full-bleed background; the card model keeps its depth shadow.
-  const shadowStyle = isPlane ? {} : getElevationShadow(baseColor, elevation, mode)
+  const resolvedLevel = pressed ? pressedLevel(inherited.level) : (level ?? inherited.level)
+
+  let backgroundColor: string
+  let shadowStyle: ViewStyle
+  if (pressed) {
+    backgroundColor = surfaceBackground(resolvedLevel, mode)
+    shadowStyle = getPressedRecessShadow(backgroundColor, mode)
+  } else if (isPlane) {
+    backgroundColor = surfaceBackground(level, mode)
+    // Planes own a flat full-bleed background — no depth shadow.
+    shadowStyle = {}
+  } else {
+    backgroundColor = getElevationSurface(baseColor, elevation, mode)
+    shadowStyle = getElevationShadow(baseColor, elevation, mode)
+  }
+
   const glowStyle = glowColor ? getGlowShadow(glowColor, glowIntensity) : {}
-  const applyRounded = rounded ?? !isPlane
+  // A pressed well and the card model round by default; a flat plane doesn't.
+  const applyRounded = rounded ?? (pressed || !isPlane)
 
   const value = useMemo<SurfaceContextValue>(
-    () => ({ mode, level: level ?? inherited.level }),
-    [mode, level, inherited.level]
+    () => ({ mode, level: resolvedLevel }),
+    [mode, resolvedLevel]
   )
 
   return (

--- a/packages/ui/src/components/ui/surface/SurfaceContext.ts
+++ b/packages/ui/src/components/ui/surface/SurfaceContext.ts
@@ -7,30 +7,43 @@
 // (no global.css, no nativewind) — the bug class this primitive retires.
 import { createContext, useContext } from 'react'
 import { getSemanticColors, type ThemeMode } from '../../../theme/tokens/semantic'
+import { surfaceRampDark } from '../../../theme/tokens/primitives'
 
 type ColorToken = keyof ReturnType<typeof getSemanticColors>
 
 /**
- * A Surface's depth on the dark surface ramp. Each level maps to an EXISTING
- * semantic surface/background token (already grounded in the derived surface
- * ramp — TD-surface-tokens S-1 — and theme-aware) — Surface introduces no new
- * hexes. Darkest → lightest:
- *   background (#1C1916) < base (#252321) < elevated (#2A2827) < raised (#2D2C2B) < overlay (#302F2E)
+ * A Surface's depth on the dark surface ramp. Each addressable level maps to an
+ * EXISTING semantic surface/background token (already grounded in the derived
+ * surface ramp — TD-surface-tokens S-1 — and theme-aware) — Surface introduces
+ * no new hexes. Darkest → lightest:
+ *   inset (#13100D) < background (#1C1916) < base (#252321) < elevated (#2A2827) < raised (#2D2C2B) < overlay (#302F2E)
+ *
+ * `inset` is the ramp's deepest pit — the sub-shell well. It's the floor a
+ * `<Surface pressed>` clamps at (see {@link pressedLevel}); it has no shipped
+ * semantic token yet, so {@link surfaceBackground} resolves it from the
+ * `surface-inset` token when present, else the `surfaceRampDark.inset` primitive.
  */
-export type SurfaceLevel = 'background' | 'base' | 'elevated' | 'raised' | 'overlay'
+export type SurfaceLevel = 'inset' | 'background' | 'base' | 'elevated' | 'raised' | 'overlay'
 
 /** On-surface neutral text roles, resolved for the current surface + theme. */
 export type OnSurfaceRole = 'primary' | 'secondary' | 'tertiary'
 
-// Which semantic token backs each level. Values live in `semantic.ts` and stay
-// in sync with the charcoal ramp — this map never carries literal hexes.
+// Which semantic token backs each ADDRESSABLE level. Values live in `semantic.ts`
+// and stay in sync with the charcoal ramp — this map never carries literal hexes.
+// `inset` is intentionally absent: it has no shipped semantic token yet, so it's
+// resolved separately (token-or-primitive) in `surfaceBackground`.
 export const SURFACE_LEVEL_TOKEN = {
   background: 'background-base',
   base: 'surface-base',
   elevated: 'surface-elevated',
   raised: 'surface-raised',
   overlay: 'surface-overlay',
-} as const satisfies Record<SurfaceLevel, ColorToken>
+} as const satisfies Record<Exclude<SurfaceLevel, 'inset'>, ColorToken>
+
+// Darkest → lightest, INCLUDING the inset floor. A `<Surface pressed>` renders
+// one index DOWN from its parent's level and clamps at `inset` (index 0). Kept
+// in lockstep with the derived ramp and the surface.contract.test PLANE_ORDER.
+const PRESSED_RAMP = ['inset', 'background', 'base', 'elevated', 'raised', 'overlay'] as const
 
 const ON_SURFACE_TOKEN = {
   primary: 'text-primary',
@@ -81,7 +94,33 @@ export function useOnSurfaceColor(role: OnSurfaceRole = 'primary'): string {
   return getSemanticColors(useSurfaceMode())[ON_SURFACE_TOKEN[role]]
 }
 
+/**
+ * The inset floor hex — the ramp's deepest pit that a pressed surface clamps at.
+ * Prefers the `surface-inset` semantic token (theme-aware; being promoted in a
+ * parallel token change) and falls back to the `surfaceRampDark.inset` primitive
+ * (#13100D, dark-ramp only) until that token ships.
+ */
+function insetFloor(mode: ThemeMode): string {
+  const colors = getSemanticColors(mode) as Record<string, string>
+  return colors['surface-inset'] ?? surfaceRampDark.inset
+}
+
 /** The background hex for a surface level under a theme mode (literal hex). */
 export function surfaceBackground(level: SurfaceLevel, mode: ThemeMode): string {
+  if (level === 'inset') return insetFloor(mode)
   return getSemanticColors(mode)[SURFACE_LEVEL_TOKEN[level]]
+}
+
+/**
+ * The level a `<Surface pressed>` resolves to: its parent's level stepped one
+ * index DOWN the ramp — the symmetric twin of a raised surface stepping up —
+ * clamped at the `inset` floor so a pressed surface never underflows the pit.
+ *   overlay→raised, raised→elevated, elevated→base, base→background,
+ *   background→inset, inset→inset (clamped).
+ * Pressed exposes ONE level of depth only (no pressed-2).
+ */
+export function pressedLevel(parent: SurfaceLevel): SurfaceLevel {
+  const index = PRESSED_RAMP.indexOf(parent)
+  const down = Math.max(0, index - 1)
+  return PRESSED_RAMP[down]
 }

--- a/packages/ui/src/components/ui/surface/index.ts
+++ b/packages/ui/src/components/ui/surface/index.ts
@@ -6,6 +6,7 @@ export {
   useOnSurfaceColor,
   onSurfaceColors,
   surfaceBackground,
+  pressedLevel,
   SURFACE_LEVEL_TOKEN,
   type SurfaceLevel,
   type OnSurfaceRole,

--- a/packages/ui/src/theme/elevation.ts
+++ b/packages/ui/src/theme/elevation.ts
@@ -1,21 +1,21 @@
 /**
  * Elevation System
- * 
+ *
  * A unified depth system where each elevation level corresponds to:
  * - Calculated surface color (derived from base using lighten)
  * - Shadow intensity and style (raised/pressed)
  * - Dynamically calculated shadow colors (derived from surface color)
  * - Semantic name for reference
- * 
+ *
  * Elevation range: -2 (deep inset) to +5 (floating overlay)
- * 
+ *
  * Negative elevations: Inset/pressed elements (sunken into surface)
  * Zero elevation: Base surface (background/page level)
  * Positive elevations: Raised elements (floating above surface)
- * 
+ *
  * All colors are calculated dynamically from a base surface color,
  * allowing for custom surfaces and consistent color relationships.
- * 
+ *
  * Lighting Model: Light source from upper-right corner
  * - Raised elements are always lighter than base (consistent across themes)
  * - Base colors must allow sufficient lightening in both themes
@@ -49,7 +49,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'pressed',
     description: 'Deeply recessed elements (e.g., input fields, deeply pressed buttons)',
   },
-  
+
   // Shallow inset (pressed buttons, sunken panels)
   [-1]: {
     name: 'inset',
@@ -58,7 +58,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'pressed',
     description: 'Shallow inset elements (e.g., pressed buttons, sunken panels within cards)',
   },
-  
+
   // Base level (page background, default surface)
   [0]: {
     name: 'base',
@@ -67,7 +67,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'raised',
     description: 'Base surface level (page background, default containers)',
   },
-  
+
   // Level 1: Subtle elevation (outline cards, subtle containers)
   [1]: {
     name: 'subtle',
@@ -76,7 +76,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'raised',
     description: 'Subtle elevation (outline cards, subtle containers)',
   },
-  
+
   // Level 2: Standard elevation (default cards, buttons)
   [2]: {
     name: 'standard',
@@ -85,7 +85,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'raised',
     description: 'Standard elevation (default cards, raised buttons)',
   },
-  
+
   // Level 3: Prominent elevation (important cards, modals)
   [3]: {
     name: 'prominent',
@@ -94,7 +94,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'raised',
     description: 'Prominent elevation (important cards, modals, dropdowns)',
   },
-  
+
   // Level 4: High elevation (overlays, popovers)
   [4]: {
     name: 'high',
@@ -103,7 +103,7 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
     shadowStyle: 'raised',
     description: 'High elevation (overlays, popovers, tooltips)',
   },
-  
+
   // Level 5: Floating (toasts, floating action buttons)
   [5]: {
     name: 'floating',
@@ -117,14 +117,14 @@ export const elevationSystem: Record<ElevationLevel, ElevationConfig> = {
 /**
  * Calculate rim light color from the BASE color.
  * Creates a consistent bright highlight with opacity that scales with elevation.
- * 
- * The rim light represents light hitting the edge of raised elements from a 
+ *
+ * The rim light represents light hitting the edge of raised elements from a
  * consistent light source. Uses ABSOLUTE HSV value (not relative lightening)
  * for consistent intensity across all surface colors.
- * 
+ *
  * For colored surfaces: preserves hue/saturation, sets value to fixed bright level
  * For gray surfaces: uses white with appropriate opacity
- * 
+ *
  * @param baseColor - The base surface color (hex)
  * @param level - Elevation level (used to scale opacity)
  */
@@ -133,22 +133,22 @@ function calculateRimLightColor(baseColor: string, level: ElevationLevel): strin
   if (!rgb) {
     return 'rgba(255, 255, 255, 0.5)'
   }
-  
+
   const hsv = rgbToHsv(rgb.r, rgb.g, rgb.b)
   const isLight = hsv.v > 0.6
-  const isSaturated = hsv.s > 0.3  // Colored (not gray)
-  
+  const isSaturated = hsv.s > 0.3 // Colored (not gray)
+
   // Opacity scales with elevation to compensate for lighter surfaces at higher levels
   // Range: +0% at level 1 to +20% at level 5
   const absLevel = Math.abs(level)
-  const opacityBoost = Math.max(0, (absLevel - 1) * 0.05)  // +5% per level above 1 (0% to 20%)
-  
+  const opacityBoost = Math.max(0, (absLevel - 1) * 0.05) // +5% per level above 1 (0% to 20%)
+
   if (isSaturated) {
     // For colored surfaces, preserve hue and saturation but set value to fixed bright level
     // This ensures consistent rim light intensity across all colored surfaces
-    const rimLightValue = 0.95  // Fixed bright value for rim light
-    const rimLightRgb = hsvToRgb(hsv.h, hsv.s * 0.3, rimLightValue)  // Reduce saturation for brighter appearance
-    
+    const rimLightValue = 0.95 // Fixed bright value for rim light
+    const rimLightRgb = hsvToRgb(hsv.h, hsv.s * 0.3, rimLightValue) // Reduce saturation for brighter appearance
+
     // Base opacity + elevation boost, capped at 1.0
     const baseOpacity = isLight ? 0.9 : 0.5
     const finalOpacity = Math.min(1, baseOpacity + opacityBoost)
@@ -164,10 +164,10 @@ function calculateRimLightColor(baseColor: string, level: ElevationLevel): strin
 /**
  * Calculate dark shadow colors from the surface color.
  * The dark shadow is cast BY the element, so it should match the surface color.
- * 
+ *
  * Uses ABSOLUTE HSV value (not relative darkening) for consistent shadow intensity
  * across all surface colors - simulating a consistent light source.
- * 
+ *
  * For colored surfaces: preserves hue/saturation, sets value to fixed dark level
  * For gray surfaces: uses black with appropriate opacity
  */
@@ -182,17 +182,17 @@ function calculateDarkShadowColors(surfaceColor: string): {
       darker: 'rgba(0, 0, 0, 0.4)',
     }
   }
-  
+
   const hsv = rgbToHsv(rgb.r, rgb.g, rgb.b)
   const isLight = hsv.v > 0.6
   const isSaturated = hsv.s > 0.3
-  
+
   if (isSaturated) {
     // For colored surfaces, preserve hue and saturation but set value to fixed dark level
     // This ensures consistent shadow intensity across all colored surfaces
-    const darkShadowValue = 0.15  // Fixed dark value for shadows
+    const darkShadowValue = 0.15 // Fixed dark value for shadows
     const darkShadowRgb = hsvToRgb(hsv.h, hsv.s, darkShadowValue)
-    
+
     if (isLight) {
       return {
         dark: `rgba(${darkShadowRgb.r}, ${darkShadowRgb.g}, ${darkShadowRgb.b}, 0.3)`,
@@ -227,8 +227,8 @@ function calculateDarkShadowColors(surfaceColor: string): {
  */
 function getRimLightConfig(): { offset: number; blur: number } {
   return {
-    offset: 1,  // Fixed 1px for crisp rim
-    blur: 1,    // Tight blur for crisp edge
+    offset: 1, // Fixed 1px for crisp rim
+    blur: 1, // Tight blur for crisp edge
   }
 }
 
@@ -253,18 +253,18 @@ function calculateElevationSurface(
   theme: 'light' | 'dark'
 ): string {
   const config = elevationSystem[level]
-  
+
   if (config.colorAdjustment === 0) {
     return baseColor
   }
-  
+
   // For raised elevations (positive), always lighten (consistent lighting model)
   // Light source is from upper-right, so raised elements are always lighter
   // For inset elevations (negative), we keep base color (shadow creates depth)
   if (level < 0) {
-    return baseColor  // Inset elements use base color
+    return baseColor // Inset elements use base color
   }
-  
+
   // Always lighten for raised elements (consistent across themes)
   // Base colors must be chosen to allow sufficient lightening in dark mode
   return lighten(baseColor, config.colorAdjustment)
@@ -273,7 +273,7 @@ function calculateElevationSurface(
 /**
  * Calculate surface color for an elevation level from a base color.
  * Results are cached to avoid redundant calculations.
- * 
+ *
  * @param baseColor - Base surface color (hex)
  * @param level - Elevation level
  * @param theme - Current theme ('light' or 'dark')
@@ -285,15 +285,15 @@ export function getElevationSurface(
   theme: 'light' | 'dark'
 ): string {
   const cacheKey = getCacheKey(baseColor, level, theme)
-  
+
   // Check cache
   if (elevationSurfaceCache.has(cacheKey)) {
     return elevationSurfaceCache.get(cacheKey)!
   }
-  
+
   // Calculate
   const result = calculateElevationSurface(baseColor, level, theme)
-  
+
   // Cache result (with size limit to prevent memory leaks)
   if (elevationSurfaceCache.size >= MAX_CACHE_SIZE) {
     // Remove oldest entry (simple FIFO)
@@ -301,7 +301,7 @@ export function getElevationSurface(
     elevationSurfaceCache.delete(firstKey)
   }
   elevationSurfaceCache.set(cacheKey, result)
-  
+
   return result
 }
 
@@ -309,7 +309,12 @@ export function getElevationSurface(
 const elevationShadowCache = new Map<string, ViewStyle>()
 const MAX_SHADOW_CACHE_SIZE = 50
 
-function getShadowCacheKey(baseColor: string, level: ElevationLevel, theme: 'light' | 'dark', isHovered: boolean): string {
+function getShadowCacheKey(
+  baseColor: string,
+  level: ElevationLevel,
+  theme: 'light' | 'dark',
+  isHovered: boolean
+): string {
   return `${baseColor}-${level}-${theme}-${isHovered}`
 }
 
@@ -320,35 +325,35 @@ function calculateElevationShadow(
   isHovered: boolean = false
 ): ViewStyle {
   const config = elevationSystem[level]
-  
+
   // Base level has no shadow
   if (level === 0) {
     return {}
   }
-  
+
   // Calculate the actual elevated surface color
   const elevatedSurfaceColor = calculateElevationSurface(baseColor, level, theme)
-  
+
   // Rim light: calculated from BASE color (consistent across all elevations)
   // This represents a consistent light source - only size changes with elevation
   const rimLightColor = calculateRimLightColor(baseColor, level)
-  
+
   // Dark shadow: calculated from ELEVATED surface color
   // The shadow is cast by the element, so it should match the surface
   const darkShadowColors = calculateDarkShadowColors(elevatedSurfaceColor)
-  
+
   // Get shadow intensity config (for dark shadow)
   const intensityConfig = {
     subtle: { offset: 1, blur: 2 },
     medium: { offset: 2, blur: 4 },
     strong: { offset: 2, blur: 5 },
   }
-  
+
   const { offset, blur } = intensityConfig[config.shadowIntensity]
-  
+
   // Get rim light config (scales with elevation level)
   const rimConfig = getRimLightConfig()
-  
+
   if (config.shadowStyle === 'pressed') {
     // Inset shadow (pressed elements)
     if (isHovered) {
@@ -365,7 +370,7 @@ function calculateElevationShadow(
         },
       }) as ViewStyle
     }
-    
+
     return Platform.select({
       web: {
         boxShadow: `inset ${offset}px ${offset}px ${blur}px ${darkShadowColors.darker}, inset -${rimConfig.offset}px -${rimConfig.offset}px ${rimConfig.blur}px ${rimLightColor}`,
@@ -394,7 +399,7 @@ function calculateElevationShadow(
         },
       }) as ViewStyle
     }
-    
+
     return Platform.select({
       web: {
         boxShadow: `${offset}px ${offset}px ${blur}px ${darkShadowColors.dark}, -${rimConfig.offset}px -${rimConfig.offset}px ${rimConfig.blur}px ${rimLightColor}`,
@@ -413,7 +418,7 @@ function calculateElevationShadow(
 /**
  * Get shadow style for an elevation level, calculated dynamically from surface color.
  * Results are cached to avoid redundant calculations.
- * 
+ *
  * @param baseColor - Base surface color (hex)
  * @param level - Elevation level
  * @param theme - Current theme ('light' or 'dark')
@@ -427,35 +432,56 @@ export function getElevationShadow(
   isHovered: boolean = false
 ): ViewStyle {
   const cacheKey = getShadowCacheKey(baseColor, level, theme, isHovered)
-  
+
   // Check cache
   if (elevationShadowCache.has(cacheKey)) {
     return elevationShadowCache.get(cacheKey)!
   }
-  
+
   // Calculate shadow
   const result = calculateElevationShadow(baseColor, level, theme, isHovered)
-  
+
   // Cache result
   if (elevationShadowCache.size >= MAX_SHADOW_CACHE_SIZE) {
     const firstKey = elevationShadowCache.keys().next().value!
     elevationShadowCache.delete(firstKey)
   }
   elevationShadowCache.set(cacheKey, result)
-  
+
   return result
+}
+
+/**
+ * Elevation level backing a `<Surface pressed>` recess: the shallow `inset`
+ * (-1) step. Pressed exposes ONE level of depth — pressed-2 is intentionally
+ * not surfaced (the deeper `-2` deep-inset stays available to `elevation`).
+ */
+export const PRESSED_ELEVATION_LEVEL: ElevationLevel = -1
+
+/**
+ * Inner-shadow recess for a pressed (sunken) surface, tuned to the well's own
+ * fill colour so the rim/shadow tints track the darker fill. Composes WITH the
+ * darker pressed fill: on web it adds an inset boxShadow; on the native path
+ * (no inset-shadow support) it's a no-op and the recess reads via the fill
+ * alone — so a pressed surface stays legibly sunken with or without the shadow.
+ *
+ * @param fillColor - The pressed surface's own fill (one ramp step down).
+ * @param theme - Current theme ('light' or 'dark').
+ */
+export function getPressedRecessShadow(fillColor: string, theme: 'light' | 'dark'): ViewStyle {
+  return getElevationShadow(fillColor, PRESSED_ELEVATION_LEVEL, theme)
 }
 
 /**
  * Get base surface color from theme.
  * This is the foundation color that all elevations are calculated from.
- * 
+ *
  * IMPORTANT: Base colors must be chosen to allow sufficient lightening.
- * 
+ *
  * **Light Mode**: Cannot use `#FFFFFF` (white) - cannot lighten white!
  *   - Use `#F3F4F6` (neutral[100]) - can lighten to `#FAFAFA` → `#FFFFFF`
  *   - This allows raised elevations to be lighter (closer to white)
- * 
+ *
  * **Dark Mode**: Need lighter base to allow sufficient lightening
  *   - Use `surface-elevated` (#2A2827, TD-surface-tokens ramp) - allows further lightening
  *
@@ -544,10 +570,7 @@ const glowConfig: Record<GlowIntensity, { blur: number; spread: number; opacity:
  * @param intensity - Glow intensity level
  * @returns ViewStyle with platform-specific shadow properties
  */
-export function getGlowShadow(
-  color: string,
-  intensity: GlowIntensity = 'medium'
-): ViewStyle {
+export function getGlowShadow(color: string, intensity: GlowIntensity = 'medium'): ViewStyle {
   const config = glowConfig[intensity]
   const rgb = hexToRgb(color)
   if (!rgb) return {}


### PR DESCRIPTION
Adds the relative-inset well API on top of the re-spaced surface ramp (#122).

## What
- **`<Surface pressed>`** steps one ramp level DOWN from the parent surface (pressed-1), clamping at `surface-inset` (the deepest pit). pressed-1 is the sole default; no `pressed-2` exposed.
- Publishes the stepped-down level to descendants (a nested press steps again).
- Inner-shadow recess composed with the darker fill (web path) so the well reads recessed even when shadow is stripped (native).
- `pressedLevel` + `getPressedRecessShadow` helpers.
- `elevation.ts` reworked to derive off the surface ramp.

## Verify
- typecheck ✓ · lint 0 errors · **2598 tests pass**
- Pressed-well test table updated to the S-3 re-spaced ramp (`overlay #373635 → raised #31302F → elevated #2C2A28`).

Second in the surface-foundation stack (tokens → **pressed** → dark-migration). Rebased onto main post-#122.