### PR TITLE
Compose all three dual VelocityStrip variants; SessionRail expands in place

### DIFF
--- a/packages/ui/src/components/custom/Workout/DualVelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/DualVelocityStrip.test.tsx
@@ -396,8 +396,8 @@ describe('DualVelocityStrip live mode', () => {
   })
 })
 
-describe('DualVelocityStrip compact variant (folded 8px)', () => {
-  it('folds the diverging pair into one strip — L top-half + R bottom-half per rep, no gutter/labels/axis', () => {
+describe('DualVelocityStrip compact variant (folded)', () => {
+  it('keeps the FOLDED footprint — the pair costs one strip height, not two', () => {
     render(
       <DualVelocityStrip
         left={{ velocities: [0.9, 0.85, 0.8], label: 'Left Arm' }}
@@ -405,19 +405,22 @@ describe('DualVelocityStrip compact variant (folded 8px)', () => {
         variant="compact"
       />
     )
-    // One folded strip (NOT two composed wings): each rep column has an L top-half + R bottom-half.
-    expect(screen.queryAllByTestId('velocity-strip-compact')).toHaveLength(0)
-    expect(screen.getByTestId('dual-velocity-bar-L-0')).toBeInTheDocument()
-    expect(screen.getByTestId('dual-velocity-bar-L-2')).toBeInTheDocument()
-    expect(screen.getByTestId('dual-velocity-bar-R-0')).toBeInTheDocument()
-    expect(screen.getByTestId('dual-velocity-bar-R-1')).toBeInTheDocument()
-    // Folded 8px leaves no room for chrome: no gutter/slot labels, no centre axis, no value labels.
+    // The fold is a FOOTPRINT guarantee, not a DOM one: compact is composed from two wings like
+    // the hero and rail, but they share DUAL_COMPACT_HEIGHT (5 + 1.5 gap + 5) rather than stacking
+    // to 2x a full strip. Asserting the height keeps the design decision locked while leaving the
+    // implementation free to compose.
+    expect(screen.getByTestId('dual-velocity-strip')).toHaveStyle({ height: '11.5px' })
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(3)
+    expect(down.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(2)
+    // Folded height leaves no room for chrome: no gutter/slot labels, no centre axis, no values.
     expect(screen.queryByTestId('dual-velocity-side-label-L')).not.toBeInTheDocument()
     expect(screen.queryByTestId('dual-velocity-axis')).not.toBeInTheDocument()
     expect(screen.queryByTestId(/^velocity-label-\d+$/)).not.toBeInTheDocument()
   })
 
-  it('index-locks — a lagging side’s un-logged reps render as faint empties at the same columns', () => {
+  it('index-locks — a lagging side keeps its columns as empties', () => {
     render(
       <DualVelocityStrip
         left={{ velocities: [0.9, 0.88, 0.86, 0.84] }}
@@ -425,10 +428,24 @@ describe('DualVelocityStrip compact variant (folded 8px)', () => {
         variant="compact"
       />
     )
-    // 4 columns; the right side logged 2, so its columns 2 & 3 are empty (index-locked under the left).
-    expect(screen.getByTestId('dual-velocity-bar-R-1')).toBeInTheDocument()
-    expect(screen.getByTestId('dual-velocity-bar-R-2-empty')).toBeInTheDocument()
-    expect(screen.getByTestId('dual-velocity-bar-R-3-empty')).toBeInTheDocument()
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(down.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(2)
+    // Four columns overall, so the lagging side holds two of them as empties rather than shrinking.
+    expect(down.queryAllByTestId('velocity-slot-empty')).toHaveLength(2)
+  })
+
+  it('carries the set-type vocabulary that the hand-rolled fold used to drop', () => {
+    render(
+      <DualVelocityStrip
+        left={{ set: { type: 'straight', velocities: [0.9, 0.86], planned: 4 } }}
+        right={{ set: { type: 'straight', velocities: [0.88, 0.84], planned: 4 } }}
+        variant="compact"
+      />
+    )
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId('velocity-slot-todo')).toHaveLength(2)
+    expect(down.queryAllByTestId('velocity-slot-todo')).toHaveLength(2)
   })
 })
 
@@ -441,13 +458,18 @@ describe('DualVelocityStrip rail variant', () => {
         variant="rail"
       />
     )
-    expect(screen.queryAllByTestId(RAIL_LEFT_BARS)).toHaveLength(2)
-    expect(screen.queryAllByTestId(RAIL_RIGHT_BARS)).toHaveLength(2)
+    // The rail is now COMPOSED from two bare `expanded` strips, so each wing emits the shared
+    // SetBarChart testIDs rather than the old bespoke `dual-velocity-bar-*` ones. Query per wing.
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(2)
+    expect(down.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(2)
+    // Still lean: no per-bar value labels, no running-best reference line.
     expect(screen.queryByTestId(/^velocity-label-\d+$/)).not.toBeInTheDocument()
     expect(screen.queryByTestId('velocity-hero-reference')).not.toBeInTheDocument()
   })
 
-  it('draws mirrored dashed todo stubs for unperformed reps', () => {
+  it('draws a to-do slot on each wing for the unperformed remainder', () => {
     render(
       <DualVelocityStrip
         left={{ velocities: [0.9] }}
@@ -456,22 +478,43 @@ describe('DualVelocityStrip rail variant', () => {
         targetReps={2}
       />
     )
-    expect(screen.queryAllByTestId(/^dual-velocity-bar-L-\d+-todo$/)).toHaveLength(1)
-    expect(screen.queryAllByTestId(/^dual-velocity-bar-R-\d+-todo$/)).toHaveLength(1)
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId('velocity-slot-todo')).toHaveLength(1)
+    expect(down.queryAllByTestId('velocity-slot-todo')).toHaveLength(1)
   })
 
-  it('rounds the up (L) bar on top and the down (R) bar on the bottom', () => {
+  it('index-locks a lagging side, giving it an aligned empty rather than fewer bars', () => {
+    // The defect this replaces: each side built its own columns, so a lagging side simply
+    // rendered FEWER bars and its remaining reps slid left out of alignment.
     render(
       <DualVelocityStrip
-        left={{ velocities: [0.9] }}
-        right={{ velocities: [0.8] }}
+        left={{ velocities: [0.9, 0.86, 0.82] }}
+        right={{ velocities: [0.85, 0.8] }}
         variant="rail"
       />
     )
-    expect(screen.getByTestId('dual-velocity-bar-L-0')).toHaveStyle({ borderTopLeftRadius: '2px' })
-    expect(screen.getByTestId('dual-velocity-bar-R-0')).toHaveStyle({
-      borderBottomLeftRadius: '2px',
-    })
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(3)
+    // The lagging side keeps three COLUMNS — two bars plus an aligned empty.
+    expect(down.queryAllByTestId(/^velocity-bar-\d+$/)).toHaveLength(2)
+    expect(down.queryAllByTestId('velocity-slot-empty')).toHaveLength(1)
+  })
+
+  it('carries set-type windows onto both wings', () => {
+    // The bespoke rail flattened to velocities, so a range's variable window never rendered.
+    render(
+      <DualVelocityStrip
+        left={{ set: { type: 'range', velocities: [0.9, 0.86], floor: 3, max: 4 } }}
+        right={{ set: { type: 'range', velocities: [0.85, 0.8], floor: 3, max: 4 } }}
+        variant="rail"
+      />
+    )
+    const up = within(screen.getByTestId('dual-velocity-wing-up'))
+    const down = within(screen.getByTestId('dual-velocity-wing-down'))
+    expect(up.queryAllByTestId('velocity-slot-variable').length).toBeGreaterThan(0)
+    expect(down.queryAllByTestId('velocity-slot-variable').length).toBeGreaterThan(0)
   })
 })
 

--- a/packages/ui/src/components/custom/Workout/SessionRail.test.tsx
+++ b/packages/ui/src/components/custom/Workout/SessionRail.test.tsx
@@ -76,6 +76,49 @@ describe('SessionRail', () => {
     expect(onExercisePress).toHaveBeenCalledWith(exercises[1], 1)
   })
 
+  describe('expandedIndex', () => {
+    const withSets: SessionRailExercise[] = exercises.map((ex, i) =>
+      i === 1
+        ? {
+            ...ex,
+            sets: [
+              {
+                state: 'done' as const,
+                setNumber: 1,
+                unit: 'lbs' as const,
+                reps: 10,
+                weight: 90,
+                velocities: [0.72, 0.66],
+              },
+            ],
+          }
+        : ex
+    )
+
+    it('renders the named exercise expanded in place, leaving the others collapsed', () => {
+      render(<SessionRail {...baseProps} exercises={withSets} expandedIndex={1} />)
+      // The expanded row reveals the set table; the collapsed ones do not.
+      expect(screen.getByText('SET')).toBeInTheDocument()
+      expect(screen.getByText('RPE')).toBeInTheDocument()
+      // Every exercise still has a row.
+      expect(screen.getByText('Seated Cable Row')).toBeInTheDocument()
+      expect(screen.getByText('Cable Chest Press')).toBeInTheDocument()
+      expect(screen.getByText('Face Pull')).toBeInTheDocument()
+    })
+
+    it('stays collapsed when the named exercise has no sets', () => {
+      // Guards the real case: an exercise whose sets have not loaded yet must not
+      // expand into an empty table.
+      render(<SessionRail {...baseProps} expandedIndex={1} />)
+      expect(screen.queryByText('SET')).not.toBeInTheDocument()
+    })
+
+    it('leaves every row collapsed when expandedIndex is omitted', () => {
+      render(<SessionRail {...baseProps} exercises={withSets} />)
+      expect(screen.queryByText('SET')).not.toBeInTheDocument()
+    })
+  })
+
   describe('accessibility', () => {
     it('has no accessibility violations', async () => {
       const { container } = render(<SessionRail {...baseProps} />)

--- a/packages/ui/src/components/custom/Workout/SessionRail.tsx
+++ b/packages/ui/src/components/custom/Workout/SessionRail.tsx
@@ -4,6 +4,8 @@ import { primitiveColors } from '../../../theme/tokens/primitives'
 import { neumorphicShadows } from '../../../theme/shadows'
 import { Surface } from '../../ui/surface'
 import { ExerciseCardHeading } from './ExerciseCardHeading'
+import { ExerciseCard } from './ExerciseCard'
+import type { SetRowProps } from './SetRow'
 import { SessionHeader } from './SessionHeader'
 import type { MetricTileData } from './MetricTiles'
 import type { SetStripSet } from './SetStrip'
@@ -38,6 +40,12 @@ export interface SessionRailExercise {
   setStates: SetStripSet[]
   /** Dim the row as a not-yet-reached exercise. */
   upcoming?: boolean
+  /**
+   * Per-set rows for the expanded body. Only read when this row is the one named
+   * by `expandedIndex` — a rail row without them can never expand, which is the
+   * correct behaviour for an exercise whose sets aren't loaded.
+   */
+  sets?: SetRowProps[]
 }
 
 export interface SessionRailProps extends ViewProps {
@@ -60,6 +68,16 @@ export interface SessionRailProps extends ViewProps {
   stripHeight?: number
   /** Rail width in px. Default 246. */
   width?: number
+  /**
+   * Index of the exercise to render EXPANDED in place — its set table opens
+   * inside the rail rather than in a separate pane. The row still draws the same
+   * `ExerciseCardHeading` (an `ExerciseCard` composes one), so an expanded row
+   * differs from a collapsed one only by the revealed body.
+   *
+   * Ignored when the named exercise has no `sets`. Omit for an all-collapsed
+   * rail, which is the prior behaviour.
+   */
+  expandedIndex?: number
   onExercisePress?: (exercise: SessionRailExercise, index: number) => void
   className?: string
 }
@@ -81,6 +99,7 @@ export function SessionRail({
   next,
   stripHeight = 8,
   width = DEFAULT_WIDTH,
+  expandedIndex,
   onExercisePress,
   className,
   style,
@@ -118,19 +137,37 @@ export function SessionRail({
               borderBottomColor: DIVIDER,
             }}
           >
-            <ExerciseCardHeading
-              name={ex.name}
-              sets={ex.summary.sets}
-              reps={ex.summary.reps}
-              load={ex.summary.weight}
-              unit={ex.summary.unit}
-              tempo={ex.tempo}
-              indicator={ex.indicator}
-              setStates={ex.setStates}
-              stripHeight={stripHeight}
-              dimmed={ex.upcoming}
-              onPress={() => onExercisePress?.(ex, i)}
-            />
+            {i === expandedIndex && ex.sets ? (
+              <ExerciseCard
+                name={ex.name}
+                expanded
+                summary={{
+                  sets: ex.summary.sets,
+                  reps: ex.summary.reps,
+                  // ExerciseCard's summary takes a numeric load; a string load is
+                  // an unset/discovery weight, which has no expanded form yet.
+                  weight: typeof ex.summary.weight === 'number' ? ex.summary.weight : 0,
+                  unit: ex.summary.unit,
+                }}
+                tempo={ex.tempo}
+                sets={ex.sets}
+                onExpandedChange={() => onExercisePress?.(ex, i)}
+              />
+            ) : (
+              <ExerciseCardHeading
+                name={ex.name}
+                sets={ex.summary.sets}
+                reps={ex.summary.reps}
+                load={ex.summary.weight}
+                unit={ex.summary.unit}
+                tempo={ex.tempo}
+                indicator={ex.indicator}
+                setStates={ex.setStates}
+                stripHeight={stripHeight}
+                dimmed={ex.upcoming}
+                onPress={() => onExercisePress?.(ex, i)}
+              />
+            )}
           </View>
         ))}
       </Surface>

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -4,20 +4,15 @@ import { View, Text, Pressable, Animated, type ViewProps, type ViewStyle } from 
 import { WORKOUT_TOKENS } from '../../../theme/workout-tokens'
 import { primitiveColors, sequentialEffort } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { useOnSurfaceColor } from '../../ui/surface/SurfaceContext'
 import { alpha } from '../../../utils/colors'
 import { formatVelocity } from '../../../utils/workout-format'
 import {
   SetBarChart,
   type SetSlot,
   type SetBarGeometry,
-  scaleDenominator,
   ChartSideRail,
   SET_BAR_DEFAULT_HEIGHT,
-  BAR_MAX_WIDTH,
-  computeBarLayout,
 } from '../charts/SetBarChart'
-import type { LayoutChangeEvent } from 'react-native'
 import { ANIMATION_EASING } from '../charts/live-rep-growth'
 
 /**
@@ -724,8 +719,6 @@ const DUAL_COMPACT_HEIGHT = 11.5
 // hero geometry for free. The `rail` variant is far smaller than a hero (no value
 // labels, reference lines, paper, or label headroom), so composing the hero would
 // drag all of that in; it keeps a lean dedicated renderer at these compact metrics.
-const RAIL_RADIUS = 2
-const RAIL_MIN_BAR = 3
 /** The vertical gap between the up/down wings on the axis-less rail (value-height dual-expanded). */
 const DUAL_WING_GAP = 2
 /** The centre gap (px) splitting the folded compact dual's L (top) and R (bottom) halves — a gap, no line. */
@@ -801,12 +794,6 @@ function alignDualSlots(left: SetSlot[], right: SetSlot[]): { left: SetSlot[]; r
     R.push(sideColumnCell(rt, kind, gap))
   }
   return { left: L, right: R }
-}
-
-/** Rail slots: performed reps (carrying a velocity) followed by todo placeholders up to `targetReps`. */
-function railSlots(done: number[], targetReps?: number): { velocity?: number }[] {
-  const total = Math.max(done.length, targetReps ?? done.length)
-  return Array.from({ length: total }, (_, i) => (i < done.length ? { velocity: done[i] } : {}))
 }
 
 /** Shared inputs for both dual renderers — the resolved per-side done arrays + presentation props. */
@@ -940,111 +927,68 @@ function DualVelocityHero({
 function DualVelocityRail({
   leftDone,
   rightDone,
+  leftStream,
+  rightStream,
   zones,
   barColor,
   scale,
   targetReps,
+  liveRepIndex,
   height,
   className,
   label,
   viewProps,
-}: DualChartProps) {
-  // Rail (= the lean dual-expanded) drops the centre axis, the gutter/vertical-axis, and the side
-  // labels; the two wings read as separate rows via a small vertical gap instead.
+}: DualChartProps & { liveRepIndex?: number }) {
+  // The lean dual-EXPANDED. Composed from two bare `expanded` strips exactly as the hero composes
+  // two heroes, rather than drawing its own bars: composing is what makes the dual inherit the
+  // single's bar widths, gaps, chunk-notch, set-type slot windows, paper and live-rep growth. The
+  // bespoke renderer this replaces took only velocities, so the dual silently dropped every
+  // set-type window and let a lagging side render fewer bars than its partner.
   const plotHalf = (height - DUAL_WING_GAP) / 2
+  // ONE shared height scale across both wings, so an L/R asymmetry reads as bar length rather than
+  // as two independent scales.
   const sharedMax = Math.max(...leftDone, ...rightDone, 0)
-  const scaleDenom = scaleDenominator(scale, sharedMax)
-  const bestL = Math.max(...leftDone, 0)
-  const bestR = Math.max(...rightDone, 0)
-  const zoneColorFor = makeBarColorFor(zones)
-  const colorFor = (v: number, best: number): string =>
-    barColor === 'loss' ? getVelocityLossColor(velocityLossForRep(v, best)) : zoneColorFor(v)
-  const barPx = (v: number): number =>
-    scaleDenom <= 0 ? RAIL_MIN_BAR : Math.max(RAIL_MIN_BAR, Math.min(1, v / scaleDenom) * plotHalf)
-  const placeholder = useOnSurfaceColor('tertiary')
-
-  const slotsL = railSlots(leftDone, targetReps)
-  const slotsR = railSlots(rightDone, targetReps)
-  const columns = Math.max(slotsL.length, slotsR.length)
-  // Share the single chart's adaptive column geometry so the rail's bars land at the SAME widths +
-  // gaps as the single expanded / hero (one shared layout via computeBarLayout).
-  const [plotW, setPlotW] = useState(0)
-  const { gap } = computeBarLayout(plotW, columns)
+  // ONE index-locked column structure. A column a side did not log renders as an aligned empty, so
+  // the lagging side's next rep lands at the SAME column index as its partner's.
+  const aligned = alignDualSlots(
+    leftStream ? streamNaturalSlots(leftStream, targetReps) : [],
+    rightStream ? streamNaturalSlots(rightStream, targetReps) : []
+  )
   const { style: externalStyle, ...restProps } = viewProps
 
-  const railBar = (
-    slot: { velocity?: number },
-    grow: 'up' | 'down',
-    best: number,
-    testID: string
-  ) => {
-    const radius =
-      grow === 'up'
-        ? { borderTopLeftRadius: RAIL_RADIUS, borderTopRightRadius: RAIL_RADIUS }
-        : { borderBottomLeftRadius: RAIL_RADIUS, borderBottomRightRadius: RAIL_RADIUS }
-    if (slot.velocity == null) {
-      return (
-        <View
-          style={{
-            width: '100%',
-            height: RAIL_MIN_BAR * 2,
-            borderWidth: 1,
-            borderStyle: 'dashed',
-            borderColor: placeholder,
-            ...radius,
-          }}
-          testID={`${testID}-todo`}
-        />
-      )
-    }
-    return (
-      <View
-        style={{
-          width: '100%',
-          height: barPx(slot.velocity),
-          backgroundColor: colorFor(slot.velocity, best),
-          ...radius,
-        }}
-        testID={testID}
-      />
-    )
-  }
+  const wing = (orientation: 'up' | 'down', columns: SetSlot[], done: number[]) => (
+    <VelocityStrip
+      variant="expanded"
+      showNumbers={false}
+      showInfo={false}
+      orientation={orientation}
+      velocities={done}
+      columnSlots={columns}
+      scale={scale}
+      scaleMax={scale === 'fixed' ? undefined : sharedMax}
+      barColor={barColor}
+      zones={zones}
+      liveRepIndex={liveRepIndex}
+      height={plotHalf}
+    />
+  )
 
   return (
     <View
       className={className}
-      style={[{ height, flexDirection: 'row' }, externalStyle]}
+      style={[{ height, flexDirection: 'column', gap: DUAL_WING_GAP }, externalStyle]}
       accessibilityRole="image"
       accessibilityLabel={label}
       testID="dual-velocity-strip"
-      onLayout={(e: LayoutChangeEvent) => setPlotW(e.nativeEvent.layout.width)}
       {...restProps}
     >
-      <View style={{ flex: 1 }}>
-        <View style={{ flexDirection: 'row', gap, height: '100%', alignItems: 'stretch' }}>
-          {Array.from({ length: columns }, (_, i) => {
-            const lSlot = slotsL[i]
-            const rSlot = slotsR[i]
-            return (
-              <View
-                key={i}
-                accessibilityElementsHidden
-                style={{ flex: 1, maxWidth: BAR_MAX_WIDTH, height: '100%', gap: DUAL_WING_GAP }}
-              >
-                <View
-                  style={{ height: plotHalf, justifyContent: 'flex-end', alignItems: 'center' }}
-                >
-                  {lSlot && railBar(lSlot, 'up', bestL, `dual-velocity-bar-L-${i}`)}
-                </View>
-                <View
-                  style={{ height: plotHalf, justifyContent: 'flex-start', alignItems: 'center' }}
-                >
-                  {rSlot && railBar(rSlot, 'down', bestR, `dual-velocity-bar-R-${i}`)}
-                </View>
-              </View>
-            )
-          })}
-        </View>
+      {/* No gutter, side labels or centre axis at rail scale — the wings read as two rows via the
+          shared gap alone. Their own labels would duplicate the dual's summary label. */}
+      <View accessibilityElementsHidden testID="dual-velocity-wing-up">
+        {wing('up', aligned.left, leftDone)}
+      </View>
+      <View accessibilityElementsHidden testID="dual-velocity-wing-down">
+        {wing('down', aligned.right, rightDone)}
       </View>
     </View>
   )
@@ -1062,6 +1006,8 @@ function DualVelocityRail({
 function DualVelocityCompactStrip({
   leftDone,
   rightDone,
+  leftStream,
+  rightStream,
   zones,
   barColor,
   targetReps,
@@ -1070,63 +1016,46 @@ function DualVelocityCompactStrip({
   label,
   viewProps,
 }: DualChartProps) {
-  // Each side is a fixed-height rounded sub-segment (a little pill), stacked above/below the fold gap.
-  const half = COMPACT_FOLD_HALF
-  const zoneColorFor = makeBarColorFor(zones)
-  const bestL = Math.max(...leftDone, 0)
-  const bestR = Math.max(...rightDone, 0)
-  const colorFor = (v: number, best: number): string =>
-    barColor === 'loss' ? getVelocityLossColor(velocityLossForRep(v, best)) : zoneColorFor(v)
-  const emptyColor = useOnSurfaceColor('tertiary')
-  const slotsL = railSlots(leftDone, targetReps)
-  const slotsR = railSlots(rightDone, targetReps)
-  const columns = Math.max(slotsL.length, slotsR.length)
-  // Measure the plot so the columns land at the SAME widths + gaps as the single chart (one shared
-  // geometry via computeBarLayout) — width 0 (unmeasured) falls back to the layout's own default.
-  const [plotW, setPlotW] = useState(0)
-  const { gap } = computeBarLayout(plotW, columns)
+  // COMPOSED, like the hero and rail: two `compact` strips at COMPACT_FOLD_HALF each, separated by
+  // COMPACT_FOLD_GAP (5 + 1.5 + 5 = DUAL_COMPACT_HEIGHT exactly). Because a compact bar FILLS its
+  // plot, each column reads as an L top pill over an R bottom pill — the folded design, but drawn
+  // by the same SetBarChart the single uses. Composing rather than hand-rolling is what makes the
+  // set-type vocabulary (to-do, the cyan variable/continue windows, drop chunk-notch) and the
+  // index-locked empty arrive for free, and keeps them from drifting apart later.
+  const half = height === DUAL_COMPACT_HEIGHT ? COMPACT_FOLD_HALF : (height - COMPACT_FOLD_GAP) / 2
+  const aligned = alignDualSlots(
+    leftStream ? streamNaturalSlots(leftStream, targetReps) : [],
+    rightStream ? streamNaturalSlots(rightStream, targetReps) : []
+  )
   const { style: externalStyle, ...restProps } = viewProps
 
-  const foldHalf = (slot: { velocity?: number } | undefined, best: number, testID: string) => {
-    // Each sub-segment is a self-contained rounded pill (all corners), not a shared top/bottom cap.
-    const radius = { borderRadius: RAIL_RADIUS }
-    const v = slot?.velocity
-    if (v == null) {
-      return (
-        <View
-          style={{ height: half, backgroundColor: emptyColor, opacity: 0.35, ...radius }}
-          testID={`${testID}-empty`}
-        />
-      )
-    }
-    return (
-      <View
-        style={{ height: half, backgroundColor: colorFor(v, best), ...radius }}
-        testID={testID}
-      />
-    )
-  }
+  const wing = (orientation: 'up' | 'down', columns: SetSlot[], done: number[]) => (
+    <VelocityStrip
+      variant="compact"
+      orientation={orientation}
+      velocities={done}
+      columnSlots={columns}
+      barColor={barColor}
+      zones={zones}
+      height={half}
+    />
+  )
 
   return (
     <View
       className={className}
-      style={[{ height, flexDirection: 'row', gap, alignItems: 'stretch' }, externalStyle]}
+      style={[{ height, flexDirection: 'column', gap: COMPACT_FOLD_GAP }, externalStyle]}
       accessibilityRole="image"
       accessibilityLabel={label}
       testID="dual-velocity-strip"
-      onLayout={(e: LayoutChangeEvent) => setPlotW(e.nativeEvent.layout.width)}
       {...restProps}
     >
-      {Array.from({ length: columns }, (_, i) => (
-        <View
-          key={i}
-          accessibilityElementsHidden
-          style={{ flex: 1, maxWidth: BAR_MAX_WIDTH, gap: COMPACT_FOLD_GAP }}
-        >
-          {foldHalf(slotsL[i], bestL, `dual-velocity-bar-L-${i}`)}
-          {foldHalf(slotsR[i], bestR, `dual-velocity-bar-R-${i}`)}
-        </View>
-      ))}
+      <View accessibilityElementsHidden testID="dual-velocity-wing-up">
+        {wing('up', aligned.left, leftDone)}
+      </View>
+      <View accessibilityElementsHidden testID="dual-velocity-wing-down">
+        {wing('down', aligned.right, rightDone)}
+      </View>
     </View>
   )
 }
@@ -1185,7 +1114,9 @@ export function DualVelocityStrip({
     viewProps: props,
   }
 
-  if (variant === 'rail') return <DualVelocityRail {...shared} />
+  // `liveRepIndex` reaches the rail too: its wings are composed strips, so the newest rep grows
+  // from the midline on BOTH sides. Compact is flat, so a grow animation has nothing to animate.
+  if (variant === 'rail') return <DualVelocityRail {...shared} liveRepIndex={liveRepIndex} />
   if (variant === 'compact') return <DualVelocityCompactStrip {...shared} />
   return <DualVelocityHero {...shared} liveRepIndex={liveRepIndex} />
 }
@@ -1366,9 +1297,18 @@ export function VelocityStrip({
   // (widths / gaps / chunk-notch / slots / paper) as compact + hero. Only the height-mode
   // (value here, flat in compact) differs, so a compact↔spotlight toggle never reflows.
   if (!framed) {
-    const spotlightSlots: SetSlot[] = set
-      ? buildSlots(set).map((s) => ({ kind: s.kind, value: s.velocity, leadingGap: s.leadingGap }))
-      : doneVelocities.map((v) => ({ kind: 'rep', value: v }))
+    // `columnSlots` wins, exactly as it does for compact and hero. The diverging dual passes the
+    // index-locked shared structure through here; ignoring it gave the expanded dual its own
+    // per-side columns, so a lagging side rendered FEWER bars instead of an aligned empty cell.
+    const spotlightSlots: SetSlot[] =
+      columnSlots ??
+      (set
+        ? buildSlots(set).map((s) => ({
+            kind: s.kind,
+            value: s.velocity,
+            leadingGap: s.leadingGap,
+          }))
+        : doneVelocities.map((v) => ({ kind: 'rep', value: v })))
     return (
       <SetBarChart
         slots={spotlightSlots}

--- a/packages/ui/src/components/custom/charts/SetBarChart.tsx
+++ b/packages/ui/src/components/custom/charts/SetBarChart.tsx
@@ -40,9 +40,9 @@ function mixHex(a: string, b: string, t: number): string {
 }
 
 /** The cyan variable-window fill — the range set's `floor..max` window (shared with SetStrip). */
-const VARIABLE_FILL = primitiveRamps.cyan[900]
+export const VARIABLE_FILL = primitiveRamps.cyan[900]
 /** The thin cyan-800 outline on the open-ended "continue" slot — reads as "keep going". */
-const CONTINUE_OUTLINE = primitiveRamps.cyan[800]
+export const CONTINUE_OUTLINE = primitiveRamps.cyan[800]
 
 /**
  * One drawn cell of the chart. `rep` carries a `value` and draws a value-height bar;


### PR DESCRIPTION
Second of three PRs split out of #129. **Component changes only** — the story reorg (third PR) depends on this one.

## 1. All three dual variants now compose

The dual `hero` composed two real `VelocityStrip` heroes, inheriting the single's geometry and set-type vocabulary for free. `rail` (the dual-expanded) and `compact` did **not** — they hand-rolled bars from `railSlots(done, targetReps)`, which flattens both sides to bare velocities. The old doc comment admitted it: *"rail only ever takes plain velocities."*

That one flattening caused three reported defects at once:

| defect | cause |
|---|---|
| No set-type windows on dual expanded/compact | variable / continue / drop-notch flattened away |
| **Missing rep cell** for a lagging side | `railSlots` ran per side, so it rendered *fewer bars* instead of an aligned empty |
| Dual bar widths + spacing not matching single | each side computed its own column count |

Both now compose like the hero: `rail` renders two bare `expanded` strips, `compact` renders two `compact` strips at `COMPACT_FOLD_HALF` each. **The fold arithmetic works out exactly** — 5 + 1.5 gap + 5 = `DUAL_COMPACT_HEIGHT` — so the folded design is preserved while the drawing comes from the same `SetBarChart` the single uses.

Single↔dual drift is now **structurally impossible** rather than merely currently-absent.

`liveRepIndex` reaches the rail, so the newest rep grows from the midline on **both** wings.

**Latent bug fixed on the way:** the bare `expanded` path ignored `columnSlots` while compact and hero honour it — any aligned dual built on it would have silently fallen back to per-side columns.

Dead code removed with the bespoke renderers: `railSlots`, `RAIL_MIN_BAR`, `RAIL_RADIUS`, and six now-unused imports.

## 2. `SessionRail.expandedIndex`

The rail hardcoded `ExerciseCardHeading` per row with no expansion path. Since `ExerciseCard` already **composes** `ExerciseCardHeading`, a collapsed row and an expanded row differ only by the revealed body — so this is a branch, not a new surface.

`expandedIndex` names the row that opens; `SessionRailExercise.sets` carries its table. Both optional: omitting `expandedIndex` reproduces the previous all-collapsed rail exactly. A row named but carrying no `sets` stays collapsed — the right answer for an exercise whose sets have not loaded, rather than an empty table.

## Tests

The rail and compact tests asserted the bespoke DOM; rewritten against the composed wings, plus new coverage for index-lock and set-type windows reaching both wings.

One worth calling out: the compact test asserted the fold as a **DOM shape** (*"NOT two composed wings"*), which encoded the implementation rather than the decision. It now asserts the **footprint** — the pair costs `DUAL_COMPACT_HEIGHT`, not 2× — which is the actual design guarantee and leaves the rendering free to compose.

## Verification

`tsc` clean · eslint **0 errors** · **2769/2769** · colour baseline unchanged.

## Follow-up

**VW-86** — the remaining drift risk is no longer single-vs-dual but set-level vs rep-level: `SegmentedBar` and `SetBarChart` compact agree on height/radius only because two independent constants happen to match, and their gaps differ in kind (fixed 5px vs 8% of bar width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)