### PR TITLE
Harden Foundations/Color stories against token drift (+ recovers #102)

### DIFF
--- a/packages/ui/src/theme/ColorSystem.stories.tsx
+++ b/packages/ui/src/theme/ColorSystem.stories.tsx
@@ -11,7 +11,10 @@ import {
   sequentialEffort,
   bestTextColor,
 } from './tokens/primitives'
+import { WORKOUT_TOKENS } from './workout-tokens'
 import { getSemanticColors } from './tokens/semantic'
+import { WORKOUT_PILL_DELOAD } from './extracted-colors-dataviz'
+import { SPINNER_PRIMARY } from './extracted-colors-ui'
 
 const t = getSemanticColors('dark')
 
@@ -130,16 +133,19 @@ const RAMP_NAMES: Array<[keyof typeof primitiveRamps, string]> = [
   ['magenta', 'Magenta'],
 ]
 
+// Sourced from the real semantic-token layer (not re-derived) so the story can't
+// silently desync if semantic.ts changes. deload/spinner come from the same
+// extracted-colors modules the components consume.
 const SEM = {
-  success: primitiveRamps.green[300],
-  warning: primitiveRamps.amber[300],
-  error: primitiveRamps.red[600],
-  info: primitiveRamps.blue[500],
-  deload: primitiveRamps.magenta[600],
-  brand: primitiveRamps.orange[400],
-  brandDark: primitiveRamps.orange[600],
-  brandSecondary: primitiveRamps.cyan[600],
-  spinner: primitiveRamps.cyan[600],
+  success: t['status-success'],
+  warning: t['status-warning'],
+  error: t['status-error'],
+  info: t['status-info'],
+  deload: WORKOUT_PILL_DELOAD,
+  brand: t['brand-primary'],
+  brandDark: t['brand-primary-dark'],
+  brandSecondary: t['brand-secondary'],
+  spinner: SPINNER_PRIMARY,
   neutral: primitiveColors.neutral[500],
 } as const
 
@@ -393,15 +399,11 @@ export const Overview: StoryObj = {
             ))}
           </View>
         </Demo>
-        {/* VelocityStrip / RPE — effort sub-sample */}
+        {/* VelocityStrip / RPE — the real 4-band production scale (WORKOUT_TOKENS.scale,
+            sequentialEffort indices [0,2,3,4] → red-600, NOT red-700). */}
         <Demo label="VelocityStrip · RPE">
           <View style={{ flexDirection: 'row', gap: 3 }}>
-            {[
-              sequentialEffort[0],
-              sequentialEffort[2],
-              sequentialEffort[3],
-              sequentialEffort[5],
-            ].map((hex, i) => (
+            {Object.values(WORKOUT_TOKENS.scale).map((hex, i) => (
               <View
                 key={i}
                 style={{

--- a/packages/ui/src/theme/Colors.stories.tsx
+++ b/packages/ui/src/theme/Colors.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
-import { primitiveColors, discreteRainbow, primitiveRamps, categoricalPalette } from './tokens/primitives'
+import {
+  primitiveColors,
+  discreteRainbow,
+  primitiveRamps,
+  categoricalPalette,
+} from './tokens/primitives'
 import { semanticColorsLight, semanticColorsDark } from './tokens/semantic'
 
 const meta: Meta = {
@@ -32,12 +37,8 @@ function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
         }}
       />
       <View>
-        <Text className="font-semibold text-text-primary text-sm">
-          {name}
-        </Text>
-        <Text className="text-text-secondary text-xs">
-          {displayValue}
-        </Text>
+        <Text className="font-semibold text-text-primary text-sm">{name}</Text>
+        <Text className="text-text-secondary text-xs">{displayValue}</Text>
       </View>
     </View>
   )
@@ -46,9 +47,7 @@ function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
 function ColorScale({ name, colors }: { name: string; colors: Record<string | number, string> }) {
   return (
     <View style={{ marginBottom: 32 }}>
-      <Text className="text-lg font-bold text-text-primary mb-3">
-        {name}
-      </Text>
+      <Text className="text-lg font-bold text-text-primary mb-3">{name}</Text>
       <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
         {Object.entries(colors).map(([shade, color]) => (
           <View key={shade} style={{ alignItems: 'center' }}>
@@ -62,9 +61,7 @@ function ColorScale({ name, colors }: { name: string; colors: Record<string | nu
                 borderColor: '#374151',
               }}
             />
-            <Text className="text-text-secondary text-xs mt-1">
-              {shade}
-            </Text>
+            <Text className="text-text-secondary text-xs mt-1">{shade}</Text>
           </View>
         ))}
       </View>
@@ -75,9 +72,7 @@ function ColorScale({ name, colors }: { name: string; colors: Record<string | nu
 export const PrimitiveColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Primitive Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Primitive Colors</Text>
       <Text className="text-text-secondary mb-6">
         Raw color values. Chromatic hues live as OKLCH tonal ramps (see the Tonal Ramps story);
         these are the achromatic and support scales. Use semantic tokens when building components.
@@ -95,17 +90,24 @@ export const PrimitiveColors: StoryObj = {
 export const BrandColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Brand Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Brand Colors</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="brand-primary" value={semanticColorsLight['brand-primary']} />
-        <ColorSwatch name="brand-primary-light" value={semanticColorsLight['brand-primary-light']} />
+        <ColorSwatch
+          name="brand-primary-light"
+          value={semanticColorsLight['brand-primary-light']}
+        />
         <ColorSwatch name="brand-primary-dark" value={semanticColorsLight['brand-primary-dark']} />
         <ColorSwatch name="brand-secondary" value={semanticColorsLight['brand-secondary']} />
-        <ColorSwatch name="brand-secondary-light" value={semanticColorsLight['brand-secondary-light']} />
-        <ColorSwatch name="brand-secondary-dark" value={semanticColorsLight['brand-secondary-dark']} />
+        <ColorSwatch
+          name="brand-secondary-light"
+          value={semanticColorsLight['brand-secondary-light']}
+        />
+        <ColorSwatch
+          name="brand-secondary-dark"
+          value={semanticColorsLight['brand-secondary-dark']}
+        />
       </View>
     </View>
   ),
@@ -114,9 +116,7 @@ export const BrandColors: StoryObj = {
 export const StatusColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Status Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Status Colors</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="status-success" value={semanticColorsLight['status-success']} />
@@ -131,9 +131,7 @@ export const StatusColors: StoryObj = {
 export const TextColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Text Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Text Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="text-primary" value={semanticColorsDark['text-primary']} />
@@ -149,9 +147,7 @@ export const TextColors: StoryObj = {
 export const SurfaceColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Surface Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Surface Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="surface-base" value={semanticColorsDark['surface-base']} />
@@ -168,34 +164,52 @@ export const SurfaceColors: StoryObj = {
 export const ResultColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Result/Outcome Colors
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Result/Outcome Colors</Text>
       <Text className="text-text-secondary mb-6">
         Colors for indicating positive, negative, or neutral outcomes.
       </Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="result-improve" value={semanticColorsLight['result-improve']} />
-        <ColorSwatch name="result-improve-light" value={semanticColorsLight['result-improve-light']} />
+        <ColorSwatch
+          name="result-improve-light"
+          value={semanticColorsLight['result-improve-light']}
+        />
         <ColorSwatch name="result-degrade" value={semanticColorsLight['result-degrade']} />
-        <ColorSwatch name="result-degrade-light" value={semanticColorsLight['result-degrade-light']} />
-        <ColorSwatch name="result-inconclusive" value={semanticColorsLight['result-inconclusive']} />
-        <ColorSwatch name="result-inconclusive-light" value={semanticColorsLight['result-inconclusive-light']} />
+        <ColorSwatch
+          name="result-degrade-light"
+          value={semanticColorsLight['result-degrade-light']}
+        />
+        <ColorSwatch
+          name="result-inconclusive"
+          value={semanticColorsLight['result-inconclusive']}
+        />
+        <ColorSwatch
+          name="result-inconclusive-light"
+          value={semanticColorsLight['result-inconclusive-light']}
+        />
         <ColorSwatch name="result-neutral" value={semanticColorsLight['result-neutral']} />
       </View>
     </View>
   ),
 }
 
-export const DataVisualizationColors: StoryObj = {
+/**
+ * LEGACY — superseded. The Paul-Tol `discreteRainbow` scale behind the `data-1..10`
+ * tokens is no longer used by any component; charts and qualitative series now use
+ * the {@link CategoricalPalette} (CVD-safe, nested-stable). Kept only to document the
+ * still-defined `--color-data-N` tokens; see `CategoricalPalette` for current work.
+ */
+export const LegacyDataVisualizationColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Data Visualization Colors
+      <Text className="text-2xl font-bold text-text-primary mb-2">
+        Data Visualization Colors — Legacy
       </Text>
       <Text className="text-text-secondary mb-6">
-        Colors optimized for charts and data visualization. Based on Paul Tol&apos;s color schemes.
+        SUPERSEDED. Paul Tol&apos;s discrete-rainbow scale behind the `data-1..10` tokens — no
+        longer used by any component. Use the Categorical Palette (below) for charts and qualitative
+        series; this is retained only to document the still-defined tokens.
       </Text>
 
       <View style={{ gap: 16 }}>
@@ -263,12 +277,11 @@ function CategoricalRow({ name, colors }: { name: string; colors: readonly strin
 export const TonalRamps: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Tonal Ramps (Foundations)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Tonal Ramps (Foundations)</Text>
       <Text className="text-text-secondary mb-6">
-        Seven OKLCH-generated hue ramps, 11 perceptual steps each (50 → 950). Built with hue-torsion and a
-        chroma arc; amber absorbs the former yellow (lemon → warm body) and cyan absorbs the former steel.
+        Seven OKLCH-generated hue ramps, 11 perceptual steps each (50 → 950). Built with hue-torsion
+        and a chroma arc; amber absorbs the former yellow (lemon → warm body) and cyan absorbs the
+        former steel.
       </Text>
 
       <ColorScale name="Red" colors={primitiveRamps.red} />
@@ -285,14 +298,13 @@ export const TonalRamps: StoryObj = {
 export const CategoricalPalette: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Categorical Palette
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Categorical Palette</Text>
       <Text className="text-text-secondary mb-6">
-        Ordered, colorblind-safe qualitative series (worst-case deut/protanopia floor 8 through the first
-        six colors; the 7th is extended — pair it with a legend). Series index is stable. Use{' '}
-        <Text className="font-semibold">default</Text> on neutral/light surfaces (also legible under black
-        text) and <Text className="font-semibold">dark</Text> where white text sits on the swatch.
+        Ordered, colorblind-safe qualitative series (worst-case deut/protanopia floor 8 through the
+        first six colors; the 7th is extended — pair it with a legend). Series index is stable. Use{' '}
+        <Text className="font-semibold">default</Text> on neutral/light surfaces (also legible under
+        black text) and <Text className="font-semibold">dark</Text> where white text sits on the
+        swatch.
       </Text>
 
       <CategoricalRow name="Default" colors={categoricalPalette.default} />
@@ -304,9 +316,7 @@ export const CategoricalPalette: StoryObj = {
 export const BorderColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">
-        Border Colors (Dark Mode)
-      </Text>
+      <Text className="text-2xl font-bold text-text-primary mb-6">Border Colors (Dark Mode)</Text>
 
       <View style={{ gap: 16 }}>
         <ColorSwatch name="border-default" value={semanticColorsDark['border-default']} />

--- a/packages/ui/src/theme/Colors.stories.tsx
+++ b/packages/ui/src/theme/Colors.stories.tsx
@@ -5,6 +5,8 @@ import {
   discreteRainbow,
   primitiveRamps,
   categoricalPalette,
+  surfaceRampDark,
+  backgroundFrameDark,
 } from './tokens/primitives'
 import { semanticColorsLight, semanticColorsDark } from './tokens/semantic'
 
@@ -15,13 +17,19 @@ const meta: Meta = {
 
 export default meta
 
+/**
+ * Hairline around every swatch, so a swatch whose fill matches the page still
+ * reads as one. Sourced from the token layer rather than a literal — the color
+ * stories should not be where raw hexes creep back in.
+ */
+const SWATCH_BORDER = semanticColorsDark['border-default']
+
 interface ColorSwatchProps {
   name: string
   value: string
-  textColor?: string
 }
 
-function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
+function ColorSwatch({ name, value }: ColorSwatchProps) {
   const displayValue = value.startsWith('rgba') ? value : value.toUpperCase()
 
   return (
@@ -33,7 +41,7 @@ function ColorSwatch({ name, value, textColor = '#FFFFFF' }: ColorSwatchProps) {
           borderRadius: 8,
           backgroundColor: value,
           borderWidth: 1,
-          borderColor: '#374151',
+          borderColor: SWATCH_BORDER,
         }}
       />
       <View>
@@ -58,7 +66,7 @@ function ColorScale({ name, colors }: { name: string; colors: Record<string | nu
                 borderRadius: 8,
                 backgroundColor: color,
                 borderWidth: 1,
-                borderColor: '#374151',
+                borderColor: SWATCH_BORDER,
               }}
             />
             <Text className="text-text-secondary text-xs mt-1">{shade}</Text>
@@ -87,28 +95,69 @@ export const PrimitiveColors: StoryObj = {
   ),
 }
 
+/**
+ * Modifier suffixes a semantic token family can carry.
+ *
+ * Rendered as a matrix rather than a flat swatch list: the useful question is
+ * almost always "what is the subtle/dark form of THIS role", which a flat list
+ * buries. Columns are derived from the shipped tokens, so a new modifier shows
+ * up here without editing the story.
+ */
+const VARIANT_SUFFIXES = ['light', 'dark', 'subtle', 'hover', 'active', 'muted'] as const
+
+function variantsOf(base: string, palette: Record<string, string>) {
+  return [
+    { suffix: 'base', name: base },
+    ...VARIANT_SUFFIXES.map((s) => ({ suffix: s, name: `${base}-${s}` })),
+  ].filter(({ name }) => name in palette)
+}
+
+function VariantMatrix({
+  bases,
+  palette,
+}: {
+  bases: readonly string[]
+  palette: Record<string, string>
+}) {
+  return (
+    <View style={{ gap: 20 }}>
+      {bases.map((base) => (
+        <View key={base}>
+          <Text className="font-semibold text-text-primary text-sm mb-2">{base}</Text>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 10 }}>
+            {variantsOf(base, palette).map(({ suffix, name }) => (
+              <View key={name} style={{ alignItems: 'center', width: 76 }}>
+                <View
+                  style={{
+                    width: 76,
+                    height: 44,
+                    borderRadius: 6,
+                    backgroundColor: palette[name],
+                    borderWidth: 1,
+                    borderColor: SWATCH_BORDER,
+                  }}
+                />
+                <Text className="text-text-secondary text-xs mt-1">{suffix}</Text>
+                <Text className="text-text-tertiary text-xs">{palette[name].toUpperCase()}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  )
+}
+
 export const BrandColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">Brand Colors</Text>
-
-      <View style={{ gap: 16 }}>
-        <ColorSwatch name="brand-primary" value={semanticColorsLight['brand-primary']} />
-        <ColorSwatch
-          name="brand-primary-light"
-          value={semanticColorsLight['brand-primary-light']}
-        />
-        <ColorSwatch name="brand-primary-dark" value={semanticColorsLight['brand-primary-dark']} />
-        <ColorSwatch name="brand-secondary" value={semanticColorsLight['brand-secondary']} />
-        <ColorSwatch
-          name="brand-secondary-light"
-          value={semanticColorsLight['brand-secondary-light']}
-        />
-        <ColorSwatch
-          name="brand-secondary-dark"
-          value={semanticColorsLight['brand-secondary-dark']}
-        />
-      </View>
+      <Text className="text-2xl font-bold text-text-primary mb-2">Brand Colors</Text>
+      <Text className="text-text-secondary mb-6">
+        Each brand role and its modifiers. <Text className="font-semibold">hover</Text> and{' '}
+        <Text className="font-semibold">active</Text> are interaction states —{' '}
+        <Text className="font-semibold">subtle</Text> is a tint for fills behind text.
+      </Text>
+      <VariantMatrix bases={['brand-primary', 'brand-secondary']} palette={semanticColorsLight} />
     </View>
   ),
 }
@@ -116,14 +165,23 @@ export const BrandColors: StoryObj = {
 export const StatusColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">Status Colors</Text>
-
-      <View style={{ gap: 16 }}>
-        <ColorSwatch name="status-success" value={semanticColorsLight['status-success']} />
-        <ColorSwatch name="status-error" value={semanticColorsLight['status-error']} />
-        <ColorSwatch name="status-warning" value={semanticColorsLight['status-warning']} />
-        <ColorSwatch name="status-info" value={semanticColorsLight['status-info']} />
-      </View>
+      <Text className="text-2xl font-bold text-text-primary mb-2">Status Colors</Text>
+      <Text className="text-text-secondary mb-6">
+        Status roles and their modifiers. <Text className="font-semibold">status-error-vivid</Text>{' '}
+        is a separate, higher-chroma role (not a modifier of status-error) reserved for destructive
+        emphasis.
+      </Text>
+      <VariantMatrix
+        bases={[
+          'status-success',
+          'status-error',
+          'status-error-vivid',
+          'status-warning',
+          'status-info',
+          'status-live',
+        ]}
+        palette={semanticColorsLight}
+      />
     </View>
   ),
 }
@@ -139,24 +197,94 @@ export const TextColors: StoryObj = {
         <ColorSwatch name="text-tertiary" value={semanticColorsDark['text-tertiary']} />
         <ColorSwatch name="text-disabled" value={semanticColorsDark['text-disabled']} />
         <ColorSwatch name="text-link" value={semanticColorsDark['text-link']} />
+        <ColorSwatch name="text-link-hover" value={semanticColorsDark['text-link-hover']} />
+        <ColorSwatch name="text-inverse" value={semanticColorsDark['text-inverse']} />
       </View>
     </View>
   ),
 }
 
+/**
+ * The dark surface ramp, darkest plane first.
+ *
+ * Order and `lStar` mirror `surfaceRampDark` in tokens/primitives.ts, plus the
+ * out-of-ramp `backgroundFrameDark` bezel that sits below it. Written as an
+ * explicit ordered list because object key order is not a contract and depth
+ * order is the whole point of this story. `surface.coverage.test.ts` asserts
+ * every ramp step appears here.
+ */
+const SURFACE_PLANES = [
+  { hex: backgroundFrameDark, lStar: 3.79, role: 'Frame / bezel — chrome outside the ramp' },
+  { hex: surfaceRampDark.inset, lStar: 4.5, role: 'Sub-shell well / pressed' },
+  { hex: surfaceRampDark.background, lStar: 9, role: 'Shell' },
+  { hex: surfaceRampDark.base, lStar: 13.5, role: 'Main content plane' },
+  { hex: surfaceRampDark.elevated, lStar: 17, role: 'Nav / rail' },
+  { hex: surfaceRampDark.raised, lStar: 20, role: 'Cards' },
+  { hex: surfaceRampDark.overlay, lStar: 22.5, role: 'Hero / popover' },
+] as const
+
+/** Semantic tokens resolving to `hex`, derived at render so the mapping can't drift. */
+function tokensResolvingTo(hex: string): string[] {
+  return Object.entries(semanticColorsDark)
+    .filter(([name, value]) => /^(surface|background)-/.test(name) && value === hex)
+    .map(([name]) => name)
+    .sort()
+}
+
+function SurfacePlaneRow({ hex, lStar, role }: { hex: string; lStar: number; role: string }) {
+  const tokens = tokensResolvingTo(hex)
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+      <View
+        style={{
+          width: 96,
+          height: 56,
+          borderRadius: 8,
+          backgroundColor: hex,
+          borderWidth: 1,
+          borderColor: SWATCH_BORDER,
+        }}
+      />
+      <View style={{ flex: 1 }}>
+        <Text className="font-semibold text-text-primary text-sm">
+          {hex.toUpperCase()}{' '}
+          <Text className="text-text-tertiary text-xs font-normal">L*{lStar}</Text>
+        </Text>
+        <Text className="text-text-secondary text-xs">{role}</Text>
+        <Text className="text-text-tertiary text-xs mt-1">
+          {tokens.length > 0 ? tokens.join(' · ') : '— no semantic alias'}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
 export const SurfaceColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">Surface Colors (Dark Mode)</Text>
+      <Text className="text-2xl font-bold text-text-primary mb-2">Surface Ramp (Dark Mode)</Text>
+      <Text className="text-text-secondary mb-6">
+        Depth is an <Text className="font-semibold">ordered ramp</Text>, not a set of unrelated
+        fills — planes are spaced by perceptual lightness (L*), so &quot;one step up&quot; is the
+        same visual distance anywhere in the stack. Listed darkest first. Several semantic tokens
+        deliberately share a plane (shown per row); that aliasing is what lets a component say what
+        it <Text className="italic">is</Text> rather than how deep it sits.
+      </Text>
 
-      <View style={{ gap: 16 }}>
-        <ColorSwatch name="surface-base" value={semanticColorsDark['surface-base']} />
-        <ColorSwatch name="surface-elevated" value={semanticColorsDark['surface-elevated']} />
-        <ColorSwatch name="surface-raised" value={semanticColorsDark['surface-raised']} />
-        <ColorSwatch name="surface-input" value={semanticColorsDark['surface-input']} />
-        <ColorSwatch name="background-base" value={semanticColorsDark['background-base']} />
-        <ColorSwatch name="background-default" value={semanticColorsDark['background-default']} />
+      <View style={{ gap: 14 }}>
+        {SURFACE_PLANES.map((plane) => (
+          <SurfacePlaneRow key={plane.hex} {...plane} />
+        ))}
       </View>
+
+      <Text className="text-text-secondary text-xs mt-8">
+        To apply these at runtime use{' '}
+        <Text className="font-semibold text-text-primary">&lt;Surface level&gt;</Text> and{' '}
+        <Text className="font-semibold text-text-primary">useOnSurfaceColor</Text> rather than
+        reading tokens directly — see Components/Atoms/Surface. Shadow and glow treatments layered
+        on top of these planes are in Foundations/Shadows; the legacy numeric elevation scale is in
+        Foundations/Elevation.
+      </Text>
     </View>
   ),
 }
@@ -164,32 +292,17 @@ export const SurfaceColors: StoryObj = {
 export const ResultColors: StoryObj = {
   render: () => (
     <View style={{ padding: 24 }}>
-      <Text className="text-2xl font-bold text-text-primary mb-6">Result/Outcome Colors</Text>
+      <Text className="text-2xl font-bold text-text-primary mb-2">Result/Outcome Colors</Text>
       <Text className="text-text-secondary mb-6">
-        Colors for indicating positive, negative, or neutral outcomes.
+        Colors for indicating positive, negative, or neutral outcomes. Distinct from status: these
+        encode the <Text className="italic">direction of a change</Text> (did this get better?), not
+        a system state.
       </Text>
 
-      <View style={{ gap: 16 }}>
-        <ColorSwatch name="result-improve" value={semanticColorsLight['result-improve']} />
-        <ColorSwatch
-          name="result-improve-light"
-          value={semanticColorsLight['result-improve-light']}
-        />
-        <ColorSwatch name="result-degrade" value={semanticColorsLight['result-degrade']} />
-        <ColorSwatch
-          name="result-degrade-light"
-          value={semanticColorsLight['result-degrade-light']}
-        />
-        <ColorSwatch
-          name="result-inconclusive"
-          value={semanticColorsLight['result-inconclusive']}
-        />
-        <ColorSwatch
-          name="result-inconclusive-light"
-          value={semanticColorsLight['result-inconclusive-light']}
-        />
-        <ColorSwatch name="result-neutral" value={semanticColorsLight['result-neutral']} />
-      </View>
+      <VariantMatrix
+        bases={['result-improve', 'result-degrade', 'result-inconclusive', 'result-neutral']}
+        palette={semanticColorsLight}
+      />
     </View>
   ),
 }
@@ -215,13 +328,13 @@ export const LegacyDataVisualizationColors: StoryObj = {
       <View style={{ gap: 16 }}>
         <ColorSwatch name="data-1" value={semanticColorsLight['data-1']} />
         <ColorSwatch name="data-2" value={semanticColorsLight['data-2']} />
-        <ColorSwatch name="data-3" value={semanticColorsLight['data-3']} textColor="#000000" />
+        <ColorSwatch name="data-3" value={semanticColorsLight['data-3']} />
         <ColorSwatch name="data-4" value={semanticColorsLight['data-4']} />
         <ColorSwatch name="data-5" value={semanticColorsLight['data-5']} />
         <ColorSwatch name="data-6" value={semanticColorsLight['data-6']} />
-        <ColorSwatch name="data-7" value={semanticColorsLight['data-7']} textColor="#000000" />
-        <ColorSwatch name="data-8" value={semanticColorsLight['data-8']} textColor="#000000" />
-        <ColorSwatch name="data-9" value={semanticColorsLight['data-9']} textColor="#000000" />
+        <ColorSwatch name="data-7" value={semanticColorsLight['data-7']} />
+        <ColorSwatch name="data-8" value={semanticColorsLight['data-8']} />
+        <ColorSwatch name="data-9" value={semanticColorsLight['data-9']} />
         <ColorSwatch name="data-10" value={semanticColorsLight['data-10']} />
       </View>
 
@@ -238,7 +351,7 @@ export const LegacyDataVisualizationColors: StoryObj = {
               borderRadius: 4,
               backgroundColor: color,
               borderWidth: 1,
-              borderColor: '#374151',
+              borderColor: SWATCH_BORDER,
             }}
           />
         ))}
@@ -263,7 +376,7 @@ function CategoricalRow({ name, colors }: { name: string; colors: readonly strin
                 borderRadius: 8,
                 backgroundColor: color,
                 borderWidth: 1,
-                borderColor: '#374151',
+                borderColor: SWATCH_BORDER,
               }}
             />
             <Text className="text-text-secondary text-xs mt-1">{color.toUpperCase()}</Text>
@@ -322,6 +435,7 @@ export const BorderColors: StoryObj = {
         <ColorSwatch name="border-default" value={semanticColorsDark['border-default']} />
         <ColorSwatch name="border-subtle" value={semanticColorsDark['border-subtle']} />
         <ColorSwatch name="border-strong" value={semanticColorsDark['border-strong']} />
+        <ColorSwatch name="border-prominent" value={semanticColorsDark['border-prominent']} />
         <ColorSwatch name="border-focus" value={semanticColorsDark['border-focus']} />
         <ColorSwatch name="border-input" value={semanticColorsDark['border-input']} />
         <ColorSwatch name="border-input-hover" value={semanticColorsDark['border-input-hover']} />

--- a/packages/ui/src/theme/color-stories.coverage.test.ts
+++ b/packages/ui/src/theme/color-stories.coverage.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { surfaceRampDark, backgroundFrameDark } from './tokens/primitives'
+import { semanticColorsDark } from './tokens/semantic'
+
+/**
+ * Drift guard for the Foundations/Color stories (VW-33).
+ *
+ * The color stories are the documentation of record for the token layer, and
+ * they have drifted twice: once when the categorical palette replaced the
+ * Paul-Tol scale, and again when the v0.10.0 surface redesign added four
+ * planes (`surface-inset`, `surface-overlay`, `background-frame`,
+ * `background-subtle`) that no story rendered. Both times the values stayed
+ * correct while the *coverage* silently fell behind — which a screenshot test
+ * cannot catch, because a story that was never written renders nothing.
+ *
+ * Two invariants, deliberately different in kind:
+ *
+ *  1. STRUCTURAL — every `surface-*`/`background-*` token resolves to a plane
+ *     in the shipped ramp. Catches a token added off-ramp (an arbitrary fill),
+ *     which is the failure the ordered-ramp story exists to prevent.
+ *  2. COVERAGE — every other semantic token is named somewhere in the color
+ *     stories, so a new token cannot ship without a swatch.
+ *
+ * The story files are read as TEXT, never imported: they pull in react-native
+ * and nativewind, which throw under the node test environment.
+ */
+
+const themeDir = path.dirname(fileURLToPath(import.meta.url))
+const storySources = ['Colors.stories.tsx', 'ColorSystem.stories.tsx']
+  .map((f) => readFileSync(path.join(themeDir, f), 'utf8'))
+  .join('\n')
+
+/** Every plane a surface/background token is allowed to land on. */
+const RAMP_PLANES = new Set<string>([...Object.values(surfaceRampDark), backgroundFrameDark])
+
+/**
+ * Token families the color stories are NOT the documentation of record for,
+ * with the story that owns them instead. Add here only with a real owner —
+ * the point of this list is that nothing falls through unowned.
+ */
+const DOCUMENTED_ELSEWHERE: Record<string, string> = {
+  hairline: 'Components/Atoms/Surface (rendered as separators, not swatches)',
+  on: 'Components/Atoms/Surface — OnSurfaceText (paired with their surface)',
+  interactive: 'Components/* (state colors are shown on the components themselves)',
+  avatar: 'Components/Atoms/Avatar',
+  divider: 'Foundations/Color/Palette — BorderColors (border-* family)',
+}
+
+const isSurfaceToken = (name: string) => /^(surface|background)-/.test(name)
+
+/** Must mirror VARIANT_SUFFIXES in Colors.stories.tsx (asserted below). */
+const VARIANT_SUFFIXES = ['light', 'dark', 'subtle', 'hover', 'active', 'muted'] as const
+
+describe('Foundations/Color story coverage', () => {
+  it('every surface/background token resolves to a plane in the shipped ramp', () => {
+    const offRamp = Object.entries(semanticColorsDark)
+      .filter(([name]) => isSurfaceToken(name))
+      .filter(([, value]) => !RAMP_PLANES.has(value as string))
+      .map(([name, value]) => `${name}=${value as string}`)
+
+    expect(
+      offRamp,
+      'surface/background tokens whose value is not a step of surfaceRampDark ' +
+        '(or the backgroundFrameDark bezel). Either fold the value into the ramp, ' +
+        'or add the plane to SURFACE_PLANES in Colors.stories.tsx and document why ' +
+        'it sits outside the ramp.'
+    ).toEqual([])
+  })
+
+  it("the test's VARIANT_SUFFIXES mirror still matches the story", () => {
+    // The coverage rule below depends on this list matching the one the story
+    // renders from; if they drift, coverage silently over- or under-reports.
+    const declared = storySources.match(/const VARIANT_SUFFIXES = \[([^\]]*)\]/)
+    expect(declared, 'VARIANT_SUFFIXES not found in Colors.stories.tsx').not.toBeNull()
+    const fromStory = [...declared![1].matchAll(/'([a-z]+)'/g)].map((m) => m[1])
+    expect(fromStory).toEqual([...VARIANT_SUFFIXES])
+  })
+
+  it('the surface story renders every ramp plane', () => {
+    // SURFACE_PLANES is built from the ramp exports, so covering the exports
+    // is what proves no plane is missing from the rendered ladder.
+    const referenced = [
+      'surfaceRampDark.inset',
+      'surfaceRampDark.background',
+      'surfaceRampDark.base',
+      'surfaceRampDark.elevated',
+      'surfaceRampDark.raised',
+      'surfaceRampDark.overlay',
+      'backgroundFrameDark',
+    ]
+    const missing = referenced.filter((ref) => !storySources.includes(ref))
+
+    expect(missing, 'ramp planes absent from the SURFACE_PLANES ladder').toEqual([])
+    // Guard the count too: a step added to the ramp must gain a row.
+    expect(Object.keys(surfaceRampDark)).toHaveLength(6)
+  })
+
+  it('every other semantic token is named in a color story', () => {
+    // A token is covered if the story names it literally, or if it is the
+    // `-light`/`-subtle`/… variant of a base the story feeds to VariantMatrix
+    // (which builds those names at runtime, so they never appear as literals).
+    const namedLiterally = (token: string) => storySources.includes(`'${token}'`)
+    const coveredByMatrix = (token: string) =>
+      VARIANT_SUFFIXES.some(
+        (suffix) =>
+          token.endsWith(`-${suffix}`) && namedLiterally(token.slice(0, -(suffix.length + 1)))
+      )
+
+    const undocumented = Object.keys(semanticColorsDark)
+      .filter((name) => !isSurfaceToken(name))
+      .filter((name) => !DOCUMENTED_ELSEWHERE[name.split('-')[0]])
+      .filter((name) => !namedLiterally(name) && !coveredByMatrix(name))
+
+    expect(
+      undocumented,
+      'semantic tokens with no swatch in Foundations/Color. Add one (a plain ' +
+        'ColorSwatch, or the base to a VariantMatrix), or add the family to ' +
+        'DOCUMENTED_ELSEWHERE with the story that owns it.'
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Colors half of the Storybook organization/hardening pass. Supersedes **#102**, which was 26 commits behind and predated the v0.10.0 surface redesign by 12 days — its commit is recovered here (see below), so **#102 can be closed**.

## The drift this closes

The color stories are the documentation of record for the token layer, and they have drifted twice — once when the categorical palette replaced the Paul-Tol scale, and again when v0.10.0 re-spaced the surface ramp. Both times the **values stayed correct while coverage fell behind**, which is exactly what screenshot tests cannot catch: a story that was never written renders nothing.

### Surface ramp
`SurfaceColors` rendered **6 of the 10** shipped surface/background tokens, as an unordered swatch list. It is now an ordered ladder (darkest first) with L\* and plane role, covering all 10 — adding `surface-inset`, `surface-overlay`, `background-frame`, `background-subtle`. Tokens sharing a plane are derived per row, so the aliasing can't go stale.

### Variant matrix
**29 shipped tokens had no swatch anywhere** — the `-light`/`-dark`/`-subtle`/`-hover`/`-active` modifiers of brand, status and result. Rendered as a matrix keyed by role rather than 29 more flat swatches, because the real question is "what is the subtle form of *this* role". Columns derive from the shipped tokens, so a new modifier appears without editing the story.

### IA
The four overlapping depth surfaces (`Color/SurfaceColors`, `Foundations/Elevation`, `Foundations/Shadows`, `Components/Atoms/Surface`) now cross-reference each other. **Nothing was deleted** — I checked, and elevation and neumorphic shadows are still consumed by Card, Surface, ToolbarButton, SessionRail and the Workout cards.

## The guard

New `color-stories.coverage.test.ts`, with two invariants that are different in kind:

1. **Structural** — every `surface-*`/`background-*` token resolves to a step of the shipped ramp. Catches a token added *off*-ramp.
2. **Coverage** — every other semantic token is named in a story, with an explicit `DOCUMENTED_ELSEWHERE` map so nothing falls through unowned.

**Both were verified non-vacuous** — each assertion was confirmed to fail when its invariant is deliberately broken (dropping a matrix base surfaced the base *and* its derived variants; pointing a surface token off-ramp was caught with an actionable message). Story files are read as **text, never imported**: they pull in react-native and nativewind, which throw under the node test environment.

## Recovered from #102

Its three real fixes, rebased onto current main: `SEM` sourced from `getSemanticColors` + the extracted-colors modules; the RPE swatch corrected to `WORKOUT_TOKENS.scale` (was `sequentialEffort[5]` = red-**700**, vs the red-**600** production actually uses); retired Paul-Tol story renamed `LegacyDataVisualizationColors`. Where main had since moved ahead independently — the `t['surface-raised']` substitution — **main's version is kept**. Most of #102's remaining diff was prettier reformatting.

## Housekeeping

Removed the last raw hexes from this file (swatch borders now use `border-default`; dropped an unused `textColor` prop that carried a literal `#FFFFFF`) so the color stories aren't themselves a source of the drift they document.

## Verification
`tsc --noEmit` clean · `eslint` clean · `prettier --check` clean · **2602/2602 tests** across 130 files, including the 717-story smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)