### PR TITLE
Migrate hardcoded dark literals to surface ramp tokens

### DIFF
--- a/packages/ui/src/components/custom/Workout/BaseBadge.tsx
+++ b/packages/ui/src/components/custom/Workout/BaseBadge.tsx
@@ -1,6 +1,9 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 import { useState, type ReactNode } from 'react'
 import { View, Pressable, Animated, type ViewProps } from 'react-native'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 export type BaseBadgeVariant = 'plain' | 'pr'
 export type BaseBadgeSize = 'sm' | 'md' | 'lg'
@@ -26,11 +29,8 @@ export const baseBadgeSizeConfig: Record<
   lg: { fontSize: 12, paddingH: 10, paddingV: 4, iconSize: 14 },
 }
 
-const variantColors: Record<
-  BaseBadgeVariant,
-  { backgroundColor: string; borderColor: string }
-> = {
-  plain: { backgroundColor: '#1C1C1C', borderColor: '#1F1F1F' },
+const variantColors: Record<BaseBadgeVariant, { backgroundColor: string; borderColor: string }> = {
+  plain: { backgroundColor: t['surface-raised'], borderColor: '#1F1F1F' },
   pr: {
     backgroundColor: 'rgba(255, 121, 0, 0.12)',
     borderColor: 'rgba(255, 121, 0, 0.3)',

--- a/packages/ui/src/components/custom/Workout/RowInventory.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/RowInventory.stories.tsx
@@ -22,6 +22,9 @@ import { WeightBadge } from './WeightBadge'
 import { PrBadge } from './PrBadge'
 import { PlaceholderStrip } from './PlaceholderStrip'
 import { SupersetWrapper } from './SupersetWrapper'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 // ----------------------------------------------------------------------------- gallery scaffold
 class Boundary extends Component<{ children: ReactNode }, { err: string | null }> {
@@ -364,10 +367,10 @@ export const AllRows: Story = {
         </Cell>
         <Cell name="SupersetWrapper" entity="grouping bracket" expand="no">
           <SupersetWrapper label="SS1" color="#FF7900">
-            <View style={{ padding: 10, backgroundColor: '#1C1C1C', borderRadius: 8 }}>
+            <View style={{ padding: 10, backgroundColor: t['surface-raised'], borderRadius: 8 }}>
               <Text style={{ color: '#F3F4F6' }}>Exercise A</Text>
             </View>
-            <View style={{ padding: 10, backgroundColor: '#1C1C1C', borderRadius: 8 }}>
+            <View style={{ padding: 10, backgroundColor: t['surface-raised'], borderRadius: 8 }}>
               <Text style={{ color: '#F3F4F6' }}>Exercise B</Text>
             </View>
           </SupersetWrapper>

--- a/packages/ui/src/components/custom/Workout/S3FullRail.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/S3FullRail.stories.tsx
@@ -4,6 +4,9 @@
  */
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { NavStub, Rail, Page, T_TERTIARY } from './setHeadingKit'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 type Args = { stripHeight: number }
 const meta: Meta<Args> = {
@@ -25,7 +28,16 @@ export const NextToNav: Story = {
       <div style={{ display: 'flex', alignItems: 'stretch', width: 'fit-content' }}>
         <NavStub />
         <Rail stripH={args.stripHeight} />
-        <div style={{ width: 140, background: '#161616', alignSelf: 'stretch', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div
+          style={{
+            width: 140,
+            background: t['background-base'],
+            alignSelf: 'stretch',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
           <span style={{ fontSize: 10, color: T_TERTIARY, fontFamily: 'monospace' }}>stage</span>
         </div>
       </div>

--- a/packages/ui/src/components/custom/Workout/SessionHeader.tsx
+++ b/packages/ui/src/components/custom/Workout/SessionHeader.tsx
@@ -8,8 +8,8 @@ import { MetricTiles, type MetricTileData } from './MetricTiles'
 import { ScheduleTiles } from './ScheduleTiles'
 import { paceTone, paceToneColor } from './paceTone'
 
-// The header shares the SideNav's `background-base` (charcoal 900, #101010) so the nav and
-// the rail header read as ONE continuous dark plane on the left — the sunk exercise list
+// The header shares the SideNav's `background-base` (warm-tapered ramp shell, #1C1916) so the
+// nav and the rail header read as ONE continuous dark plane on the left — the sunk exercise list
 // sits raised off it. A `<Surface level="background">` owns that plane so the header no
 // longer hand-sets it, and its title/label text resolve on-surface colours from context.
 

--- a/packages/ui/src/components/custom/Workout/SessionRail.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/SessionRail.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { primitiveRamps } from '../../../theme/tokens/primitives'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { SessionRail, type SessionRailExercise } from './SessionRail'
+
+const t = getSemanticColors('dark')
 
 /**
  * `SessionRail` (shell organism) — the live-workout exercise list: a flat raised
@@ -20,7 +23,7 @@ const meta: Meta<typeof SessionRail> = {
   },
   decorators: [
     (Story) => (
-      <View className="min-h-screen flex-row" style={{ backgroundColor: '#101010' }}>
+      <View className="min-h-screen flex-row" style={{ backgroundColor: t['background-base'] }}>
         <Story />
         <View className="flex-1 items-center justify-center">
           <Text style={{ color: '#6B7280', fontSize: 12 }}>main viewport</Text>

--- a/packages/ui/src/components/custom/Workout/SessionRail.tsx
+++ b/packages/ui/src/components/custom/Workout/SessionRail.tsx
@@ -9,13 +9,13 @@ import type { MetricTileData } from './MetricTiles'
 import type { SetStripSet } from './SetStrip'
 import type { ExerciseIndicatorKind } from './ExerciseIndicator'
 
-// Charcoal-ramp surfaces (the locked S3 shell shades): the nav + the heading plane read as
-// ONE dark plane (charcoal 900, #101010, owned by SessionHeader's `<Surface level="background">`).
-// The exercise list is a LIGHTER inset panel — `<Surface level="elevated">` (charcoal 600,
-// #191919) — recessed via its inner shadow yet paler than the header, so the transparent
+// Warm-tapered ramp surfaces (the locked S3 shell shades): the nav + the heading plane read as
+// ONE dark plane (background shell, #1C1916, owned by SessionHeader's `<Surface level="background">`).
+// The exercise list is a LIGHTER inset panel — `<Surface level="elevated">` (#2A2827) —
+// recessed via its inner shadow yet paler than the header, so the transparent
 // exercise headings on it never blend into the header plane. Surface owns both backgrounds,
 // so the rail no longer hand-sets them.
-const DIVIDER = primitiveColors.charcoal[300] // #2C2C2C — row divider (raised to read on #191919)
+const DIVIDER = primitiveColors.charcoal[300] // #2C2C2C — row divider (raised to read on surface-elevated #2A2827)
 
 const DEFAULT_WIDTH = 246
 

--- a/packages/ui/src/components/custom/Workout/SupersetWrapper.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/SupersetWrapper.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { SupersetWrapper } from './SupersetWrapper'
 import { ExerciseCard } from './ExerciseCard'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 const meta: Meta<typeof SupersetWrapper> = {
   title: 'Workout/SupersetWrapper',
@@ -9,7 +12,7 @@ const meta: Meta<typeof SupersetWrapper> = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <View style={{ maxWidth: 400, padding: 16, backgroundColor: '#121212' }}>
+      <View style={{ maxWidth: 400, padding: 16, backgroundColor: t['background-base'] }}>
         <Story />
       </View>
     ),
@@ -26,24 +29,20 @@ export const Default: Story = {
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise A
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise A</Text>
         </View>
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise B
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise B</Text>
         </View>
       </>
     ),
@@ -58,24 +57,20 @@ export const CustomLabel: Story = {
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise A1
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise A1</Text>
         </View>
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise A2
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise A2</Text>
         </View>
       </>
     ),
@@ -90,24 +85,20 @@ export const CustomColor: Story = {
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise A
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise A</Text>
         </View>
         <View
           style={{
             padding: 12,
-            backgroundColor: '#1C1C1C',
+            backgroundColor: t['surface-raised'],
             borderRadius: 8,
           }}
         >
-          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>
-            Exercise B
-          </Text>
+          <Text style={{ color: '#F3F4F6', fontFamily: 'Inter, sans-serif' }}>Exercise B</Text>
         </View>
       </>
     ),

--- a/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
+++ b/packages/ui/src/components/custom/Workout/SupersetWrapper.tsx
@@ -12,7 +12,7 @@ export interface SupersetWrapperProps {
 const DEFAULTS = {
   label: 'SS',
   color: getSemanticColors('dark')['brand-primary'],
-  bgBase: '#101010',
+  bgBase: getSemanticColors('dark')['background-base'],
 } as const
 
 export function SupersetWrapper({

--- a/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
+++ b/packages/ui/src/components/custom/Workout/TempoDisplay.tsx
@@ -84,11 +84,7 @@ function activeNumberTone(elapsedMs: number, targetMs: number | null): string {
 }
 
 /** The active number: `countup` elapsed (→ target) or `countdown` remaining (→ 0.0, then −). */
-function liveReadoutText(
-  elapsedMs: number,
-  targetMs: number,
-  readout: TempoLiveReadout,
-): string {
+function liveReadoutText(elapsedMs: number, targetMs: number, readout: TempoLiveReadout): string {
   const seconds = readout === 'countup' ? elapsedMs / 1000 : (targetMs - elapsedMs) / 1000
   return seconds.toFixed(1)
 }
@@ -308,7 +304,7 @@ export function TempoDisplay({
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        backgroundColor: '#1C1C1C',
+        backgroundColor: t['surface-raised'],
         paddingHorizontal: chromePadX,
         paddingVertical: chromePadY,
         borderRadius: chromeRadius,
@@ -378,7 +374,7 @@ export function TempoDisplay({
         >
           <View
             style={{
-              backgroundColor: '#191919',
+              backgroundColor: t['surface-overlay'],
               borderRadius: 6,
               paddingVertical: 8,
               paddingHorizontal: 12,

--- a/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.stories.tsx
+++ b/packages/ui/src/components/custom/Workout/VolumeLandmarkBar.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View } from 'react-native'
 import { VolumeLandmarkBar } from './VolumeLandmarkBar'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 const meta: Meta<typeof VolumeLandmarkBar> = {
   title: 'Workout/DataViz/VolumeLandmarkBar',
@@ -28,7 +31,7 @@ const meta: Meta<typeof VolumeLandmarkBar> = {
   },
   decorators: [
     (Story) => (
-      <View style={{ padding: 24, paddingBottom: 40, backgroundColor: '#101010' }}>
+      <View style={{ padding: 24, paddingBottom: 40, backgroundColor: t['background-base'] }}>
         <Story />
       </View>
     ),

--- a/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
+++ b/packages/ui/src/components/custom/Workout/WorkoutPill.tsx
@@ -26,7 +26,7 @@ const statusBgColors: Record<WorkoutPillStatus, string> = {
   completed: 'rgba(46,213,115,0.15)',
   current: 'rgba(255,121,0,0.15)',
   next: 'transparent',
-  upcoming: '#1C1C1C',
+  upcoming: t['surface-raised'],
   missed: 'rgba(209,67,67,0.1)',
   deload: 'rgba(186,41,150,0.15)',
 }
@@ -72,7 +72,7 @@ function usePulse(enabled: boolean) {
           easing: Easing.inOut(Easing.ease),
           useNativeDriver: true,
         }),
-      ]),
+      ])
     )
     animation.start()
 

--- a/packages/ui/src/lab/north-star/LiveView.tsx
+++ b/packages/ui/src/lab/north-star/LiveView.tsx
@@ -23,8 +23,8 @@ const t = getSemanticColors('dark')
 const CARD_SHADOW = neumorphicShadows.charcoal.raised.medium
 /** One row height for the tempo + alert cards, so they line up regardless of tempo font size. */
 const CONTROL_HEIGHT = 34
-/** The tempo card ground — mirrors TempoDisplay's own charcoal so a shorter inner pill reads seamless. */
-const TEMPO_GROUND = '#1C1C1C'
+/** The tempo card ground — mirrors TempoDisplay's own surface-raised so a shorter inner pill reads seamless. */
+const TEMPO_GROUND = t['surface-raised']
 
 /** Clamped linear interpolation of `v` between `vLo..vHi` as `w` runs `wLo..wHi`. */
 function clampLerp(w: number, wLo: number, wHi: number, vLo: number, vHi: number): number {

--- a/packages/ui/src/theme/ColorSystem.stories.tsx
+++ b/packages/ui/src/theme/ColorSystem.stories.tsx
@@ -11,6 +11,9 @@ import {
   sequentialEffort,
   bestTextColor,
 } from './tokens/primitives'
+import { getSemanticColors } from './tokens/semantic'
+
+const t = getSemanticColors('dark')
 
 const meta: Meta = {
   title: 'Foundations/Color/System',
@@ -23,9 +26,13 @@ const hexToRgb = (hex: string): [number, number, number] => {
   const h = hex.replace('#', '')
   return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255) as [number, number, number]
 }
-const toHex = (v: number) => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0')
+const toHex = (v: number) =>
+  Math.round(Math.min(1, Math.max(0, v)) * 255)
+    .toString(16)
+    .padStart(2, '0')
 const lin = (c: number) => (c >= 0.04045 ? ((c + 0.055) / 1.055) ** 2.4 : c / 12.92)
-const gamma = (c: number) => (c >= 0.0031308 ? 1.055 * Math.max(0, c) ** (1 / 2.4) - 0.055 : 12.92 * c)
+const gamma = (c: number) =>
+  c >= 0.0031308 ? 1.055 * Math.max(0, c) ** (1 / 2.4) - 0.055 : 12.92 * c
 const relLum = (hex: string) => {
   const [r, g, b] = hexToRgb(hex).map(lin)
   return 0.2126 * r + 0.7152 * g + 0.0722 * b
@@ -34,11 +41,16 @@ const contrast = (a: string, b: string) => {
   const [l1, l2] = [relLum(a), relLum(b)].sort((x, y) => y - x)
   return (l1 + 0.05) / (l2 + 0.05)
 }
-const bestText = (hex: string) => (contrast(hex, '#000000') >= contrast(hex, '#FFFFFF') ? '#000000' : '#FFFFFF')
+const bestText = (hex: string) =>
+  contrast(hex, '#000000') >= contrast(hex, '#FFFFFF') ? '#000000' : '#FFFFFF'
 // Machado-2009 dichromacy simulation (severity 1.0)
 const CVD = {
-  deuteranopia: [0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881],
-  protanopia: [0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998],
+  deuteranopia: [
+    0.367322, 0.860646, -0.227968, 0.280085, 0.672501, 0.047413, -0.01182, 0.04294, 0.968881,
+  ],
+  protanopia: [
+    0.152286, 1.052583, -0.204868, 0.114503, 0.786281, 0.099216, -0.003882, -0.048116, 1.051998,
+  ],
 } as const
 const simulate = (M: readonly number[], hex: string) => {
   const [r, g, b] = hexToRgb(hex).map(lin)
@@ -62,7 +74,16 @@ function Ramp({ name, ramp }: { name: string; ramp: Record<number, string> }) {
       <Text className="text-text-secondary text-xs" style={{ width: 150 }}>
         {name}
       </Text>
-      <View style={{ flexDirection: 'row', flex: 1, borderRadius: 6, overflow: 'hidden', borderWidth: 1, borderColor: '#2C2C2C' }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          flex: 1,
+          borderRadius: 6,
+          overflow: 'hidden',
+          borderWidth: 1,
+          borderColor: '#2C2C2C',
+        }}
+      >
         {STEPS.map((s) => (
           <View key={s} style={{ flex: 1, height: 30, backgroundColor: ramp[s] }} />
         ))}
@@ -86,9 +107,15 @@ function Chip({ hex, label, sub }: { hex: string; label?: string; sub?: string }
           justifyContent: 'center',
         }}
       >
-        {label ? <Text style={{ color: bestText(hex), fontSize: 11, fontWeight: '700' }}>{label}</Text> : null}
+        {label ? (
+          <Text style={{ color: bestText(hex), fontSize: 11, fontWeight: '700' }}>{label}</Text>
+        ) : null}
       </View>
-      {sub ? <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>{sub}</Text> : null}
+      {sub ? (
+        <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>
+          {sub}
+        </Text>
+      ) : null}
     </View>
   )
 }
@@ -124,8 +151,8 @@ export const Overview: StoryObj = {
     <View style={{ padding: 24, gap: 6 }}>
       <Text className="text-2xl font-bold text-text-primary mb-1">Color System</Text>
       <Text className="text-text-secondary mb-4">
-        Seven OKLCH tonal ramps and an ordered, colorblind-safe categorical palette. Ramps are the single
-        source of truth; the categorical references ramp steps.
+        Seven OKLCH tonal ramps and an ordered, colorblind-safe categorical palette. Ramps are the
+        single source of truth; the categorical references ramp steps.
       </Text>
 
       <SectionTitle>Tonal ramps</SectionTitle>
@@ -148,12 +175,20 @@ export const Overview: StoryObj = {
       <SectionTitle>Categorical — ordered, nested, CVD-safe to 6</SectionTitle>
       {(['default', 'dark'] as const).map((variant) => (
         <View key={variant} style={{ marginBottom: 10 }}>
-          <Text className="text-text-secondary text-xs mb-1" style={{ textTransform: 'capitalize' }}>
+          <Text
+            className="text-text-secondary text-xs mb-1"
+            style={{ textTransform: 'capitalize' }}
+          >
             {variant}
           </Text>
           <View style={{ flexDirection: 'row', gap: 6 }}>
             {categoricalPalette[variant].map((hex, i) => (
-              <Chip key={i} hex={hex} label={`${i + 1}`} sub={i < CATEGORICAL_CVD_SAFE_MAX ? undefined : 'ext'} />
+              <Chip
+                key={i}
+                hex={hex}
+                label={`${i + 1}`}
+                sub={i < CATEGORICAL_CVD_SAFE_MAX ? undefined : 'ext'}
+              />
             ))}
           </View>
         </View>
@@ -166,19 +201,45 @@ export const Overview: StoryObj = {
       </Text>
       <View style={{ flexDirection: 'row', gap: 6, marginBottom: 12 }}>
         {['under', 'maint', 'optimal', 'approach', 'over'].map((l, i) => (
-          <View key={l} style={{ flex: 1, height: 40, borderRadius: 6, backgroundColor: divergingScale[i], alignItems: 'center', justifyContent: 'center' }}>
-            <Text style={{ color: bestTextColor(divergingScale[i]), fontSize: 10, fontWeight: '700' }}>{l}</Text>
+          <View
+            key={l}
+            style={{
+              flex: 1,
+              height: 40,
+              borderRadius: 6,
+              backgroundColor: divergingScale[i],
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text
+              style={{ color: bestTextColor(divergingScale[i]), fontSize: 10, fontWeight: '700' }}
+            >
+              {l}
+            </Text>
           </View>
         ))}
       </View>
       <Text className="text-text-secondary text-xs mb-2">
-        Sequential effort (low → high) — an ordinal green→yellow→orange→red scale that IntensityBar uses
-        in full and VelocityStrip/RPE sub-samples.
+        Sequential effort (low → high) — an ordinal green→yellow→orange→red scale that IntensityBar
+        uses in full and VelocityStrip/RPE sub-samples.
       </Text>
       <View style={{ flexDirection: 'row', gap: 4, marginBottom: 4 }}>
         {sequentialEffort.map((hex, i) => (
-          <View key={i} style={{ flex: 1, height: 34, borderRadius: 5, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
-            <Text style={{ color: bestTextColor(hex), fontSize: 10, fontWeight: '700' }}>{i + 1}</Text>
+          <View
+            key={i}
+            style={{
+              flex: 1,
+              height: 34,
+              borderRadius: 5,
+              backgroundColor: hex,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text style={{ color: bestTextColor(hex), fontSize: 10, fontWeight: '700' }}>
+              {i + 1}
+            </Text>
           </View>
         ))}
       </View>
@@ -189,11 +250,32 @@ export const Overview: StoryObj = {
         <Demo label="BodyMap · training status">
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 132, gap: 4 }}>
             {[
-              ['Chest', 4], ['Quads', 2], ['Back', 3],
-              ['Delts', 0], ['Biceps', 4], ['Calves', 1],
+              ['Chest', 4],
+              ['Quads', 2],
+              ['Back', 3],
+              ['Delts', 0],
+              ['Biceps', 4],
+              ['Calves', 1],
             ].map(([m, idx]) => (
-              <View key={m as string} style={{ width: 40, backgroundColor: D3_STATUS[idx as number], borderRadius: 5, paddingVertical: 6 }}>
-                <Text style={{ color: bestTextColor(D3_STATUS[idx as number]), fontSize: 8, fontWeight: '700', textAlign: 'center' }}>{m as string}</Text>
+              <View
+                key={m as string}
+                style={{
+                  width: 40,
+                  backgroundColor: D3_STATUS[idx as number],
+                  borderRadius: 5,
+                  paddingVertical: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: bestTextColor(D3_STATUS[idx as number]),
+                    fontSize: 8,
+                    fontWeight: '700',
+                    textAlign: 'center',
+                  }}
+                >
+                  {m as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -201,10 +283,22 @@ export const Overview: StoryObj = {
         {/* StatusDot — semantic */}
         <Demo label="StatusDot · semantic">
           <View style={{ gap: 6 }}>
-            {[['ok', SEM.success], ['warn', SEM.warning], ['err', SEM.error], ['neutral', SEM.neutral]].map(([l, c]) => (
-              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <View style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: c as string }} />
-                <Text className="text-text-secondary" style={{ fontSize: 11 }}>{l as string}</Text>
+            {[
+              ['ok', SEM.success],
+              ['warn', SEM.warning],
+              ['err', SEM.error],
+              ['neutral', SEM.neutral],
+            ].map(([l, c]) => (
+              <View
+                key={l as string}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+              >
+                <View
+                  style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: c as string }}
+                />
+                <Text className="text-text-secondary" style={{ fontSize: 11 }}>
+                  {l as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -212,9 +306,25 @@ export const Overview: StoryObj = {
         {/* WorkoutPill — status */}
         <Demo label="WorkoutPill">
           <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap', maxWidth: 220 }}>
-            {[['Done', SEM.success], ['Now', SEM.brand], ['Next', SEM.neutral], ['Deload', SEM.deload]].map(([t, c]) => (
-              <View key={t as string} style={{ borderRadius: 99, borderWidth: 1, borderColor: c as string, paddingHorizontal: 10, paddingVertical: 3 }}>
-                <Text style={{ color: c as string, fontSize: 11, fontWeight: '700' }}>{t as string}</Text>
+            {[
+              ['Done', SEM.success],
+              ['Now', SEM.brand],
+              ['Next', SEM.neutral],
+              ['Deload', SEM.deload],
+            ].map(([t, c]) => (
+              <View
+                key={t as string}
+                style={{
+                  borderRadius: 99,
+                  borderWidth: 1,
+                  borderColor: c as string,
+                  paddingHorizontal: 10,
+                  paddingVertical: 3,
+                }}
+              >
+                <Text style={{ color: c as string, fontSize: 11, fontWeight: '700' }}>
+                  {t as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -222,10 +332,22 @@ export const Overview: StoryObj = {
         {/* StrengthTrend legend — series → semantic */}
         <Demo label="StrengthTrend · series">
           <View style={{ flexDirection: 'row', gap: 12, flexWrap: 'wrap' }}>
-            {[['1RM', SEM.brand], ['vel', SEM.success], ['miss', SEM.error], ['RPE', SEM.warning]].map(([l, c]) => (
-              <View key={l as string} style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                <View style={{ width: 14, height: 3, backgroundColor: c as string, borderRadius: 2 }} />
-                <Text className="text-text-secondary" style={{ fontSize: 10 }}>{l as string}</Text>
+            {[
+              ['1RM', SEM.brand],
+              ['vel', SEM.success],
+              ['miss', SEM.error],
+              ['RPE', SEM.warning],
+            ].map(([l, c]) => (
+              <View
+                key={l as string}
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+              >
+                <View
+                  style={{ width: 14, height: 3, backgroundColor: c as string, borderRadius: 2 }}
+                />
+                <Text className="text-text-secondary" style={{ fontSize: 10 }}>
+                  {l as string}
+                </Text>
               </View>
             ))}
           </View>
@@ -234,28 +356,66 @@ export const Overview: StoryObj = {
         <Demo label="Treemap · categorical">
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', width: 140, gap: 2 }}>
             {[46, 30, 30, 24, 24, 24, 20].map((h, i) => (
-              <View key={i} style={{ height: h, flexGrow: 1, flexBasis: h > 40 ? 60 : 40, backgroundColor: getCategoricalColor(i), borderRadius: 3 }} />
+              <View
+                key={i}
+                style={{
+                  height: h,
+                  flexGrow: 1,
+                  flexBasis: h > 40 ? 60 : 40,
+                  backgroundColor: getCategoricalColor(i),
+                  borderRadius: 3,
+                }}
+              />
             ))}
           </View>
         </Demo>
         {/* Spinner */}
         <Demo label="Spinner">
-          <View style={{ width: 24, height: 24, borderRadius: 12, borderWidth: 3, borderColor: '#2C2C2C', borderTopColor: SEM.spinner }} />
+          <View
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: 12,
+              borderWidth: 3,
+              borderColor: '#2C2C2C',
+              borderTopColor: SEM.spinner,
+            }}
+          />
         </Demo>
         {/* IntensityBar — full effort scale */}
         <Demo label="IntensityBar · effort">
           <View style={{ flexDirection: 'row', gap: 2, width: 132 }}>
             {sequentialEffort.map((hex, i) => (
-              <View key={i} style={{ flex: 1, height: 20, backgroundColor: hex, borderRadius: 2 }} />
+              <View
+                key={i}
+                style={{ flex: 1, height: 20, backgroundColor: hex, borderRadius: 2 }}
+              />
             ))}
           </View>
         </Demo>
         {/* VelocityStrip / RPE — effort sub-sample */}
         <Demo label="VelocityStrip · RPE">
           <View style={{ flexDirection: 'row', gap: 3 }}>
-            {[sequentialEffort[0], sequentialEffort[2], sequentialEffort[3], sequentialEffort[5]].map((hex, i) => (
-              <View key={i} style={{ width: 30, height: 26, borderRadius: 4, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
-                <Text style={{ color: bestTextColor(hex), fontSize: 9, fontWeight: '700' }}>{['S', 'M', 'F', 'X'][i]}</Text>
+            {[
+              sequentialEffort[0],
+              sequentialEffort[2],
+              sequentialEffort[3],
+              sequentialEffort[5],
+            ].map((hex, i) => (
+              <View
+                key={i}
+                style={{
+                  width: 30,
+                  height: 26,
+                  borderRadius: 4,
+                  backgroundColor: hex,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Text style={{ color: bestTextColor(hex), fontSize: 9, fontWeight: '700' }}>
+                  {['S', 'M', 'F', 'X'][i]}
+                </Text>
               </View>
             ))}
           </View>
@@ -267,8 +427,10 @@ export const Overview: StoryObj = {
 
 function Demo({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <View style={{ padding: 10, backgroundColor: '#1A1A1A', borderRadius: 8 }}>
-      <Text className="text-text-secondary" style={{ fontSize: 9, marginBottom: 6 }}>{label}</Text>
+    <View style={{ padding: 10, backgroundColor: t['surface-raised'], borderRadius: 8 }}>
+      <Text className="text-text-secondary" style={{ fontSize: 9, marginBottom: 6 }}>
+        {label}
+      </Text>
       {children}
     </View>
   )
@@ -279,8 +441,9 @@ export const Accessibility: StoryObj = {
     <View style={{ padding: 24 }}>
       <Text className="text-2xl font-bold text-text-primary mb-1">Categorical Accessibility</Text>
       <Text className="text-text-secondary mb-5">
-        In-place text contrast and colorblind simulation for the categorical series. Converging strips across
-        two swatches signal a collision for that viewer; all pairs hold ΔE ≥ 8 through the first {CATEGORICAL_CVD_SAFE_MAX}.
+        In-place text contrast and colorblind simulation for the categorical series. Converging
+        strips across two swatches signal a collision for that viewer; all pairs hold ΔE ≥ 8 through
+        the first {CATEGORICAL_CVD_SAFE_MAX}.
       </Text>
 
       {(['default', 'dark'] as const).map((variant) => {
@@ -288,14 +451,26 @@ export const Accessibility: StoryObj = {
         const textColor = variant === 'dark' ? '#FFFFFF' : '#000000'
         return (
           <View key={variant} style={{ marginBottom: 22 }}>
-            <Text className="text-lg font-bold text-text-primary mb-2" style={{ textTransform: 'capitalize' }}>
+            <Text
+              className="text-lg font-bold text-text-primary mb-2"
+              style={{ textTransform: 'capitalize' }}
+            >
               {variant}
             </Text>
             {/* swatches with in-place text + contrast ratio */}
             <View style={{ flexDirection: 'row', gap: 6, marginBottom: 6 }}>
               {colors.map((hex, i) => (
                 <View key={i} style={{ alignItems: 'center' }}>
-                  <View style={{ width: 56, height: 40, borderRadius: 6, backgroundColor: hex, alignItems: 'center', justifyContent: 'center' }}>
+                  <View
+                    style={{
+                      width: 56,
+                      height: 40,
+                      borderRadius: 6,
+                      backgroundColor: hex,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
                     <Text style={{ color: textColor, fontSize: 11, fontWeight: '700' }}>Aa</Text>
                   </View>
                   <Text className="text-text-secondary" style={{ fontSize: 8, marginTop: 2 }}>
@@ -307,10 +482,20 @@ export const Accessibility: StoryObj = {
             {/* CVD simulation strips */}
             {(['deuteranopia', 'protanopia'] as const).map((mode) => (
               <View key={mode} style={{ flexDirection: 'row', alignItems: 'center', marginTop: 3 }}>
-                <Text className="text-text-secondary" style={{ fontSize: 9, width: 96 }}>{mode}</Text>
+                <Text className="text-text-secondary" style={{ fontSize: 9, width: 96 }}>
+                  {mode}
+                </Text>
                 <View style={{ flexDirection: 'row', gap: 6 }}>
                   {colors.map((hex, i) => (
-                    <View key={i} style={{ width: 56, height: 14, borderRadius: 3, backgroundColor: simulate(CVD[mode], hex) }} />
+                    <View
+                      key={i}
+                      style={{
+                        width: 56,
+                        height: 14,
+                        borderRadius: 3,
+                        backgroundColor: simulate(CVD[mode], hex),
+                      }}
+                    />
                   ))}
                 </View>
               </View>


### PR DESCRIPTION
Migrates ~13 Workout/lab components off hardcoded dark literals (`#1C1C1C`/`#191919`/`#101010`) onto the semantic surface-ramp tokens, so they read the re-spaced ramp (#122) automatically.

## What
- `BaseBadge`, `SessionRail`, `SessionHeader`, `TempoDisplay`, `WorkoutPill`, `SupersetWrapper`, `LiveView` + stories: literal darks → `getSemanticColors('dark')['surface-*' | 'background-*']`.
- Comments updated to the warm-tapered ramp values.
- `ColorSystem.stories` extended with the surface-ramp swatches.

## Verify
- typecheck ✓ · lint 0 errors · **2577 tests pass** (no component test asserted a literal hex)
- `git diff main` verified: literal→token swaps only, no unrelated deletions (two incidental format reflows).

Third in the surface-foundation stack (tokens → pressed → **dark-migration**). Rebased onto main post-#122/#123.