### PR TITLE
Ratcheted no-raw-color lint rule (blocks new colour, burns down the existing 470)

### DIFF
--- a/packages/ui/eslint-rules/no-raw-color.js
+++ b/packages/ui/eslint-rules/no-raw-color.js
@@ -1,0 +1,101 @@
+/**
+ * ESLint rule: no-raw-color
+ *
+ * Colour in titan has exactly one source of truth: the OKLCH tonal ramps, and
+ * the semantic tokens that reference them. A raw colour written into a component
+ * bypasses that — it can't respond to a theme, can't be audited for contrast or
+ * colourblind safety, and won't move when the ramps are re-spaced. The v0.10.0
+ * surface work made that concrete: re-spacing the dark ramp updated every
+ * tokenised surface automatically and left every hardcoded one behind.
+ *
+ * RATCHET, not a wall. There are existing violations, and a rule that fails on
+ * all of them would simply be switched off. So each file carries an allowance in
+ * `raw-color-baseline.json`: occurrences up to that count pass, and the first
+ * one beyond it fails. New colour can't get in, and the backlog can be burned
+ * down file by file without a flag day.
+ *
+ * Regenerate after burning some down:  node scripts/update-raw-color-baseline.mjs
+ * The generator shares its detection with this rule (raw-color-patterns.js), so
+ * the baseline always describes what the rule actually counts.
+ *
+ * NOT flagged, deliberately:
+ *   - `transparent` — encodes absence, has no token equivalent
+ *   - `currentColor` — defers to the cascade, which is the desired behaviour
+ *   - anything in `src/theme/**` — that IS the colour system
+ */
+
+const path = require('node:path')
+const { extractRawColors } = require('./raw-color-patterns')
+
+let baselineCache = null
+function loadBaseline() {
+  if (baselineCache) return baselineCache
+  try {
+    baselineCache = require('./raw-color-baseline.json')
+  } catch {
+    baselineCache = {}
+  }
+  return baselineCache
+}
+
+/** Baseline keys are package-relative POSIX paths, so they're stable across machines. */
+function baselineKey(context) {
+  const cwd = context.getCwd?.() ?? process.cwd()
+  return path
+    .relative(cwd, context.filename ?? context.getFilename())
+    .split(path.sep)
+    .join('/')
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow raw colour values outside the theme layer; use semantic tokens or ramp references.',
+    },
+    schema: [],
+    messages: {
+      hex: 'Raw hex colour. Use a semantic token (getSemanticColors / Surface / a className) so this follows the ramps and the theme.',
+      functional:
+        'Raw {{ notation }} colour. For translucency, derive it from a token (alpha(token, n)) rather than hardcoding channels.',
+      twPalette:
+        'Tailwind palette colour. titan ships its own ramps — use a semantic utility (bg-surface-raised, text-text-primary) instead of Tailwind’s default palette.',
+      twAchromatic:
+        'Tailwind white/black. Use a semantic token — pure white/black are almost never right on the dark ramp.',
+      twArbitrary:
+        'Arbitrary Tailwind colour value. This bypasses the token layer entirely; use a semantic utility.',
+      named: 'Bare CSS colour keyword. Use a semantic token so this responds to the theme.',
+    },
+  },
+
+  create(context) {
+    // Remaining allowance per colour VALUE, not a plain count. Keying on the
+    // value means the message lands on the colour you just added rather than on
+    // whichever grandfathered literal happened to sit at the count boundary.
+    const remaining = new Map(Object.entries(loadBaseline()[baselineKey(context)] ?? {}))
+
+    const check = (text, node, loc) => {
+      for (const { value, id } of extractRawColors(text)) {
+        const left = remaining.get(value) ?? 0
+        if (left > 0) {
+          remaining.set(value, left - 1)
+          continue
+        }
+        const data = { notation: id === 'functional' ? 'functional' : id }
+        context.report(loc ? { loc, messageId: id, data } : { node, messageId: id, data })
+        return // one message per literal is enough to act on
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') check(node.value, node)
+      },
+      TemplateElement(node) {
+        check(node.value.raw, node)
+      },
+    }
+  },
+}

--- a/packages/ui/eslint-rules/raw-color-baseline.json
+++ b/packages/ui/eslint-rules/raw-color-baseline.json
@@ -1,0 +1,471 @@
+{
+  "src/arch/Architecture.stories.tsx": {
+    "rgba(": 1
+  },
+  "src/components/custom/CircularTimer/CircularTimer.stories.tsx": {
+    "#0e0e0e": 1,
+    "#dadada": 1,
+    "rgba(": 1
+  },
+  "src/components/custom/EmptyState/EmptyState.stories.tsx": {
+    "text-white": 1
+  },
+  "src/components/custom/Gauge/Gauge.stories.tsx": {
+    "#5b9bd5": 1
+  },
+  "src/components/custom/Gauge/Gauge.tsx": {
+    "rgba(": 1
+  },
+  "src/components/custom/Scatter/Scatter.stories.tsx": {
+    "#14b8a6": 2,
+    "#5b9bd5": 2,
+    "#f4a736": 1,
+    "#f83030": 2
+  },
+  "src/components/custom/Scatter/Scatter.tsx": {
+    "#ffffff": 1,
+    "rgba(": 3
+  },
+  "src/components/custom/Sidebar/Sidebar.stories.tsx": {
+    "text-white": 1
+  },
+  "src/components/custom/stepper/Stepper.tsx": {
+    "text-white": 1
+  },
+  "src/components/custom/Table/Table.tsx": {
+    "text-white": 2
+  },
+  "src/components/custom/TimerReadout/TimerReadout.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Treemap/Treemap.stories.tsx": {
+    "#5b9bd5": 3,
+    "#f4a736": 3,
+    "#f83030": 4
+  },
+  "src/components/custom/Treemap/Treemap.tsx": {
+    "[#0b0b0b]": 1,
+    "#3a3a3a": 1,
+    "#ffffff": 1
+  },
+  "src/components/custom/Workout/ActiveWorkoutPage.stories.tsx": {
+    "#22d3ee": 1
+  },
+  "src/components/custom/Workout/BaseBadge.stories.tsx": {
+    "#9ca3af": 3,
+    "#ff7900": 4
+  },
+  "src/components/custom/Workout/BaseBadge.tsx": {
+    "#1f1f1f": 1,
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/BodyMap.tsx": {
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/BodyMapDetailPanel.stories.tsx": {
+    "#0e0e0e": 2,
+    "#ff7900": 1,
+    "#ffffff": 1
+  },
+  "src/components/custom/Workout/BodyMapDetailPanel.tsx": {
+    "#000000": 1,
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/CapacityBandChart.stories.tsx": {
+    "#9ca3af": 1
+  },
+  "src/components/custom/Workout/CapacityBandChart.tsx": {
+    "#f3f4f6": 1,
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/DeviationBar.tsx": {
+    "#6b7280": 1,
+    "#f3f4f6": 1,
+    "rgba(": 4
+  },
+  "src/components/custom/Workout/ExerciseCard.stories.tsx": {
+    "#121212": 1
+  },
+  "src/components/custom/Workout/ExerciseCardHeading.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/ExerciseDetailPage.tsx": {
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/ExerciseHeading.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/ExerciseIndicator.stories.tsx": {
+    "#131313": 1,
+    "#8a8a8a": 3,
+    "#cfcfcf": 2
+  },
+  "src/components/custom/Workout/FatigueMeter.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/InputBar.stories.tsx": {
+    "#111111": 1
+  },
+  "src/components/custom/Workout/InputBar.tsx": {
+    "#ffffff": 1
+  },
+  "src/components/custom/Workout/IntensityBar.tsx": {
+    "#333333": 1,
+    "#6b7280": 1,
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/LiveAuraFrame.stories.tsx": {
+    "#070707": 1
+  },
+  "src/components/custom/Workout/MesoCard.tsx": {
+    "#1f1f1f": 1,
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/MesoProgressBar.tsx": {
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/MesoStatusCard.tsx": {
+    "rgba(": 15
+  },
+  "src/components/custom/Workout/metricText.stories.tsx": {
+    "#131313": 1,
+    "#6b7280": 4,
+    "#f3f4f6": 4
+  },
+  "src/components/custom/Workout/MuscleGroupChip.tsx": {
+    "#2c2c2c": 2
+  },
+  "src/components/custom/Workout/PlaceholderStrip.stories.tsx": {
+    "#2ed573": 1,
+    "#ffa502": 1,
+    "#ffd43b": 1
+  },
+  "src/components/custom/Workout/PrHistoryModal.stories.tsx": {
+    "#ff7900": 1,
+    "#ffffff": 1
+  },
+  "src/components/custom/Workout/PrHistoryModal.tsx": {
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/ReadinessCheck.tsx": {
+    "#ffffff": 1,
+    "rgba(": 1
+  },
+  "src/components/custom/Workout/RestTimer.stories.tsx": {
+    "#0e0e0e": 1,
+    "#5a5a5a": 1
+  },
+  "src/components/custom/Workout/RestTimer.tsx": {
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/RowInventory.stories.tsx": {
+    "#0c0d0f": 1,
+    "#0f1012": 1,
+    "#131418": 1,
+    "#24262d": 1,
+    "#31343d": 1,
+    "#5b616d": 1,
+    "#8d95a3": 3,
+    "#e8eaed": 3,
+    "#f3f4f6": 2,
+    "#ff6b6b": 1,
+    "#ff7900": 2
+  },
+  "src/components/custom/Workout/S3FullRail.stories.tsx": {
+    "#131313": 1,
+    "#1f1f1f": 1
+  },
+  "src/components/custom/Workout/S3SessionPace.stories.tsx": {
+    "#1c1c1c": 2,
+    "#22252c": 1,
+    "#2c2c2c": 1,
+    "rgba(": 4
+  },
+  "src/components/custom/Workout/S3SetTypes.stories.tsx": {
+    "#0b3149": 1,
+    "#112c5a": 1,
+    "#14407e": 1
+  },
+  "src/components/custom/Workout/S3WorkoutExpansion.stories.tsx": {
+    "#2c2c2c": 1,
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/SegmentedBar.stories.tsx": {
+    "#01b5d1": 2,
+    "#131313": 1,
+    "#2ed573": 3,
+    "#d14343": 2,
+    "#f9b415": 3,
+    "#ff7900": 1,
+    "#ffffff": 1
+  },
+  "src/components/custom/Workout/SegmentedProgressBar.stories.tsx": {
+    "#242424": 1
+  },
+  "src/components/custom/Workout/SessionRail.stories.tsx": {
+    "#6b7280": 1
+  },
+  "src/components/custom/Workout/SetBar.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/setHeadingKit.tsx": {
+    "#0a0a0a": 1,
+    "#131313": 1,
+    "#1c1c1c": 1,
+    "#1f1f1f": 1,
+    "#2196f3": 1,
+    "#21c05d": 1,
+    "#2c2c2c": 1,
+    "#2ed573": 1,
+    "#58f69e": 1,
+    "#6b7280": 2,
+    "#9ca3af": 1,
+    "#a4221c": 1,
+    "#d14343": 1,
+    "#da5f00": 1,
+    "#e05254": 1,
+    "#e08c00": 1,
+    "#f3f4f6": 1,
+    "#f9b415": 1,
+    "#ff7900": 1,
+    "#ffa063": 1,
+    "#ffd352": 1,
+    "rgba(": 3
+  },
+  "src/components/custom/Workout/SetRow.tsx": {
+    "rgba(": 1
+  },
+  "src/components/custom/Workout/SetsRepsLoad.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/SetStrip.stories.tsx": {
+    "#131313": 1,
+    "#6b7280": 1,
+    "#f3f4f6": 1
+  },
+  "src/components/custom/Workout/SetTableHeader.stories.tsx": {
+    "#131313": 1
+  },
+  "src/components/custom/Workout/Sparkline.stories.tsx": {
+    "#2ed573": 3,
+    "#ff4757": 3,
+    "#ffa502": 2,
+    "#ffd43b": 2
+  },
+  "src/components/custom/Workout/StatusDot.tsx": {
+    "#0a5c52": 1,
+    "#5c1a1a": 1,
+    "#6b4000": 1,
+    "#6b7280": 2,
+    "#9ca3af": 1,
+    "#d1d5db": 1,
+    "rgba(": 13
+  },
+  "src/components/custom/Workout/StrengthTrendChart.stories.tsx": {
+    "#9ca3af": 1
+  },
+  "src/components/custom/Workout/StrengthTrendChart.tsx": {
+    "rgba(": 6
+  },
+  "src/components/custom/Workout/SupersetWrapper.stories.tsx": {
+    "#22c55e": 1,
+    "#f3f4f6": 6,
+    "#ff7900": 2
+  },
+  "src/components/custom/Workout/TempoDisplay.stories.tsx": {
+    "#9ca3af": 2,
+    "#e5e7eb": 1
+  },
+  "src/components/custom/Workout/TempoDisplay.tsx": {
+    "#2c2c2c": 2,
+    "#6b7280": 1,
+    "#9ca3af": 4
+  },
+  "src/components/custom/Workout/VelocityStrip.modalities.stories.tsx": {
+    "#0a0a0a": 1,
+    "#22465f": 1,
+    "#22d3ee": 1,
+    "#2a2a2e": 4
+  },
+  "src/components/custom/Workout/VelocityStrip.responsive.stories.tsx": {
+    "#2a2a2e": 1
+  },
+  "src/components/custom/Workout/VelocityStrip.stories.tsx": {
+    "#0e0e0e": 2,
+    "#5a5a5a": 2,
+    "#9ca3af": 1
+  },
+  "src/components/custom/Workout/WeekRow.tsx": {
+    "rgba(": 2
+  },
+  "src/components/custom/Workout/WeightBadge.tsx": {
+    "#9ca3af": 1
+  },
+  "src/components/custom/Workout/WorkoutCard.tsx": {
+    "#1f1f1f": 1,
+    "rgba(": 1
+  },
+  "src/components/custom/Workout/WorkoutPill.tsx": {
+    "#1f1f1f": 1,
+    "#6b7280": 1,
+    "rgba(": 10
+  },
+  "src/components/custom/Workout/ZoneTrack.stories.tsx": {
+    "#131313": 1,
+    "rgba(": 1
+  },
+  "src/components/shell/DashboardShell.stories.tsx": {
+    "#0e0e0e": 1,
+    "#8a8a8a": 1,
+    "#e5e5e5": 1
+  },
+  "src/components/shell/SessionRailSpecimen.stories.tsx": {
+    "#0f1012": 1,
+    "#101113": 1,
+    "#131418": 1,
+    "#141519": 1,
+    "#17181c": 1,
+    "#1e2025": 1,
+    "#2196f3": 1,
+    "#22252c": 2,
+    "#24262d": 1,
+    "#2a2d34": 1,
+    "#2ed573": 2,
+    "#31343d": 1,
+    "#3a3d44": 1,
+    "#5b616d": 1,
+    "#8d95a3": 1,
+    "#b8bec9": 1,
+    "#e8eaed": 1,
+    "#ff4757": 2,
+    "#ff7900": 2,
+    "#ffa502": 1,
+    "#ffb020": 1,
+    "#ffd43b": 1,
+    "rgba(": 11
+  },
+  "src/components/ui/alert/Alert.stories.tsx": {
+    "#0e0e0e": 2,
+    "#5a5a5a": 2
+  },
+  "src/components/ui/alert/Alert.tsx": {
+    "bg-black": 2,
+    "text-white": 3
+  },
+  "src/components/ui/button/Button.tsx": {
+    "#ffffff": 6,
+    "text-white": 6
+  },
+  "src/components/ui/card/Card.tsx": {
+    "#fafafa": 1
+  },
+  "src/components/ui/checkbox/Checkbox.tsx": {
+    "bg-white": 2
+  },
+  "src/components/ui/chip/Chip.tsx": {
+    "bg-black": 2,
+    "bg-neutral-100": 1,
+    "bg-neutral-600": 1,
+    "bg-neutral-800": 1,
+    "border-neutral-300": 1,
+    "border-neutral-600": 1,
+    "text-neutral-200": 2,
+    "text-neutral-700": 2,
+    "text-white": 7
+  },
+  "src/components/ui/data-row/DataRow.stories.tsx": {
+    "#22c55e": 1,
+    "#fff": 1
+  },
+  "src/components/ui/drawer/Drawer.tsx": {
+    "bg-black": 1
+  },
+  "src/components/ui/indicator/Indicator.stories.tsx": {
+    "#45b7d1": 1,
+    "#4ecdc4": 1,
+    "#ff6b6b": 1
+  },
+  "src/components/ui/list-item/ListItem.stories.tsx": {
+    "#22c55e": 1,
+    "#6366f1": 1,
+    "#9ca3af": 1,
+    "#fff": 1
+  },
+  "src/components/ui/modal/Modal.tsx": {
+    "bg-black": 2
+  },
+  "src/components/ui/popover/Popover.stories.tsx": {
+    "text-white": 1
+  },
+  "src/components/ui/radio/Radio.tsx": {
+    "bg-white": 1
+  },
+  "src/components/ui/section/Section.stories.tsx": {
+    "#6366f1": 3,
+    "#a0a0a0": 7
+  },
+  "src/components/ui/select/Select.stories.tsx": {
+    "blue": 2,
+    "green": 2,
+    "red": 2,
+    "yellow": 2
+  },
+  "src/components/ui/select/Select.tsx": {
+    "bg-black": 1,
+    "text-white": 1
+  },
+  "src/components/ui/spinner/Spinner.stories.tsx": {
+    "white": 2
+  },
+  "src/components/ui/spinner/Spinner.tsx": {
+    "#6b7280": 1,
+    "#ffffff": 1,
+    "white": 1
+  },
+  "src/components/ui/stack/Stack.stories.tsx": {
+    "text-neutral-400": 3,
+    "text-white": 4
+  },
+  "src/components/ui/surface/Surface.stories.tsx": {
+    "#111": 1,
+    "#22c55e": 1,
+    "#ef4444": 1,
+    "#f3f4f6": 1,
+    "#ff7900": 3,
+    "#fff": 8
+  },
+  "src/components/ui/switch/Switch.tsx": {
+    "bg-white": 1
+  },
+  "src/components/ui/tabs/Tabs.tsx": {
+    "text-white": 2
+  },
+  "src/components/ui/toolbar-button/ToolbarButton.stories.tsx": {
+    "#1f1f1f": 1,
+    "#3c3c3c": 2,
+    "#6e6e6e": 4,
+    "#d1d1d1": 1,
+    "#ff7900": 1,
+    "#ffffff": 1
+  },
+  "src/components/ui/toolbar-button/ToolbarButton.tsx": {
+    "[#d1d1d1]": 1,
+    "#2c2c2c": 1,
+    "#3c3c3c": 1,
+    "#6e6e6e": 1,
+    "#d1d1d1": 1,
+    "#ffffff": 1,
+    "rgba(": 1,
+    "text-white": 1
+  },
+  "src/components/ui/tooltip/Tooltip.tsx": {
+    "bg-neutral-800": 1,
+    "text-white": 1
+  },
+  "src/lab/north-star/LiveWallDashboard.stories.tsx": {
+    "#0e0e0e": 1
+  },
+  "src/stories/PresetShowcase.stories.tsx": {
+    "text-white": 1
+  }
+}

--- a/packages/ui/eslint-rules/raw-color-patterns.js
+++ b/packages/ui/eslint-rules/raw-color-patterns.js
@@ -1,0 +1,90 @@
+/**
+ * Raw-colour detection, shared by the `no-raw-color` ESLint rule and the script
+ * that regenerates its baseline.
+ *
+ * Deliberately one module: if the rule and the generator drifted apart, the
+ * baseline would stop describing what the rule actually counts, and the ratchet
+ * would quietly stop ratcheting.
+ *
+ * Hex is only one way a colour reaches the screen, so this covers the notations
+ * that actually appear in a React Native + nativewind codebase: functional CSS
+ * colours, Tailwind palette utilities, and the handful of bare CSS keywords that
+ * get typed out of habit. `oklch`/`lab`/`lch` have no occurrences today and are
+ * included so the first one is caught rather than grandfathered.
+ */
+
+/** `#abc`, `#abcd`, `#aabbcc`, `#aabbccdd`. */
+const HEX = /#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/
+
+/** `rgb(...)`, `rgba(...)`, `hsl(...)`, `hsla(...)`, `oklch(...)`, `lab(...)`, `lch(...)`. */
+const FUNCTIONAL = /\b(?:rgba?|hsla?|oklch|oklab|lab|lch|color-mix)\s*\(/
+
+/** Tailwind palette utility: `bg-red-500`, `text-slate-200`, `ring-cyan-400`. */
+const TW_PALETTE =
+  /\b(?:bg|text|border|from|via|to|fill|stroke|ring|shadow|decoration|outline|caret|accent|divide)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|[1-9]00|950)\b/
+
+/** Tailwind achromatic utility: `bg-white`, `text-black`. */
+const TW_ACHROMATIC = /\b(?:bg|text|border|fill|stroke|divide|ring)-(?:white|black)\b/
+
+/** Tailwind arbitrary colour value: `bg-[#1C1C1C]`, `text-[rgb(0,0,0)]`. */
+const TW_ARBITRARY = /\[(?:#[0-9a-fA-F]{3,8}|(?:rgba?|hsla?)\([^\]]*\))\]/
+
+/**
+ * A bare CSS colour keyword used as a whole value.
+ *
+ * Anchored to the entire string so prose ("white text on black") and identifiers
+ * ("whiteboard") never match — only `color: 'white'` style values do.
+ * `transparent` is excluded on purpose: it encodes absence, not a colour, and
+ * has no token equivalent.
+ */
+const NAMED_KEYWORD =
+  /^(?:white|black|red|green|blue|gray|grey|silver|orange|purple|yellow|cyan|magenta|pink|brown|navy|teal|olive|maroon|lime|aqua|fuchsia)$/i
+
+/**
+ * Most specific first. `bg-[#1C1C1C]` is matched by TW_ARBITRARY *and* HEX, and
+ * `[rgba(0,0,0,.5)]` by TW_ARBITRARY *and* FUNCTIONAL — whichever runs first
+ * claims the span, and later patterns skip anything overlapping it. Without
+ * that ordering those literals count twice, which both double-reports and
+ * over-funds the baseline.
+ */
+const PATTERNS = [
+  { re: TW_ARBITRARY, id: 'twArbitrary' },
+  { re: FUNCTIONAL, id: 'functional' },
+  { re: TW_PALETTE, id: 'twPalette' },
+  { re: TW_ACHROMATIC, id: 'twAchromatic' },
+  { re: HEX, id: 'hex' },
+]
+
+/**
+ * Every raw colour in `text`, as `{ value, id }` pairs.
+ *
+ * Extracts the colour substrings rather than keying on the whole literal, so the
+ * baseline stays stable when unrelated text moves — editing one class in
+ * `"flex bg-red-500 p-2"` shouldn't re-flag the colour that was already there.
+ * Values are lowercased so `#FFF` and `#fff` are the same debt.
+ */
+function extractRawColors(text) {
+  if (typeof text !== 'string') return []
+  const found = []
+  /** Spans already claimed by a more specific pattern. */
+  const claimed = []
+  const overlaps = (start, end) => claimed.some(([s, e]) => start < e && end > s)
+
+  for (const { re, id } of PATTERNS) {
+    const global = new RegExp(re.source, re.flags.includes('g') ? re.flags : `${re.flags}g`)
+    for (const match of text.matchAll(global)) {
+      const start = match.index
+      const end = start + match[0].length
+      if (overlaps(start, end)) continue
+      claimed.push([start, end])
+      found.push({ value: match[0].toLowerCase(), id, index: start })
+    }
+  }
+  if (NAMED_KEYWORD.test(text.trim())) {
+    found.push({ value: text.trim().toLowerCase(), id: 'named', index: 0 })
+  }
+  // Source order keeps the reported colour predictable and the baseline stable.
+  return found.sort((a, b) => a.index - b.index)
+}
+
+module.exports = { PATTERNS, NAMED_KEYWORD, extractRawColors }

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -3,6 +3,7 @@ const tseslint = require('typescript-eslint')
 const react = require('eslint-plugin-react')
 const reactHooks = require('eslint-plugin-react-hooks')
 const noDeviceInternals = require('./eslint-rules/no-device-internals')
+const noRawColor = require('./eslint-rules/no-raw-color')
 
 module.exports = tseslint.config(
   // Global ignores
@@ -80,10 +81,46 @@ module.exports = tseslint.config(
   {
     files: ['src/**/*.{ts,tsx}'],
     plugins: {
-      titan: { rules: { 'no-device-internals': noDeviceInternals } },
+      // The whole `titan` plugin is declared here — a flat config may only
+      // define a plugin name once, so rules scoped differently (see no-raw-color
+      // below) are enabled in their own block without re-declaring `plugins`.
+      titan: {
+        rules: {
+          'no-device-internals': noDeviceInternals,
+          'no-raw-color': noRawColor,
+        },
+      },
     },
     rules: {
       'titan/no-device-internals': 'error',
+    },
+  },
+
+  // Colour has one source of truth: the ramps, and the semantic tokens that
+  // reference them. A raw colour in a component can't theme, can't be audited
+  // for contrast/CVD, and won't move when the ramps are re-spaced — the v0.10.0
+  // surface work re-spaced the dark ramp and left every hardcoded colour behind.
+  //
+  // Errors, but RATCHETED: each file's existing count is recorded in
+  // raw-color-baseline.json and only occurrences beyond it fail. New colour is
+  // blocked immediately; the backlog burns down file by file. A rule that failed
+  // on all ~250 existing violations would just get switched off.
+  //
+  // src/theme/** is exempt — it IS the colour system.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      // The colour system itself.
+      'src/theme/**',
+      // Colour maths (parsing/blending) legitimately handles literal values.
+      'src/utils/colors.ts',
+      // Tests assert against literal hex on purpose: under the RNW vitest alias
+      // a token reference resolves to `var(...)`, which breaks toHaveStyle. A
+      // literal is the correct assertion, not debt.
+      'src/**/*.test.{ts,tsx}',
+    ],
+    rules: {
+      'titan/no-raw-color': 'error',
     },
   },
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -72,7 +72,8 @@
     "test:visual:tokens": "playwright test --config playwright.tokens.config.ts",
     "test:visual:stories": "playwright test stories.spec.ts",
     "test:visual:stories:update": "playwright test stories.spec.ts --update-snapshots",
-    "prepublishOnly": "tsup && vitest --run"
+    "prepublishOnly": "tsup && vitest --run",
+    "lint:colors:baseline": "node scripts/update-raw-color-baseline.mjs"
   },
   "peerDependencies": {
     "nativewind": "^4.2.1",

--- a/packages/ui/scripts/update-raw-color-baseline.mjs
+++ b/packages/ui/scripts/update-raw-color-baseline.mjs
@@ -1,0 +1,121 @@
+/**
+ * Regenerate `eslint-rules/raw-color-baseline.json`.
+ *
+ * Runs the real `titan/no-raw-color` rule with an empty baseline and records how
+ * many violations each file actually produces. Going through ESLint rather than
+ * re-scanning with regexes is the point: the baseline then counts exactly what
+ * the rule counts, including its AST scoping (string literals and template
+ * chunks only — not comments, identifiers, or imports).
+ *
+ * The file only ever shrinks in practice: run this after removing raw colours to
+ * lower a file's allowance and lock the progress in. It will refuse to raise an
+ * allowance unless you pass --allow-increase, so a regen can't silently absorb
+ * new violations someone just added.
+ *
+ *   node scripts/update-raw-color-baseline.mjs [--allow-increase]
+ */
+
+import { ESLint } from 'eslint'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const { extractRawColors } = createRequire(import.meta.url)('../eslint-rules/raw-color-patterns.js')
+
+/**
+ * Source text the rule reported on, recovered from the message range.
+ *
+ * ESLint interpolates a message's `data` into its string before returning it, so
+ * the offending value can't be read back off the result — but the node's
+ * line/column range can, and slicing it gives the original literal to re-extract
+ * from. Falls back to the whole first line if a range is missing.
+ */
+function literalAt(lines, m) {
+  // The slice spans the whole node, quotes included, but the bare-keyword
+  // pattern is anchored to the entire string — so `'white'` would not match
+  // until the delimiters come off.
+  const unquote = (s) => s.replace(/^['"`]/, '').replace(/['"`]$/, '')
+  if (!m.line) return ''
+  if (!m.endLine || m.endLine === m.line) {
+    return unquote(
+      (lines[m.line - 1] ?? '').slice(m.column - 1, m.endColumn ? m.endColumn - 1 : undefined)
+    )
+  }
+  const chunk = [(lines[m.line - 1] ?? '').slice(m.column - 1)]
+  for (let i = m.line; i < m.endLine - 1; i++) chunk.push(lines[i] ?? '')
+  chunk.push((lines[m.endLine - 1] ?? '').slice(0, m.endColumn - 1))
+  return unquote(chunk.join('\n'))
+}
+
+const pkgDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const baselinePath = path.join(pkgDir, 'eslint-rules', 'raw-color-baseline.json')
+const allowIncrease = process.argv.includes('--allow-increase')
+
+// Empty the baseline first so the rule reports every occurrence, not just the
+// ones past the current allowance.
+const previous = existsSync(baselinePath) ? JSON.parse(readFileSync(baselinePath, 'utf8')) : {}
+writeFileSync(baselinePath, '{}\n')
+
+let results
+try {
+  const eslint = new ESLint({ cwd: pkgDir })
+  results = await eslint.lintFiles(['src/**/*.{ts,tsx}'])
+} finally {
+  // Restore on failure so a crashed run can't leave the repo unguarded.
+  if (!results) writeFileSync(baselinePath, JSON.stringify(previous, null, 2) + '\n')
+}
+
+// With an empty baseline the rule reports every raw colour. The offending value
+// can't be read back off the message (ESLint interpolates `data` into the string
+// before returning it), so the source is re-read and the reported range sliced
+// out to rebuild the multiset.
+const counts = {}
+for (const result of results) {
+  const source = readFileSync(result.filePath, 'utf8').split('\n')
+  const file = path.relative(pkgDir, result.filePath).split(path.sep).join('/')
+  for (const m of result.messages) {
+    if (m.ruleId !== 'titan/no-raw-color') continue
+    // Record EVERY colour in the reported literal, not just the one that
+    // triggered the message. The rule consumes allowance for all of them, so
+    // recording only the first would leave the rest unfunded and fail at
+    // baseline.
+    for (const { value } of extractRawColors(literalAt(source, m))) {
+      counts[file] ??= {}
+      counts[file][value] = (counts[file][value] ?? 0) + 1
+    }
+  }
+}
+
+const fileTotal = (entry) => Object.values(entry ?? {}).reduce((a, b) => a + b, 0)
+
+const raised = Object.entries(counts).filter(
+  ([file, entry]) => fileTotal(entry) > fileTotal(previous[file])
+)
+if (raised.length > 0 && !allowIncrease) {
+  writeFileSync(baselinePath, JSON.stringify(previous, null, 2) + '\n')
+  console.error('Refusing to raise the raw-colour baseline for:\n')
+  for (const [file, entry] of raised) {
+    console.error(`  ${file}: ${fileTotal(previous[file])} -> ${fileTotal(entry)}`)
+  }
+  console.error(
+    '\nThese files gained raw colours. Replace them with tokens, or re-run with\n' +
+      '--allow-increase if the increase is genuinely intended.'
+  )
+  process.exit(1)
+}
+
+const sorted = Object.fromEntries(
+  Object.entries(counts)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([file, entry]) => [
+      file,
+      Object.fromEntries(Object.entries(entry).sort(([a], [b]) => a.localeCompare(b))),
+    ])
+)
+writeFileSync(baselinePath, JSON.stringify(sorted, null, 2) + '\n')
+
+const total = Object.values(sorted).reduce((a, e) => a + fileTotal(e), 0)
+const before = Object.values(previous).reduce((a, e) => a + fileTotal(e), 0)
+console.log(`raw-colour baseline: ${total} occurrences across ${Object.keys(sorted).length} files`)
+if (before) console.log(`previous: ${before} — delta ${total - before}`)

--- a/packages/ui/src/test/raw-color-patterns.test.ts
+++ b/packages/ui/src/test/raw-color-patterns.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'node:module'
+
+const { extractRawColors } = createRequire(import.meta.url)(
+  '../../eslint-rules/raw-color-patterns.js'
+) as { extractRawColors: (text: string) => Array<{ value: string; id: string }> }
+
+const ids = (text: string) => extractRawColors(text).map((c) => c.id)
+const values = (text: string) => extractRawColors(text).map((c) => c.value)
+
+/**
+ * Detection for the `no-raw-color` ratchet. The rule and its baseline generator
+ * share this module, so a gap here silently widens the allowance rather than
+ * failing loudly — worth pinning the notations directly.
+ */
+describe('extractRawColors', () => {
+  it('detects every hex length', () => {
+    expect(ids('#fff')).toEqual(['hex'])
+    expect(ids('#ffff')).toEqual(['hex'])
+    expect(ids('#1C1916')).toEqual(['hex'])
+    expect(ids('#1C1916FF')).toEqual(['hex'])
+  })
+
+  it('detects functional notations, including ones with no occurrences today', () => {
+    for (const text of [
+      'rgb(1,2,3)',
+      'rgba(1,2,3,0.5)',
+      'hsl(1 2% 3%)',
+      'hsla(1,2%,3%,0.5)',
+      'oklch(0.5 0.2 30)',
+      'lab(50% 40 59)',
+      'color-mix(in oklch, red, blue)',
+    ]) {
+      expect(ids(text), text).toContain('functional')
+    }
+  })
+
+  it('detects Tailwind colour utilities but not layout classes', () => {
+    expect(ids('bg-red-500')).toEqual(['twPalette'])
+    expect(ids('text-slate-200')).toEqual(['twPalette'])
+    expect(ids('bg-white')).toEqual(['twAchromatic'])
+    expect(ids('bg-[#1C1C1C]')).toEqual(['twArbitrary'])
+    expect(ids('flex flex-row gap-2 p-4 rounded-lg')).toEqual([])
+    // Semantic utilities are the desired output, not violations.
+    expect(ids('bg-surface-raised text-text-primary')).toEqual([])
+  })
+
+  it('treats a bare keyword as a colour only when it is the whole value', () => {
+    expect(ids('white')).toEqual(['named'])
+    expect(ids('  black  ')).toEqual(['named'])
+    // Prose and identifiers must not match, or every comment becomes a violation.
+    expect(ids('white text on a black plane')).toEqual([])
+    expect(ids('whiteboard')).toEqual([])
+  })
+
+  it('does not flag absence or inheritance', () => {
+    // `transparent` encodes absence and `currentColor` defers to the cascade;
+    // neither has a token equivalent.
+    expect(ids('transparent')).toEqual([])
+    expect(ids('currentColor')).toEqual([])
+  })
+
+  it('normalises case so #FFF and #fff are the same debt', () => {
+    expect(values('#ABCDEF')).toEqual(['#abcdef'])
+  })
+
+  it('extracts every colour in a multi-colour literal', () => {
+    // The baseline funds each one, so both have to come back.
+    expect(values('linear-gradient(#111111, #222222)')).toEqual(['#111111', '#222222'])
+  })
+})


### PR DESCRIPTION
Enforcement half of the colour-system hardening. Independent of #126 — that one fixes the *documentation*, this stops the *drift*.

## Why

Colour has one source of truth: the OKLCH ramps and the semantic tokens referencing them. A raw colour in a component can't theme, can't be audited for contrast/CVD, and won't move when the ramps are re-spaced. **v0.10.0 made that concrete** — re-spacing the dark ramp updated every tokenised surface automatically and left every hardcoded one behind.

## Hex is only one notation

Also covered: `rgb`/`hsl`/`oklch`/`lab`/`color-mix`, Tailwind palette utilities (`bg-red-500`), Tailwind `white`/`black`, arbitrary values (`bg-[#1C1C1C]`), and bare CSS keywords. `oklch`/`lab` have **zero occurrences today** and are included deliberately so the first one is caught rather than grandfathered.

Not flagged: `transparent` and `currentColor` — they encode absence and inheritance, and have no token equivalent.

## Ratcheted, not a wall

**470 violations across 101 files.** A rule that failed on all of them would just get switched off. Each file's existing colours are recorded in `raw-color-baseline.json`; only occurrences *beyond* that allowance fail. New colour is blocked from day one, the backlog burns down file by file, no flag day.

**The baseline keys on colour values, not counts.** My first version was count-based and had a real usability flaw: it reported whichever grandfathered literal happened to sit at the count boundary, so the error pointed at innocent code rather than the colour you just added. Value-keying fixes that, still fails when you add a *duplicate* of an existing colour, and doesn't re-flag untouched colours when surrounding text moves.

The generator drives the real rule through ESLint rather than re-scanning with regexes, so the baseline counts exactly what the rule counts — including its AST scoping. It refuses to raise an allowance without `--allow-increase`. Rule and generator share one detection module for the same reason.

Regen: `pnpm lint:colors:baseline`

## Exemptions

`src/theme/**` (that IS the colour system), `src/utils/colors.ts` (colour maths), and tests — which assert literal hex *on purpose*, since under the RNW vitest alias a token reference resolves to `var(...)` and breaks `toHaveStyle`.

## Verification

- **0 residual** violations at baseline; regen idempotent (delta 0)
- Every notation confirmed to **fail on injection**, each with its own message — plus a duplicate of an already-grandfathered value
- Unit test pins detection, including that `bg-[#1C1C1C]` counts **once**, not as both arbitrary and hex (a real double-count the test caught)
- 2605/2605 tests · eslint clean · prettier clean

## What the baseline reveals

| area | count | | notation | count |
|---|---|---|---|---|
| stories | **266** | | hex | 294 |
| components/custom | 144 | | functional (rgba) | 106 |
| components/ui | 60 | | tw white/black | 44 |

**57% is in stories**, and the `rgba` cluster is glows and translucent fills (`rgba(255,121,0,0.6)` is brand-primary at 60%) — those want an `alpha()` helper and a defined shadow/glow system, not token swaps. Migration tickets follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)