### PR TITLE
Lock the live-rep entrance onto both diverging dual-hero wings

### DIFF
--- a/packages/ui/src/components/custom/Workout/DualVelocityStrip.test.tsx
+++ b/packages/ui/src/components/custom/Workout/DualVelocityStrip.test.tsx
@@ -1,7 +1,44 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { DualVelocityStrip } from './VelocityStrip'
+
+/**
+ * The newest-rep entrance is an `Animated` value applied IMPERATIVELY, so jsdom never reflects it:
+ * a live bar's inline height sits at its static value for the whole animation, and driving
+ * requestAnimationFrame does not change that. The shared hook is therefore the only observable
+ * seam for "did the entrance actually arm on this wing".
+ *
+ * The spy PASSES THROUGH to the real implementation, so every other test in this file renders
+ * exactly as it would unmocked; it only records the arguments each composed strip armed with.
+ */
+const liveEntranceCalls = vi.hoisted(
+  () => [] as Array<[boolean, number | undefined, number | undefined, boolean]>
+)
+
+vi.mock('../charts/live-rep-growth', async () => {
+  const actual =
+    await vi.importActual<typeof import('../charts/live-rep-growth')>('../charts/live-rep-growth')
+  return {
+    ...actual,
+    useLiveRepGrowth: (
+      active: boolean,
+      liveRepIndex: number | undefined,
+      liveVelocity: number | undefined,
+      isNewPeak: boolean
+    ) => {
+      liveEntranceCalls.push([active, liveRepIndex, liveVelocity, isNewPeak])
+      return actual.useLiveRepGrowth(active, liveRepIndex, liveVelocity, isNewPeak)
+    },
+  }
+})
+
+/**
+ * The entrance each composed wing armed with, in render order (up wing, then down wing).
+ * `velocity: undefined` means the wing resolved no live rep, so its entrance stays inert.
+ */
+const wingEntrances = () =>
+  liveEntranceCalls.map(([, index, velocity, isNewPeak]) => ({ index, velocity, isNewPeak }))
 
 // Literal-hex zone colours (must match the component's tokens exactly — same as the
 // single-strip suite): the default effort scale and the WA 5-band mapping.
@@ -361,9 +398,113 @@ describe('DualVelocityStrip set-type streams (windows render on the composed her
 
 describe('DualVelocityStrip live mode', () => {
   const originalMatchMedia = window.matchMedia
+  beforeEach(() => {
+    liveEntranceCalls.length = 0
+  })
   afterEach(() => {
     if (originalMatchMedia) window.matchMedia = originalMatchMedia
     else delete (window as { matchMedia?: unknown }).matchMedia
+  })
+
+  // The newest rep must animate in on BOTH wings. Before the dual composed real VelocityStrips it
+  // hand-rolled its own wing bars and drove them from a dual-only entrance hook, so the animation
+  // was a second implementation that could — and did — drift from the single strip's. Now both
+  // wings ARE single strips, and `liveRepIndex` reaches them through the ordinary composed prop:
+  // an entrance that fires on one wing only is no longer expressible.
+  it('arms the newest-rep entrance on BOTH wings, each with its OWN live velocity', () => {
+    render(
+      <DualVelocityStrip
+        left={{ velocities: [0.9, 0.85, 0.8] }}
+        right={{ velocities: [0.82, 0.78, 0.7] }}
+        variant="hero"
+        liveRepIndex={2}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: 2, velocity: 0.8, isNewPeak: false },
+      { index: 2, velocity: 0.7, isNewPeak: false },
+    ])
+  })
+
+  it('flags a new set peak PER WING — a peak on one side never speaks for the other', () => {
+    // Up wing climbs to its best on rep 2; down wing declines from its best. The peak bounce is
+    // the loud half of the entrance, so a shared flag would fire it on a wing that got slower.
+    render(
+      <DualVelocityStrip
+        left={{ velocities: [0.7, 0.8, 0.9] }}
+        right={{ velocities: [0.9, 0.8, 0.7] }}
+        variant="hero"
+        liveRepIndex={2}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: 2, velocity: 0.9, isNewPeak: true },
+      { index: 2, velocity: 0.7, isNewPeak: false },
+    ])
+  })
+
+  it('keeps a LAGGING wing inert while the leading wing still animates', () => {
+    // The lagging side holds an index-locked empty at that column, so it has no rep to animate —
+    // but that must not disarm its partner's entrance.
+    render(
+      <DualVelocityStrip
+        left={{ velocities: [0.9, 0.85, 0.8] }}
+        right={{ velocities: [0.82, 0.78] }}
+        variant="hero"
+        liveRepIndex={2}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: 2, velocity: 0.8, isNewPeak: false },
+      { index: 2, velocity: undefined, isNewPeak: false },
+    ])
+  })
+
+  it('reaches both wings through a set descriptor, past its set-type windows', () => {
+    // A `range` set puts cyan variable-window stubs after the performed reps. Rep indices are
+    // counted over rep cells only, so the window must not shift which bar the entrance lands on.
+    render(
+      <DualVelocityStrip
+        left={{ set: { type: 'range', velocities: [0.9, 0.85, 0.8], floor: 4, max: 6 } }}
+        right={{ set: { type: 'range', velocities: [0.8, 0.75, 0.7], floor: 4, max: 6 } }}
+        variant="hero"
+        liveRepIndex={2}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: 2, velocity: 0.8, isNewPeak: false },
+      { index: 2, velocity: 0.7, isNewPeak: false },
+    ])
+  })
+
+  it('arms both wings at rail scale too — its wings are composed strips as well', () => {
+    render(
+      <DualVelocityStrip
+        left={{ velocities: [0.9, 0.85, 0.8] }}
+        right={{ velocities: [0.82, 0.78, 0.7] }}
+        variant="rail"
+        liveRepIndex={2}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: 2, velocity: 0.8, isNewPeak: false },
+      { index: 2, velocity: 0.7, isNewPeak: false },
+    ])
+  })
+
+  it('leaves the folded compact dual inert — flat bars have no height to animate', () => {
+    render(
+      <DualVelocityStrip
+        left={{ velocities: [0.9, 0.8] }}
+        right={{ velocities: [0.8, 0.7] }}
+        variant="compact"
+        liveRepIndex={1}
+      />
+    )
+    expect(wingEntrances()).toEqual([
+      { index: undefined, velocity: undefined, isNewPeak: false },
+      { index: undefined, velocity: undefined, isNewPeak: false },
+    ])
   })
 
   it('renders the live mirrored pair at the given index (hero)', () => {

--- a/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
+++ b/packages/ui/src/components/custom/Workout/VelocityStrip.tsx
@@ -649,6 +649,15 @@ const ANIMATION_DURATION = 400
 // It reuses VelocityStrip's slot model ({@link buildSlots}/{@link VelocitySlot}), its
 // zone color scale ({@link makeBarColorFor}), the hero geometry constants, and the
 // live-rep entrance ({@link useLiveRepGrowth}) — side is POSITION only, never hue.
+//
+// LIVE-REP ENTRANCE — do NOT re-add a dual-only one. The dual used to hand-roll its wing bars and
+// drive them from its own scale-pop hook, so the newest-rep animation existed TWICE and the two
+// copies drifted. Composing single strips retired that hook: `liveRepIndex` is now an ordinary
+// prop on each wing, so both wings animate through the same code path as a single hero and an
+// entrance that fires on one wing only is not expressible. Whether the wings should POP (a
+// whole-bar scale) rather than GROW from the axis is a live design question — but it belongs in
+// SetBarChart's shared entrance, applied to the single hero and the wings together. Reintroducing
+// it here would rebuild exactly the divergence this composition removed.
 
 /** One voltra's velocity stream — the SAME shape VelocityStrip accepts (one of these). */
 export interface DualVelocityStream {


### PR DESCRIPTION
TD-07.02. Ports the intent of `e8986ed` (`feat/TD-ghost-primitives`) onto the composed dual.

**Note on the title.** This was scoped as "Restore the live-rep pop on both diverging dual-hero wings". The *pop* specifically — a whole-bar `transform: scale` entrance — is deliberately not restored; see below. The title reflects what the PR does.

## Why a cherry-pick was not possible

`e8986ed` adds `useLiveRepPop` + `POP_EASING` and applies the scale via `WingBar`, the hand-rolled dual bar renderer. #131 deleted `WingBar` (along with `railSlots` / `RAIL_MIN_BAR` / `RAIL_RADIUS`) when all three dual variants became composed `VelocityStrip`s. The commit's ~55 lines have no surface left to attach to — restoring them means restoring the bespoke renderer, which is exactly what #131 removed.

## What the composed structure already does

`DualVelocityHero` passes `liveRepIndex` to each wing as an ordinary prop; each wing is a real hero, so the entrance runs through `SetBarChart` → `useLiveRepGrowth` per wing, off that wing's own velocities and its own new-peak flag. I verified this at the hook seam across hero, rail, compact, set descriptors, `targetReps` padding, and a lagging side — it is armed symmetrically in every case.

So the asymmetry the dual-only hook existed to manage is not fixed, it is **unexpressible**: there is no dual-side code path that could fire on one wing and not the other. That is the property #131 bought, and it is preserved here.

## What was actually missing: the test

The entrance is an imperative `Animated` value. jsdom never reflects it — a live bar's inline height stays at its static value for the whole animation, and driving `requestAnimationFrame` under fake timers does not change that. The existing live-mode test therefore only asserted that the bars *render*, which a one-wing regression would pass.

Six tests added at the shared-hook seam (a pass-through spy, so every other test in the file renders unmocked):

- both wings armed, each with its **own** live velocity
- new-peak flagged **per wing** — a peak on one side must not fire the bounce on a side that got slower
- a lagging wing stays inert **without** disarming its partner
- a `range` set's cyan window does not shift which bar the entrance lands on
- rail wings armed (also composed strips)
- folded compact inert (flat bars, nothing to animate)

**Verified non-vacuous:** temporarily passing `liveRepIndex` to the up wing only fails four of the six. The pre-existing DOM test still passes under that mutation — it was blind to exactly this bug class.

## What I did NOT do, and why

I did not reintroduce the scale-pop character (pop vs. grow-from-axis). Doing so would need an entrance-style fork threaded `VelocityStrip` → `SetBarChart`, making the dual animate differently from a single hero — rebuilding the single/dual divergence #131 eliminated — and it would require editing `charts/SetBarChart.tsx`, outside this task's file ownership. `e8986ed`'s own message calls the single-grows / dual-pops split "an open Phase C review question, not resolved here"; it still is.

If the pop is wanted, it belongs in `SetBarChart`'s shared entrance, applied to the single hero and the wings together. A code comment in the dual section records this so the next reader doesn't re-add a dual-only hook.

## Gates

- `CI=true npx vitest run` — 140 files, 2766 tests, all passing
- `npx tsc --noEmit` — clean
- `npx eslint src` — 0 errors (89 pre-existing warnings, none in changed files)

Not screenshotted: the change is test-and-comment only, no geometry touched, and a still frame cannot show an entrance animation anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)