### PR TITLE
Refresh specimen GT surface tokens for v0.10.0 ramp (VW-74)

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -32,8 +32,8 @@ const HTML_CSS = `
     --brand-primary-subtle: rgba(255, 121, 0, 0.12);
     --brand-secondary: #307B9B;
     --bg-base: #101010;
-    --surface-elevated: #191919;
-    --surface-raised: #1C1C1C;
+    --surface-elevated: #2C2A28;
+    --surface-raised: #31302F;
     --text-primary: #F3F4F6;
     --text-secondary: #9CA3AF;
     --text-tertiary: #6B7280;

--- a/packages/ui/specimen/comparison.visual.test.ts
+++ b/packages/ui/specimen/comparison.visual.test.ts
@@ -950,7 +950,7 @@ test.describe('HTML vs React Component Comparison', () => {
       const cs = window.getComputedStyle(el)
       return { backgroundColor: cs.backgroundColor, flexDirection: cs.flexDirection, alignItems: cs.alignItems }
     })
-    expect.soft(styles.backgroundColor, 'InputBar bg').toBe('rgb(25, 25, 25)')
+    expect.soft(styles.backgroundColor, 'InputBar bg').toBe('rgb(44, 42, 40)')
     expect.soft(styles.flexDirection, 'InputBar flexDirection').toBe('row')
     expect.soft(styles.alignItems, 'InputBar alignItems').toBe('center')
   })
@@ -966,7 +966,7 @@ test.describe('HTML vs React Component Comparison', () => {
       const cs = window.getComputedStyle(el)
       return { backgroundColor: cs.backgroundColor, paddingLeft: cs.paddingLeft, paddingRight: cs.paddingRight }
     })
-    expect.soft(styles.backgroundColor, 'RestTimer bg').toBe('rgb(28, 28, 28)')
+    expect.soft(styles.backgroundColor, 'RestTimer bg').toBe('rgb(49, 48, 47)')
     expect.soft(styles.paddingLeft, 'RestTimer paddingLeft').toBe('16px')
     expect.soft(styles.paddingRight, 'RestTimer paddingRight').toBe('16px')
   })


### PR DESCRIPTION
## Problem
The v0.10.0 surface foundation re-spaced the dark surface ramp and migrated component backgrounds to the new tokens, but the **Layer-3 HTML-vs-React parity** harness (`test:visual:compare`) was missed. Its hand-authored ground truth still carried the old surface literals, so the advisory `visual` gate went **red on `main`** after the v0.10.0 release (VW-74).

Every failing specimen showed the identical delta — `backgroundColor: HTML="rgb(28, 28, 28)" React="rgb(49, 48, 47)"` — i.e. old `#1C1C1C` GT vs new `surface-raised #31302F`.

## Fix
- **`comparison.tsx`** `HTML_CSS`: bump the stale ramp vars to the shipped v0.10.0 hexes
  - `--surface-elevated: #191919 → #2C2A28`
  - `--surface-raised: #1C1C1C → #31302F`
  - (fixes all 14 `assertStyleMatch` specimens: weight-badge ×6, muscle-chip ×5, tempo ×2, workout-pill)
- **`comparison.visual.test.ts`**: update the two hardcoded background assertions
  - `InputBar bg`: `rgb(25, 25, 25) → rgb(44, 42, 40)` (surface-elevated)
  - `RestTimer bg`: `rgb(28, 28, 28) → rgb(49, 48, 47)` (surface-raised)

Values verified against shipped `global.css` (`--color-surface-elevated: #2C2A28`, `--color-surface-raised: #31302F`), not just the CI-rendered output.

## Layer 1 baselines
No PNG refresh needed — the committed component screenshot baselines already encode v0.10.0 (**0/68 drift** vs the in-container `component-visual-baselines` refresh artifact; dark-migration #124 refreshed them). This PR is purely the Layer-3 harness.

## Verification
`pnpm test:visual:compare` → **80/80 green** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)