### PR TITLE
Fatigue card design pass: ROM text, band alignment, surface grounding

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { GhostBand, BAND_H } from './GhostBand'
+import { PHASE_AXIS_COLOR } from './fatigue-tokens'
+import type { PhaseSegment } from './fatigue-model'
+
+/** Phase runs with SEAMS between them — the shape the sample-derived model actually produces. */
+const segments: PhaseSegment[] = [
+  { phase: 'eccentric', startMs: 0, endMs: 1182 },
+  { phase: 'idle', startMs: 1273, endMs: 1600 },
+  { phase: 'concentric', startMs: 1691, endMs: 3545 },
+]
+
+const x = (ms: number) => 12 + (ms / 4000) * 300
+
+const band = (segs: PhaseSegment[] = segments) =>
+  render(
+    <svg>
+      <GhostBand segments={segs} x={x} top={0} height={BAND_H} />
+    </svg>
+  ).container
+
+const geom = (r: Element) => ({
+  x: Number(r.getAttribute('x')),
+  width: Number(r.getAttribute('width')),
+  fill: r.getAttribute('fill'),
+})
+
+/** The strip floor — the one rect sitting directly in the clipped group. */
+const floorOf = (c: HTMLElement) => geom(c.querySelector('g[clip-path] > rect')!)
+/** The phase runs — one rect per run, each in its own group. */
+const runsOf = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('g[clip-path] > g > rect')).map(geom)
+
+describe('GhostBand', () => {
+  it('draws a contiguous strip — each run butts against the next with no gap', () => {
+    const runs = runsOf(band())
+    runs.forEach((r, i) => {
+      const next = runs[i + 1]
+      if (next) expect(r.x + r.width).toBeCloseTo(next.x, 5)
+    })
+  })
+
+  it('floors the whole rep with the idle tone so a pause reads as band, not a hole', () => {
+    const floor = floorOf(band())
+    expect(floor.fill).toBe(PHASE_AXIS_COLOR.idle)
+    expect(floor.x).toBeCloseTo(x(0), 5)
+    expect(floor.x + floor.width).toBeCloseTo(x(3545), 5)
+  })
+
+  it('paints the pause run in the idle tone', () => {
+    const runs = runsOf(band())
+    expect(runs.map((r) => r.fill)).toEqual([
+      PHASE_AXIS_COLOR.eccentric,
+      PHASE_AXIS_COLOR.idle,
+      PHASE_AXIS_COLOR.concentric,
+    ])
+  })
+
+  it('renders nothing when every run is zero-width', () => {
+    const c = band([{ phase: 'idle', startMs: 500, endMs: 500 }])
+    expect(c.querySelectorAll('rect')).toHaveLength(0)
+  })
+
+  it('rounds the band once, as a clip — never per run', () => {
+    const c = band()
+    expect(c.querySelector('clipPath rect')?.getAttribute('rx')).toBe('2')
+    const runRects = Array.from(c.querySelectorAll('g[clip-path] > g > rect'))
+    expect(runRects.every((r) => r.getAttribute('rx') == null)).toBe(true)
+  })
+})

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -1,0 +1,83 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+/**
+ * GhostBand — the wide phase-coloured AXIS BAND that carries movement phase for the
+ * ghost family (eccentric magenta / concentric cyan / idle grey), with the ECC / CON
+ * labels rendered INSIDE it. Extracted from GhostSpark so the single sparkline and a
+ * future top/bottom dual compose the SAME band instead of re-rolling it.
+ *
+ * It is a pure SVG group: the caller owns the x-scale (`x`) and the band's vertical
+ * placement (`top`), so the same band serves a bottom-pinned single or a centred dual.
+ */
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { FONT_UI, PHASE_AXIS_COLOR } from './fatigue-tokens'
+import type { PhaseSegment } from './fatigue-model'
+
+const t = getSemanticColors('dark')
+
+/** Band height in px. */
+export const BAND_H = 16
+/** Gap between the band's near edge and a bloom's baseline. */
+export const BAND_GAP = 4
+
+export interface GhostBandProps {
+  /** The current rep's phase runs, in stream order. */
+  segments: PhaseSegment[]
+  /** Time (ms) → px mapper, owned by the caller. */
+  x: (ms: number) => number
+  /** The band's top edge, px. */
+  top: number
+  /** Band height, px. Default {@link BAND_H}. */
+  height?: number
+  /** Reveal the ECC / CON labels inside the band. */
+  showLabels?: boolean
+  /** Label colour. Default the primary text token. */
+  labelColor?: string
+}
+
+/** The phase-coloured axis band — one rounded rect per phase run, ECC/CON labelled inside. */
+export function GhostBand({
+  segments,
+  x,
+  top,
+  height = BAND_H,
+  showLabels = false,
+  labelColor = t['text-primary'],
+}: GhostBandProps) {
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const segW = x(seg.endMs) - x(seg.startMs)
+        if (segW <= 0) return null
+        const label =
+          seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
+        return (
+          <g key={i}>
+            <rect
+              x={x(seg.startMs)}
+              y={top}
+              width={Math.max(0, segW - 1)}
+              height={height}
+              rx={2}
+              fill={PHASE_AXIS_COLOR[seg.phase]}
+            />
+            {showLabels && label && segW > 20 && (
+              <text
+                x={(x(seg.startMs) + x(seg.endMs)) / 2}
+                y={top + height / 2}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill={labelColor}
+                fontSize={8}
+                fontWeight={800}
+                letterSpacing={1}
+                fontFamily={FONT_UI}
+              >
+                {label}
+              </text>
+            )}
+          </g>
+        )
+      })}
+    </>
+  )
+}

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -48,8 +48,7 @@ export function GhostBand({
       {segments.map((seg, i) => {
         const segW = x(seg.endMs) - x(seg.startMs)
         if (segW <= 0) return null
-        const label =
-          seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
+        const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
         return (
           <g key={i}>
             <rect

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -8,6 +8,7 @@
  * It is a pure SVG group: the caller owns the x-scale (`x`) and the band's vertical
  * placement (`top`), so the same band serves a bottom-pinned single or a centred dual.
  */
+import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FONT_UI, PHASE_AXIS_COLOR } from './fatigue-tokens'
 import type { PhaseSegment } from './fatigue-model'
@@ -34,7 +35,15 @@ export interface GhostBandProps {
   labelColor?: string
 }
 
-/** The phase-coloured axis band — one rounded rect per phase run, ECC/CON labelled inside. */
+/**
+ * The phase-coloured axis band — ONE contiguous strip whose internal boundaries land
+ * exactly on the sparkline's phase transitions.
+ *
+ * Contiguity is structural, not incidental: the band is a single rounded silhouette
+ * (clipped), floored with the idle tone across its whole time extent, and each phase run
+ * paints SQUARE inside that clip, extended to the next run's start. No per-segment inset
+ * and no per-segment rounding — those read as gaps between sections.
+ */
 export function GhostBand({
   segments,
   x,
@@ -43,40 +52,69 @@ export function GhostBand({
   showLabels = false,
   labelColor = t['text-primary'],
 }: GhostBandProps) {
+  const rawId = useId()
+  const clipId = `ghost-band-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+
+  const drawn = segments.filter((seg) => x(seg.endMs) - x(seg.startMs) > 0)
+  if (drawn.length === 0) return null
+
+  const bandLeft = x(drawn[0].startMs)
+  const bandRight = x(drawn[drawn.length - 1].endMs)
+  const bandW = bandRight - bandLeft
+  if (bandW <= 0) return null
+
   return (
-    <>
-      {segments.map((seg, i) => {
-        const segW = x(seg.endMs) - x(seg.startMs)
-        if (segW <= 0) return null
-        const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
-        return (
-          <g key={i}>
-            <rect
-              x={x(seg.startMs)}
-              y={top}
-              width={Math.max(0, segW - 1)}
-              height={height}
-              rx={2}
-              fill={PHASE_AXIS_COLOR[seg.phase]}
-            />
-            {showLabels && label && segW > 20 && (
-              <text
-                x={(x(seg.startMs) + x(seg.endMs)) / 2}
-                y={top + height / 2}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={labelColor}
-                fontSize={8}
-                fontWeight={800}
-                letterSpacing={1}
-                fontFamily={FONT_UI}
-              >
-                {label}
-              </text>
-            )}
-          </g>
-        )
-      })}
-    </>
+    <g>
+      <defs>
+        <clipPath id={clipId}>
+          <rect x={bandLeft} y={top} width={bandW} height={height} rx={2} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>
+        {/* the strip floor — the idle tone spans the rep so a pause is band, not a hole. */}
+        <rect
+          x={bandLeft}
+          y={top}
+          width={bandW}
+          height={height}
+          fill={PHASE_AXIS_COLOR.idle}
+          data-testid="ghost-band-floor"
+        />
+        {drawn.map((seg, i) => {
+          const left = x(seg.startMs)
+          // Butt each run against the next run's start (not its own end) so rounding
+          // between the two can never open a seam; the last run runs to the band edge.
+          const right = i === drawn.length - 1 ? bandRight : x(drawn[i + 1].startMs)
+          const segW = Math.max(0, right - left)
+          const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
+          return (
+            <g key={i}>
+              <rect
+                x={left}
+                y={top}
+                width={segW}
+                height={height}
+                fill={PHASE_AXIS_COLOR[seg.phase]}
+              />
+              {showLabels && label && segW > 20 && (
+                <text
+                  x={left + segW / 2}
+                  y={top + height / 2}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fill={labelColor}
+                  fontSize={8}
+                  fontWeight={800}
+                  letterSpacing={1}
+                  fontFamily={FONT_UI}
+                >
+                  {label}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </g>
+    </g>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
@@ -1,0 +1,95 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+/**
+ * GhostBloom — the smoothPath velocity "bloom": the faded ghost fan of prior reps, a
+ * dark halo underlay, and the control-aware silver→red current-rep line on top. Extracted
+ * from GhostSpark so the single sparkline and a future top/bottom dual compose the SAME
+ * bloom (one grows up from a baseline, the mirrored twin grows down) rather than forking
+ * the path machinery.
+ *
+ * It is a pure SVG group: the caller owns the x/y scale (so orientation — grow up or down —
+ * is a mapping decision) and passes the silver→red `tint` from {@link ghostLineColor}.
+ */
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+
+const t = getSemanticColors('dark')
+const PARCH = t['text-primary']
+
+export type Pt = [number, number]
+
+/** Catmull-Rom → cubic-bezier smoothing over a point list. */
+export function smoothPath(pts: Pt[]): string {
+  if (pts.length < 2) return pts.length ? `M ${pts[0][0]} ${pts[0][1]}` : ''
+  let d = `M ${pts[0][0].toFixed(1)} ${pts[0][1].toFixed(1)}`
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]
+    const p1 = pts[i]
+    const p2 = pts[i + 1]
+    const p3 = pts[i + 2] ?? p2
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6
+    d += ` C ${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${p2[0].toFixed(1)} ${p2[1].toFixed(1)}`
+  }
+  return d
+}
+
+export interface GhostBloomProps {
+  /** The current rep's points, already mapped to px. */
+  current: Pt[]
+  /** Prior-rep ("ghost") point sets, oldest first, already mapped to px. */
+  ghosts?: Pt[][]
+  /** The current-line tint — silver→red from {@link ghostLineColor}. */
+  tint: string
+  /** Per-ghost stroke colour by index; default fades the primary text token. */
+  ghostStroke?: (index: number) => string
+  /** Current-line stroke width, px. Default 3.5. */
+  lineWidth?: number
+  /** Dark halo underlay width, px. Default 7. */
+  haloWidth?: number
+}
+
+/** The ghost fan + halo + tinted current line. Render inside an `<svg>`. */
+export function GhostBloom({
+  current,
+  ghosts = [],
+  tint,
+  ghostStroke = (i) => alpha(PARCH, 0.1 + i * 0.015),
+  lineWidth = 3.5,
+  haloWidth = 7,
+}: GhostBloomProps) {
+  return (
+    <>
+      {/* prior reps — faded ghosts (absolute time → the fan reads as drift). */}
+      {ghosts.map((pts, i) => (
+        <path
+          key={i}
+          d={smoothPath(pts)}
+          fill="none"
+          stroke={ghostStroke(i)}
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+        />
+      ))}
+
+      {/* current rep — a soft dark halo underlay, then the tinted line on top. */}
+      <path
+        d={smoothPath(current)}
+        fill="none"
+        stroke={alpha('#000000', 0.55)}
+        strokeWidth={haloWidth}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <path
+        d={smoothPath(current)}
+        fill="none"
+        stroke={tint}
+        strokeWidth={lineWidth}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </>
+  )
+}

--- a/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
@@ -12,6 +12,7 @@
  * one-prop flip, not a second component.
  */
 import { useId } from 'react'
+import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 
@@ -127,7 +128,7 @@ export function GhostBloom({
         <path
           d={curD}
           fill="none"
-          stroke={alpha('#000000', 0.3)}
+          stroke={alpha(primitiveColors.black, 0.3)}
           strokeWidth={lineWidth + 3}
           strokeLinejoin="round"
           strokeLinecap="round"
@@ -138,7 +139,7 @@ export function GhostBloom({
         <path
           d={curD}
           fill="none"
-          stroke={alpha('#000000', 0.33)}
+          stroke={alpha(primitiveColors.black, 0.33)}
           strokeWidth={lineWidth + 0.5}
           strokeLinejoin="round"
           strokeLinecap="round"
@@ -162,7 +163,7 @@ export function GhostBloom({
         <path
           d={curD}
           fill="none"
-          stroke={alpha('#FFFFFF', 0.28)}
+          stroke={alpha(primitiveColors.white, 0.28)}
           strokeWidth={1.1}
           strokeLinejoin="round"
           strokeLinecap="round"

--- a/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
@@ -1,23 +1,27 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 /**
- * GhostBloom — the smoothPath velocity "bloom": the faded ghost fan of prior reps, a
- * dark halo underlay, and the control-aware silver→red current-rep line on top. Extracted
- * from GhostSpark so the single sparkline and a future top/bottom dual compose the SAME
- * bloom (one grows up from a baseline, the mirrored twin grows down) rather than forking
- * the path machinery.
+ * GhostBloom — the smoothPath velocity "bloom": the faded ghost fan of prior reps and the
+ * control-aware silver→red current-rep line, over a paper-inspired line treatment.
+ * Extracted from GhostSpark so the single sparkline and the mirrored dual compose the SAME
+ * bloom — the dual is just two blooms sharing one axis, one grown UP and one flipped to grow
+ * DOWN (the ghost analogue of the diverging VelocityStrip's orientation flip). Improve the
+ * bloom once and both single + dual inherit it.
  *
- * It is a pure SVG group: the caller owns the x/y scale (so orientation — grow up or down —
- * is a mapping decision) and passes the silver→red `tint` from {@link ghostLineColor}.
+ * The caller owns the x-scale and passes MAGNITUDES (px height off the axis, ≥ 0); the bloom
+ * owns the `baseline` (axis y) and `orientation` (grow up or down), so a mirrored twin is a
+ * one-prop flip, not a second component.
  */
+import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 
 const t = getSemanticColors('dark')
 const PARCH = t['text-primary']
 
+/** A point as `[x_px, magnitude_px]` — magnitude is height off the axis baseline (≥ 0). */
 export type Pt = [number, number]
 
-/** Catmull-Rom → cubic-bezier smoothing over a point list. */
+/** Catmull-Rom → cubic-bezier smoothing over absolute `[x, y]` points. */
 export function smoothPath(pts: Pt[]): string {
   if (pts.length < 2) return pts.length ? `M ${pts[0][0]} ${pts[0][1]}` : ''
   let d = `M ${pts[0][0].toFixed(1)} ${pts[0][1].toFixed(1)}`
@@ -35,37 +39,70 @@ export function smoothPath(pts: Pt[]): string {
   return d
 }
 
+/**
+ * The line's ground treatment. Adapts the bar "paper" language (grain + rim-light + soft
+ * contact shadow) to a chart LINE — no hard black outline:
+ * - `soft` — a soft, blurred, low-opacity dark shadow with no hard edge (the quiet default).
+ * - `glow` — a soft blurred halo in the line's OWN tint (no black at all).
+ * - `rimlight` — a thin lighter rim on the upper edge + a soft blurred contact shadow below
+ *   (paper's inset highlight + drop shadow).
+ */
+export type BloomTreatment = 'soft' | 'glow' | 'rimlight'
+
 export interface GhostBloomProps {
-  /** The current rep's points, already mapped to px. */
+  /** The current rep as `[x_px, magnitude_px]` points (magnitude ≥ 0 off the baseline). */
   current: Pt[]
-  /** Prior-rep ("ghost") point sets, oldest first, already mapped to px. */
+  /** Prior-rep ("ghost") point sets, oldest first, same `[x, magnitude]` shape. */
   ghosts?: Pt[][]
   /** The current-line tint — silver→red from {@link ghostLineColor}. */
   tint: string
+  /** The axis y (px) the bloom grows from. */
+  baseline: number
+  /** Grow UP from the baseline (default) or DOWN — the mirrored-dual flip. */
+  orientation?: 'up' | 'down'
+  /** The paper-inspired line ground treatment. Default `soft`. */
+  treatment?: BloomTreatment
   /** Per-ghost stroke colour by index; default fades the primary text token. */
   ghostStroke?: (index: number) => string
   /** Current-line stroke width, px. Default 3.5. */
   lineWidth?: number
-  /** Dark halo underlay width, px. Default 7. */
-  haloWidth?: number
 }
 
-/** The ghost fan + halo + tinted current line. Render inside an `<svg>`. */
+/** The ghost fan + the paper-treated tinted current line. Render inside an `<svg>`. */
 export function GhostBloom({
   current,
   ghosts = [],
   tint,
+  baseline,
+  orientation = 'up',
+  treatment = 'soft',
   ghostStroke = (i) => alpha(PARCH, 0.1 + i * 0.015),
   lineWidth = 3.5,
-  haloWidth = 7,
 }: GhostBloomProps) {
+  const rawId = useId()
+  const blurId = `bloom-blur-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+  const toY = (mag: number) => (orientation === 'down' ? baseline + mag : baseline - mag)
+  const toAbs = (pts: Pt[]): Pt[] => pts.map(([px, mag]) => [px, toY(mag)])
+  const curD = smoothPath(toAbs(current))
+  const ghostDs = ghosts.map((g) => smoothPath(toAbs(g)))
+  // Rim-light sits on the side the line grows toward (its "top"); shadow falls the other way.
+  const rimDy = orientation === 'down' ? 1 : -1
+  const shadowDy = orientation === 'down' ? -2.2 : 2.2
+  const blurStdDev = treatment === 'glow' ? 3.4 : treatment === 'rimlight' ? 1.8 : 2.6
+
   return (
     <>
+      <defs>
+        <filter id={blurId} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation={blurStdDev} />
+        </filter>
+      </defs>
+
       {/* prior reps — faded ghosts (absolute time → the fan reads as drift). */}
-      {ghosts.map((pts, i) => (
+      {ghostDs.map((d, i) => (
         <path
           key={i}
-          d={smoothPath(pts)}
+          d={d}
           fill="none"
           stroke={ghostStroke(i)}
           strokeWidth={1.5}
@@ -73,23 +110,65 @@ export function GhostBloom({
         />
       ))}
 
-      {/* current rep — a soft dark halo underlay, then the tinted line on top. */}
+      {/* ground treatment — a paper-inspired line contact, never a hard black outline. */}
+      {treatment === 'glow' && (
+        <path
+          d={curD}
+          fill="none"
+          stroke={tint}
+          strokeWidth={lineWidth + 4}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          opacity={0.55}
+          filter={`url(#${blurId})`}
+        />
+      )}
+      {treatment === 'soft' && (
+        <path
+          d={curD}
+          fill="none"
+          stroke={alpha('#000000', 0.3)}
+          strokeWidth={lineWidth + 3}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          filter={`url(#${blurId})`}
+        />
+      )}
+      {treatment === 'rimlight' && (
+        <path
+          d={curD}
+          fill="none"
+          stroke={alpha('#000000', 0.33)}
+          strokeWidth={lineWidth + 0.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          filter={`url(#${blurId})`}
+          transform={`translate(0,${shadowDy})`}
+        />
+      )}
+
+      {/* the crisp tinted line. */}
       <path
-        d={smoothPath(current)}
-        fill="none"
-        stroke={alpha('#000000', 0.55)}
-        strokeWidth={haloWidth}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-      />
-      <path
-        d={smoothPath(current)}
+        d={curD}
         fill="none"
         stroke={tint}
         strokeWidth={lineWidth}
         strokeLinejoin="round"
         strokeLinecap="round"
       />
+
+      {/* rim-light: a thin lighter edge on the line's upper side (paper inset highlight). */}
+      {treatment === 'rimlight' && (
+        <path
+          d={curD}
+          fill="none"
+          stroke={alpha('#FFFFFF', 0.28)}
+          strokeWidth={1.1}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          transform={`translate(0,${rimDy})`}
+        />
+      )}
     </>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -7,6 +7,7 @@ import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FATIGUE_STATES } from './fatigue-mock'
+import type { PhaseSegment } from './fatigue-model'
 
 const PANEL_BG = primitiveColors.charcoal[800]
 const PAGE_BG = primitiveColors.charcoal[900]
@@ -150,4 +151,36 @@ export const LineTreatmentSoft: Story = {
       <TreatmentDemo treatment="soft" />
     </View>
   ),
+}
+
+/**
+ * A rep with REAL pauses (the sample-derived mock collapses its pauses to zero width, so
+ * the idle tone never shows there). Segments are handed in with SEAMS between the runs —
+ * the shape the model actually produces — to prove the band closes them: one contiguous
+ * strip, boundaries on the phase transitions, the pause reading as band material.
+ */
+const PAUSED_SEGMENTS: PhaseSegment[] = [
+  { phase: 'eccentric', startMs: 0, endMs: 2100 },
+  { phase: 'idle', startMs: 2190, endMs: 2900 },
+  { phase: 'concentric', startMs: 2990, endMs: 4050 },
+  { phase: 'idle', startMs: 4140, endMs: 4600 },
+]
+
+export const PausedRepBand: Story = {
+  render: () => {
+    const w = 360
+    const h = 60
+    const bandTop = 22
+    const x = (ms: number) => 12 + (ms / 4800) * (w - 20)
+    return (
+      <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+        {label('PHASE BAND · REP WITH REAL PAUSES (bottom hold + top hold)')}
+        <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+          <svg width={w} height={h}>
+            <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels />
+          </svg>
+        </View>
+      </View>
+    )
+  },
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -40,7 +40,9 @@ const box = (child: React.ReactNode) => (
 const cur = FATIGUE_STATES[3].model // the full 8-rep set
 
 const label = (s: string) => (
-  <Text style={{ fontSize: 9, letterSpacing: 1, fontFamily: 'monospace', color: t['text-tertiary'] }}>
+  <Text
+    style={{ fontSize: 9, letterSpacing: 1, fontFamily: 'monospace', color: t['text-tertiary'] }}
+  >
     {s}
   </Text>
 )
@@ -58,7 +60,15 @@ export const Default: Story = {
 /** The line tint across the set — early controlled reps stay silver, late reps go through shades of red. */
 export const ControlAwareTint: Story = {
   render: () => (
-    <View style={{ backgroundColor: PAGE_BG, padding: 28, flexDirection: 'row', gap: 24, flexWrap: 'wrap' }}>
+    <View
+      style={{
+        backgroundColor: PAGE_BG,
+        padding: 28,
+        flexDirection: 'row',
+        gap: 24,
+        flexWrap: 'wrap',
+      }}
+    >
       {FATIGUE_STATES.map((s) => (
         <View key={s.name} style={{ gap: 8 }}>
           {label(s.name)}
@@ -83,19 +93,29 @@ function TreatmentDemo({ treatment }: { treatment: BloomTreatment }) {
   const c = curves[curves.length - 1]
   const allSamples = curves.flatMap((cc) => cc.samples)
   const vmax = Math.max(0.01, ...allSamples.map((s) => s.velocityMps)) * 1.06
-  const axisMaxT = Math.max(1, ...curves.map((cc) => cc.samples[cc.samples.length - 1]?.tMs ?? 0)) * 1.04
+  const axisMaxT =
+    Math.max(1, ...curves.map((cc) => cc.samples[cc.samples.length - 1]?.tMs ?? 0)) * 1.04
   const bandTop = h - padBot - BAND_H
   const baseline = bandTop - BAND_GAP
   const plotH = Math.max(1, baseline - padTop)
   const x = (ms: number) => padL + (ms / axisMaxT) * (w - padL - padR)
   const magOf = (v: number) => clamp01(v / vmax) * plotH
   const curPts: Pt[] = c.samples.map((s) => [x(s.tMs), magOf(s.velocityMps)])
-  const ghostPts: Pt[][] = curves.slice(0, -1).map((cc) => cc.samples.map((s): Pt => [x(s.tMs), magOf(s.velocityMps)]))
+  const ghostPts: Pt[][] = curves
+    .slice(0, -1)
+    .map((cc) => cc.samples.map((s): Pt => [x(s.tMs), magOf(s.velocityMps)]))
   const tint = ghostLineColor(c.tempoDeviation, c.grindSignature)
   return (
     <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
       <svg width={w} height={h}>
-        <GhostBloom current={curPts} ghosts={ghostPts} tint={tint} baseline={baseline} orientation="up" treatment={treatment} />
+        <GhostBloom
+          current={curPts}
+          ghosts={ghostPts}
+          tint={tint}
+          baseline={baseline}
+          orientation="up"
+          treatment={treatment}
+        />
         <GhostBand segments={c.phaseSegments} x={x} top={bandTop} showLabels />
       </svg>
     </View>

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { GhostSpark } from './GhostSpark'
+import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
+import { GhostBloom, type Pt, type BloomTreatment } from './GhostBloom'
+import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FATIGUE_STATES } from './fatigue-mock'
@@ -17,15 +20,14 @@ const meta: Meta<typeof GhostSpark> = {
     docs: {
       description: {
         component:
-          'Per-rep velocity-time sparkline on the band model (coherent with the dual ghost-line): a wide ' +
-          'phase-coloured band at the bottom (ecc magenta / con cyan, ECC/CON labelled inside) with the ' +
-          'velocity blooming UP from it — current rep solid over faded ghosts, control-aware silver/red line ' +
-          'tint (silver when controlled, dimming with tempo drift; shades of red on collapse), and the tempo ' +
-          'tuple embedded (revealed on hover). `forceRevealed` pins the annotated state.',
+          'Per-rep velocity-time sparkline on the band model (coherent with the mirrored dual): a wide ' +
+          'phase-coloured band at the bottom (ecc magenta / con cyan, ECC/CON labelled inside, always ' +
+          'shown) with the velocity blooming UP from it — current rep solid over faded ghosts, a control-' +
+          'aware silver/red line tint (silver when controlled, dimming with tempo drift; shades of red on ' +
+          'collapse), over a soft paper-inspired ground (no hard outline).',
       },
     },
   },
-  argTypes: { forceRevealed: { control: 'boolean' } },
 }
 export default meta
 type Story = StoryObj<typeof GhostSpark>
@@ -37,59 +39,18 @@ const box = (child: React.ReactNode) => (
 )
 const cur = FATIGUE_STATES[3].model // the full 8-rep set
 
-/** Rest vs hover — identical geometry, only the annotations bloom. */
-export const RestVsHover: Story = {
+const label = (s: string) => (
+  <Text style={{ fontSize: 9, letterSpacing: 1, fontFamily: 'monospace', color: t['text-tertiary'] }}>
+    {s}
+  </Text>
+)
+
+/** The default spark — band + bloom, ECC/CON labels always visible. */
+export const Default: Story = {
   render: () => (
-    <View
-      style={{
-        backgroundColor: PAGE_BG,
-        padding: 28,
-        flexDirection: 'row',
-        gap: 24,
-        alignItems: 'flex-start',
-      }}
-    >
-      <View style={{ gap: 8 }}>
-        <Text
-          style={{
-            fontSize: 9,
-            letterSpacing: 1,
-            fontFamily: 'monospace',
-            color: t['text-tertiary'],
-          }}
-        >
-          RESTING (hover me)
-        </Text>
-        {box(
-          <GhostSpark
-            curves={cur.velocityCurves}
-            tempoSeconds={cur.tempoSeconds}
-            width={360}
-            height={190}
-          />
-        )}
-      </View>
-      <View style={{ gap: 8 }}>
-        <Text
-          style={{
-            fontSize: 9,
-            letterSpacing: 1,
-            fontFamily: 'monospace',
-            color: t['text-tertiary'],
-          }}
-        >
-          REVEALED
-        </Text>
-        {box(
-          <GhostSpark
-            curves={cur.velocityCurves}
-            tempoSeconds={cur.tempoSeconds}
-            width={360}
-            height={190}
-            forceRevealed
-          />
-        )}
-      </View>
+    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+      {label('GHOST SPARK')}
+      {box(<GhostSpark curves={cur.velocityCurves} width={360} height={190} />)}
     </View>
   ),
 }
@@ -97,38 +58,76 @@ export const RestVsHover: Story = {
 /** The line tint across the set — early controlled reps stay silver, late reps go through shades of red. */
 export const ControlAwareTint: Story = {
   render: () => (
-    <View
-      style={{
-        backgroundColor: PAGE_BG,
-        padding: 28,
-        flexDirection: 'row',
-        gap: 24,
-        flexWrap: 'wrap',
-      }}
-    >
+    <View style={{ backgroundColor: PAGE_BG, padding: 28, flexDirection: 'row', gap: 24, flexWrap: 'wrap' }}>
       {FATIGUE_STATES.map((s) => (
         <View key={s.name} style={{ gap: 8 }}>
-          <Text
-            style={{
-              fontSize: 9,
-              letterSpacing: 1,
-              fontFamily: 'monospace',
-              color: t['text-tertiary'],
-            }}
-          >
-            {s.name}
-          </Text>
-          {box(
-            <GhostSpark
-              curves={s.model.velocityCurves}
-              tempoSeconds={s.model.tempoSeconds}
-              width={360}
-              height={170}
-              forceRevealed
-            />
-          )}
+          {label(s.name)}
+          {box(<GhostSpark curves={s.model.velocityCurves} width={360} height={170} />)}
         </View>
       ))}
+    </View>
+  ),
+}
+
+// --- Line ground treatment comparison ------------------------------------------------
+// The paper-inspired line treatments, fed the same current rep, for the operator to pick.
+// Each renders GhostBloom directly (same geometry GhostSpark uses) at one treatment.
+function TreatmentDemo({ treatment }: { treatment: BloomTreatment }) {
+  const w = 360
+  const h = 190
+  const padL = 12
+  const padR = 8
+  const padTop = 10
+  const padBot = 6
+  const curves = cur.velocityCurves
+  const c = curves[curves.length - 1]
+  const allSamples = curves.flatMap((cc) => cc.samples)
+  const vmax = Math.max(0.01, ...allSamples.map((s) => s.velocityMps)) * 1.06
+  const axisMaxT = Math.max(1, ...curves.map((cc) => cc.samples[cc.samples.length - 1]?.tMs ?? 0)) * 1.04
+  const bandTop = h - padBot - BAND_H
+  const baseline = bandTop - BAND_GAP
+  const plotH = Math.max(1, baseline - padTop)
+  const x = (ms: number) => padL + (ms / axisMaxT) * (w - padL - padR)
+  const magOf = (v: number) => clamp01(v / vmax) * plotH
+  const curPts: Pt[] = c.samples.map((s) => [x(s.tMs), magOf(s.velocityMps)])
+  const ghostPts: Pt[][] = curves.slice(0, -1).map((cc) => cc.samples.map((s): Pt => [x(s.tMs), magOf(s.velocityMps)]))
+  const tint = ghostLineColor(c.tempoDeviation, c.grindSignature)
+  return (
+    <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+      <svg width={w} height={h}>
+        <GhostBloom current={curPts} ghosts={ghostPts} tint={tint} baseline={baseline} orientation="up" treatment={treatment} />
+        <GhostBand segments={c.phaseSegments} x={x} top={bandTop} showLabels />
+      </svg>
+    </View>
+  )
+}
+
+/** (a) Soft blurred GLOW in the line's own tint — a colored halo, no black. */
+export const LineTreatmentGlow: Story = {
+  render: () => (
+    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+      {label('A · GLOW (colored halo, no black)')}
+      <TreatmentDemo treatment="glow" />
+    </View>
+  ),
+}
+
+/** (b) Rim-light: a thin lighter edge on the upper side + a soft contact shadow below. */
+export const LineTreatmentRimlight: Story = {
+  render: () => (
+    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+      {label('B · RIM-LIGHT (upper rim + soft contact shadow)')}
+      <TreatmentDemo treatment="rimlight" />
+    </View>
+  ),
+}
+
+/** (c) Soft: a much softer/blurrier low-opacity shadow with no hard edge (the default). */
+export const LineTreatmentSoft: Story = {
+  render: () => (
+    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+      {label('C · SOFT (blurred low-opacity shadow, no hard edge)')}
+      <TreatmentDemo treatment="soft" />
     </View>
   ),
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.test.tsx
@@ -7,93 +7,38 @@ const model = FATIGUE_STATES[3].model // the full 8-rep set
 
 describe('GhostSpark', () => {
   it('renders without crashing for a populated set', () => {
-    render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-      />
-    )
+    render(<GhostSpark curves={model.velocityCurves} width={360} height={180} />)
     expect(screen.getByTestId('ghost-spark')).toBeInTheDocument()
   })
 
   it('renders an empty box for no curves', () => {
-    render(<GhostSpark curves={[]} tempoSeconds={null} width={360} height={180} />)
+    render(<GhostSpark curves={[]} width={360} height={180} />)
     expect(screen.getByTestId('ghost-spark')).toBeInTheDocument()
   })
 
-  it('hides the peak annotation at rest', () => {
-    render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-      />
-    )
+  it('does not render a peak annotation (chrome removed)', () => {
+    render(<GhostSpark curves={model.velocityCurves} width={360} height={180} />)
     expect(screen.queryByText(/peak/)).not.toBeInTheDocument()
   })
 
-  it('reveals the peak annotation when forced revealed', () => {
-    render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-        forceRevealed
-      />
-    )
-    expect(screen.getByText(/^peak /)).toBeInTheDocument()
-  })
-
-  it('renders one ghost path per prior rep plus the current line + halo', () => {
+  it('renders one ghost path per prior rep plus the current line + soft ground', () => {
     const { container } = render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-      />
+      <GhostSpark curves={model.velocityCurves} width={360} height={180} />
     )
-    // 7 ghosts + 2 current (halo + tint) = 9 paths for an 8-rep set.
+    // 7 ghosts + 2 current (soft ground + tint line) = 9 paths for an 8-rep set.
     expect(container.querySelectorAll('path')).toHaveLength(9)
   })
 
   it('draws the wide phase band (rects) for the current rep phase runs', () => {
     const { container } = render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-      />
+      <GhostSpark curves={model.velocityCurves} width={360} height={180} />
     )
     // one band rect per phase segment (ecc / pause / con / hold ⇒ ≥ 2).
     expect(container.querySelectorAll('rect').length).toBeGreaterThanOrEqual(2)
   })
 
-  it('hides the ECC/CON band labels at rest, shows them when revealed', () => {
-    const { rerender } = render(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-      />
-    )
-    expect(screen.queryByText('ECC')).not.toBeInTheDocument()
-    expect(screen.queryByText('CON')).not.toBeInTheDocument()
-    rerender(
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={360}
-        height={180}
-        forceRevealed
-      />
-    )
+  it('always shows the ECC / CON band labels (no longer hover-gated)', () => {
+    render(<GhostSpark curves={model.velocityCurves} width={360} height={180} />)
     expect(screen.getByText('ECC')).toBeInTheDocument()
     expect(screen.getByText('CON')).toBeInTheDocument()
   })

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
@@ -1,94 +1,35 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 /**
  * GhostSpark — the per-rep velocity-time sparkline, on the band model (coherent with
- * the dual ghost-line: single = one bloom + band; dual = two blooms + the same band).
+ * the mirrored dual: single = one bloom + band; dual = two blooms sharing one band).
  *
  * A WIDE phase-coloured AXIS BAND ({@link GhostBand}) sits at the BOTTOM, filled per the
  * current rep's phase runs (eccentric magenta / concentric cyan / idle grey), each sized
- * to its time extent, with the ECC / CON labels INSIDE the band. Velocity is drawn as
- * MAGNITUDE blooming UP from just above the band ({@link GhostBloom}) — the current rep
- * SOLID over faded grey GHOSTS of the prior reps. Phase is carried by the band colour
+ * to its time extent, with the ECC / CON labels always shown INSIDE the band. Velocity is
+ * drawn as MAGNITUDE blooming UP from just above the band ({@link GhostBloom}) — the current
+ * rep SOLID over faded grey GHOSTS of the prior reps. Phase is carried by the band colour
  * beneath the line (no ecc-below / con-above split), so single and dual read the same.
  *
  * The current line's TINT is control-aware silver/red (see {@link ghostLineColor}): a
  * controlled rep stays silver (dimming slightly with tempo drift), a collapsing rep goes
- * through shades of red.
- *
- * At rest it's the band + the bloom. On HOVER the annotations bloom — the ECC/CON band
- * labels, the peak marker, and the current-rep TEMPO tuple (colored digits, overlaid
- * top-left) — with identical geometry, so nothing shifts. Tempo lives HERE (embedded);
- * there is no standalone hero-tempo treatment.
+ * through shades of red. The line rides a paper-inspired ground treatment (soft contact
+ * shadow), not a hard outline.
  */
-import { useState } from 'react'
-import { View, Text, Pressable } from 'react-native'
-import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { roundTempo } from '../../../utils/workout-format'
-import { FONT_UI, FONT_MONO, TEMPO_DIGIT_COLOR, ghostLineColor, clamp01 } from './fatigue-tokens'
+import { View } from 'react-native'
+import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
 import { GhostBloom, type Pt } from './GhostBloom'
 import type { RepVelocityCurve } from './fatigue-model'
 
-const t = getSemanticColors('dark')
-
 export interface GhostSparkProps {
   /** Per-rep velocity-time curves, oldest first (last = current rep). */
   curves: RepVelocityCurve[]
-  /** Current-rep tempo tuple `[ecc, pauseBottom, con, pauseTop]` seconds — the hover overlay. `null` = no overlay. */
-  tempoSeconds: [number, number, number, number] | null
   width: number
   /** Plot height in px. Default 172. */
   height?: number
-  /** Pin the revealed (hover) state — for static screenshots / tests. */
-  forceRevealed?: boolean
 }
 
-/** A bare inline tempo tuple — colored digits + grey dashes only (ecc magenta / con cyan). */
-function MiniTempoTuple({ tempo }: { tempo: [number, number, number, number] }) {
-  const digits = roundTempo(tempo)
-  const dash = t['text-tertiary']
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-      {digits.map((n, i) => (
-        <View key={i} style={{ flexDirection: 'row', alignItems: 'center' }}>
-          {i > 0 && (
-            <Text
-              style={{
-                color: dash,
-                fontSize: 11,
-                fontWeight: '700',
-                fontFamily: FONT_UI,
-                marginHorizontal: 3,
-              }}
-            >
-              -
-            </Text>
-          )}
-          <Text
-            style={{
-              color: TEMPO_DIGIT_COLOR[i],
-              fontSize: 11,
-              fontWeight: '800',
-              fontFamily: FONT_UI,
-            }}
-          >
-            {n}
-          </Text>
-        </View>
-      ))}
-    </View>
-  )
-}
-
-export function GhostSpark({
-  curves,
-  tempoSeconds,
-  width,
-  height = 172,
-  forceRevealed,
-}: GhostSparkProps) {
-  const [hovered, setHovered] = useState(false)
-  const revealed = forceRevealed ?? hovered
-
+export function GhostSpark({ curves, width, height = 172 }: GhostSparkProps) {
   const w = width
   const h = height
   const padL = 12
@@ -113,70 +54,30 @@ export function GhostSpark({
   const baseline = bandTop - BAND_GAP
   const plotH = Math.max(1, baseline - padTop)
   const x = (ms: number) => padL + (ms / axisMaxT) * (w - padL - padR)
-  const y = (mag: number) => baseline - clamp01(mag / vmax) * plotH
+  const mag = (v: number) => clamp01(v / vmax) * plotH
 
   const lineTint = ghostLineColor(cur.tempoDeviation, cur.grindSignature)
-  const curPts: Pt[] = cur.samples.map((s) => [x(s.tMs), y(s.velocityMps)])
+  const curPts: Pt[] = cur.samples.map((s) => [x(s.tMs), mag(s.velocityMps)])
   const ghostPts: Pt[][] = curves
     .slice(0, -1)
-    .map((c) => c.samples.map((s): Pt => [x(s.tMs), y(s.velocityMps)]))
-  const peak = cur.samples.reduce((a, b) => (b.velocityMps > a.velocityMps ? b : a), cur.samples[0])
+    .map((c) => c.samples.map((s): Pt => [x(s.tMs), mag(s.velocityMps)]))
 
   return (
-    <Pressable
-      testID="ghost-spark"
-      onHoverIn={() => setHovered(true)}
-      onHoverOut={() => setHovered(false)}
-      style={{ paddingHorizontal: 4 }}
-    >
+    <View testID="ghost-spark" style={{ paddingHorizontal: 4 }}>
       <svg width={w} height={h}>
-        {/* the ghost fan + halo + tinted current line. */}
-        <GhostBloom current={curPts} ghosts={ghostPts} tint={lineTint} />
-
-        {/* peak marker (annotated view only) — ties back to the velocity hero. */}
-        {revealed && peak && (
-          <>
-            <circle
-              cx={x(peak.tMs)}
-              cy={y(peak.velocityMps)}
-              r={4}
-              fill={lineTint}
-              stroke={t['background-base']}
-              strokeWidth={1.5}
-            />
-            <text
-              x={x(peak.tMs) + 7}
-              y={y(peak.velocityMps) - 6}
-              fill={t['text-primary']}
-              fontSize={11}
-              fontWeight={800}
-              fontFamily={FONT_UI}
-            >
-              peak {peak.velocityMps.toFixed(2)} m/s
-            </text>
-          </>
-        )}
+        {/* the ghost fan + paper-treated tinted current line, blooming up from the band. */}
+        <GhostBloom
+          current={curPts}
+          ghosts={ghostPts}
+          tint={lineTint}
+          baseline={baseline}
+          orientation="up"
+        />
 
         {/* the WIDE phase-colored axis band at the bottom — the sole carrier of phase,
-            filled per the current rep's phase runs, ECC/CON labelled INSIDE (on hover). */}
-        <GhostBand segments={cur.phaseSegments} x={x} top={bandTop} showLabels={revealed} />
+            filled per the current rep's phase runs, ECC/CON labelled INSIDE. */}
+        <GhostBand segments={cur.phaseSegments} x={x} top={bandTop} showLabels />
       </svg>
-
-      {/* hover: the bare current-rep tempo tuple, overlaid top-left so nothing reflows. */}
-      {revealed && tempoSeconds && (
-        <View pointerEvents="none" style={{ position: 'absolute', top: 4, left: 8 }}>
-          <MiniTempoTuple tempo={tempoSeconds} />
-        </View>
-      )}
-      {/* a11y: the tempo digits are decorative on hover; expose the tuple as a label. */}
-      {tempoSeconds && (
-        <Text
-          accessibilityElementsHidden
-          style={{ position: 'absolute', width: 1, height: 1, opacity: 0, fontFamily: FONT_MONO }}
-        >
-          tempo {roundTempo(tempoSeconds).join('-')}
-        </Text>
-      )}
-    </Pressable>
+    </View>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
@@ -3,12 +3,12 @@
  * GhostSpark — the per-rep velocity-time sparkline, on the band model (coherent with
  * the dual ghost-line: single = one bloom + band; dual = two blooms + the same band).
  *
- * A WIDE phase-coloured AXIS BAND sits at the BOTTOM, filled per the current rep's phase
- * runs (eccentric magenta / concentric cyan / idle grey), each sized to its time extent,
- * with the ECC / CON labels INSIDE the band. Velocity is drawn as MAGNITUDE blooming UP
- * from just above the band — the current rep SOLID over faded grey GHOSTS of the prior
- * reps. Phase is carried by the band colour beneath the line (no ecc-below / con-above
- * split), so single and dual read the same.
+ * A WIDE phase-coloured AXIS BAND ({@link GhostBand}) sits at the BOTTOM, filled per the
+ * current rep's phase runs (eccentric magenta / concentric cyan / idle grey), each sized
+ * to its time extent, with the ECC / CON labels INSIDE the band. Velocity is drawn as
+ * MAGNITUDE blooming UP from just above the band ({@link GhostBloom}) — the current rep
+ * SOLID over faded grey GHOSTS of the prior reps. Phase is carried by the band colour
+ * beneath the line (no ecc-below / con-above split), so single and dual read the same.
  *
  * The current line's TINT is control-aware silver/red (see {@link ghostLineColor}): a
  * controlled rep stays silver (dimming slightly with tempo drift), a collapsing rep goes
@@ -21,43 +21,14 @@
  */
 import { useState } from 'react'
 import { View, Text, Pressable } from 'react-native'
-import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { alpha } from '../../../utils/colors'
 import { roundTempo } from '../../../utils/workout-format'
-import {
-  FONT_UI,
-  FONT_MONO,
-  PHASE_AXIS_COLOR,
-  TEMPO_DIGIT_COLOR,
-  ghostLineColor,
-  clamp01,
-} from './fatigue-tokens'
+import { FONT_UI, FONT_MONO, TEMPO_DIGIT_COLOR, ghostLineColor, clamp01 } from './fatigue-tokens'
+import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
+import { GhostBloom, type Pt } from './GhostBloom'
 import type { RepVelocityCurve } from './fatigue-model'
 
 const t = getSemanticColors('dark')
-const PARCH = t['text-primary']
-
-const BAND_H = 16 // the wide phase-colored axis band, at the bottom
-const BAND_GAP = 4 // gap between the band's top edge and the bloom's baseline
-
-type Pt = [number, number]
-function smoothPath(pts: Pt[]): string {
-  if (pts.length < 2) return pts.length ? `M ${pts[0][0]} ${pts[0][1]}` : ''
-  let d = `M ${pts[0][0].toFixed(1)} ${pts[0][1].toFixed(1)}`
-  for (let i = 0; i < pts.length - 1; i++) {
-    const p0 = pts[i - 1] ?? pts[i]
-    const p1 = pts[i]
-    const p2 = pts[i + 1]
-    const p3 = pts[i + 2] ?? p2
-    const c1x = p1[0] + (p2[0] - p0[0]) / 6
-    const c1y = p1[1] + (p2[1] - p0[1]) / 6
-    const c2x = p2[0] - (p3[0] - p1[0]) / 6
-    const c2y = p2[1] - (p3[1] - p1[1]) / 6
-    d += ` C ${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${p2[0].toFixed(1)} ${p2[1].toFixed(1)}`
-  }
-  return d
-}
 
 export interface GhostSparkProps {
   /** Per-rep velocity-time curves, oldest first (last = current rep). */
@@ -146,6 +117,9 @@ export function GhostSpark({
 
   const lineTint = ghostLineColor(cur.tempoDeviation, cur.grindSignature)
   const curPts: Pt[] = cur.samples.map((s) => [x(s.tMs), y(s.velocityMps)])
+  const ghostPts: Pt[][] = curves
+    .slice(0, -1)
+    .map((c) => c.samples.map((s): Pt => [x(s.tMs), y(s.velocityMps)]))
   const peak = cur.samples.reduce((a, b) => (b.velocityMps > a.velocityMps ? b : a), cur.samples[0])
 
   return (
@@ -156,35 +130,8 @@ export function GhostSpark({
       style={{ paddingHorizontal: 4 }}
     >
       <svg width={w} height={h}>
-        {/* prior reps — faded grey ghosts blooming up (absolute time → the fan is drift). */}
-        {curves.slice(0, -1).map((c, rep) => (
-          <path
-            key={rep}
-            d={smoothPath(c.samples.map((s) => [x(s.tMs), y(s.velocityMps)]))}
-            fill="none"
-            stroke={alpha(PARCH, 0.1 + rep * 0.015)}
-            strokeWidth={1.5}
-            strokeLinejoin="round"
-          />
-        ))}
-
-        {/* current rep — a soft dark halo underlay, then the tinted line on top. */}
-        <path
-          d={smoothPath(curPts)}
-          fill="none"
-          stroke={alpha(primitiveColors.black, 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-        <path
-          d={smoothPath(curPts)}
-          fill="none"
-          stroke={lineTint}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        {/* the ghost fan + halo + tinted current line. */}
+        <GhostBloom current={curPts} ghosts={ghostPts} tint={lineTint} />
 
         {/* peak marker (annotated view only) — ties back to the velocity hero. */}
         {revealed && peak && (
@@ -212,39 +159,7 @@ export function GhostSpark({
 
         {/* the WIDE phase-colored axis band at the bottom — the sole carrier of phase,
             filled per the current rep's phase runs, ECC/CON labelled INSIDE (on hover). */}
-        {cur.phaseSegments.map((seg, i) => {
-          const segW = x(seg.endMs) - x(seg.startMs)
-          if (segW <= 0) return null
-          const label =
-            seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
-          return (
-            <g key={i}>
-              <rect
-                x={x(seg.startMs)}
-                y={bandTop}
-                width={Math.max(0, segW - 1)}
-                height={BAND_H}
-                rx={2}
-                fill={PHASE_AXIS_COLOR[seg.phase]}
-              />
-              {revealed && label && segW > 20 && (
-                <text
-                  x={(x(seg.startMs) + x(seg.endMs)) / 2}
-                  y={bandTop + BAND_H / 2}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fill={t['text-primary']}
-                  fontSize={8}
-                  fontWeight={800}
-                  letterSpacing={1}
-                  fontFamily={FONT_UI}
-                >
-                  {label}
-                </text>
-              )}
-            </g>
-          )
-        })}
+        <GhostBand segments={cur.phaseSegments} x={x} top={bandTop} showLabels={revealed} />
       </svg>
 
       {/* hover: the bare current-rep tempo tuple, overlaid top-left so nothing reflows. */}

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta<typeof LiveFatigueCard> = {
   },
   argTypes: {
     width: { control: { type: 'number', min: 260, max: 420, step: 2 } },
-    revealChart: { control: 'boolean' },
   },
 }
 export default meta
@@ -36,9 +35,9 @@ const Frame = ({ children }: { children: React.ReactNode }) => (
   </View>
 )
 
-/** The default (form breaking down) card, ghost-spark revealed. */
+/** The default (form breaking down) card. */
 export const Default: Story = {
-  args: { model: FATIGUE_STATES[3].model, width: 318, height: 508, revealChart: true },
+  args: { model: FATIGUE_STATES[3].model, width: 318, height: 508 },
   render: (args) => (
     <Frame>
       <LiveFatigueCard {...args} />
@@ -70,7 +69,7 @@ export const States: Story = {
           >
             {s.name}
           </Text>
-          <LiveFatigueCard model={s.model} width={300} height={500} revealChart />
+          <LiveFatigueCard model={s.model} width={300} height={500} />
         </View>
       ))}
     </View>

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { LiveFatigueCard } from './LiveFatigueCard'
-import { primitiveColors } from '../../../theme/tokens/primitives'
+import { Surface } from '../../ui/surface/Surface'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FATIGUE_STATES, WARMING_UP_MODEL } from './fatigue-mock'
 
-const PAGE_BG = primitiveColors.charcoal[900]
 const t = getSemanticColors('dark')
 
 const meta: Meta<typeof LiveFatigueCard> = {
@@ -18,7 +17,10 @@ const meta: Meta<typeof LiveFatigueCard> = {
         component:
           'The vertical live fatigue card — consumes one `LiveFatigueModel`. Composes `VerdictHero` ' +
           '(RPE + verdict word) · `FatigueLights` (VEL/ROM/TEMPO dots) · `RomProgressionChart` · ' +
-          '`GhostSpark` (tempo embedded), grounded on a `Surface` raised plane.',
+          '`GhostSpark` (tempo embedded). Grounded on the `Surface` **base** plane — one step ' +
+          'above the `background` shell the live stage paints — separated by the alpha ' +
+          '`hairline-default` edge and finished with the shared **paper** accent (matte grain + ' +
+          'top rim-light + contact shadow), the hero-surface treatment from the surface north-star.',
       },
     },
   },
@@ -29,10 +31,11 @@ const meta: Meta<typeof LiveFatigueCard> = {
 export default meta
 type Story = StoryObj<typeof LiveFatigueCard>
 
+/** The live stage the card actually sits on — the `background` shell plane, not a raw hex. */
 const Frame = ({ children }: { children: React.ReactNode }) => (
-  <View style={{ backgroundColor: PAGE_BG, padding: 28, alignItems: 'flex-start' }}>
+  <Surface level="background" style={{ padding: 28, alignItems: 'flex-start' }}>
     {children}
-  </View>
+  </Surface>
 )
 
 /** The default (form breaking down) card. */
@@ -48,9 +51,9 @@ export const Default: Story = {
 /** The four verdict states side by side — the whole spectrum. */
 export const States: Story = {
   render: () => (
-    <View
+    <Surface
+      level="background"
       style={{
-        backgroundColor: PAGE_BG,
         padding: 28,
         flexDirection: 'row',
         gap: 20,
@@ -72,7 +75,7 @@ export const States: Story = {
           <LiveFatigueCard model={s.model} width={300} height={500} />
         </View>
       ))}
-    </View>
+    </Surface>
   ),
 }
 

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
@@ -27,14 +27,12 @@ export interface LiveFatigueCardProps {
   width?: number
   /** Card height in px — when set, the sections spread through the leftover height. */
   height?: number
-  /** Pin the ghost-spark into its revealed (annotated) state — for static screenshots. */
-  revealChart?: boolean
 }
 
 const PAD = 18
 const GHOST_GUTTER = 4 // GhostSpark carries this L/R padding internally
 
-export function LiveFatigueCard({ model, width = 318, height, revealChart }: LiveFatigueCardProps) {
+export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardProps) {
   const chartW = width - PAD * 2 - GHOST_GUTTER * 2
   const chartH = height != null ? Math.round(Math.min(240, Math.max(168, height * 0.4))) : 172
   return (
@@ -66,13 +64,7 @@ export function LiveFatigueCard({ model, width = 318, height, revealChart }: Liv
 
       <View style={{ flex: 1, minHeight: 16 }} />
 
-      <GhostSpark
-        curves={model.velocityCurves}
-        tempoSeconds={model.tempoSeconds}
-        width={chartW}
-        height={chartH}
-        forceRevealed={revealChart}
-      />
+      <GhostSpark curves={model.velocityCurves} width={chartW} height={chartH} />
     </Surface>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
@@ -5,13 +5,22 @@
  * (tempo embedded), the last two spread through the leftover height. Consumes ONE
  * {@link LiveFatigueModel}.
  *
- * The card grounds on a {@link Surface} `raised` plane (the paper-accent hero surface)
- * — it never hardcodes a surface hex, so it inherits the surface-ramp / paper-accent
- * refresh when that ships.
+ * SURFACE (TD-07.08). The card grounds on the `base` plane — ONE step above the
+ * `background` shell the live stage paints, per the surface north-star's pairing matrix
+ * (a card is parent+1; `raised`/`overlay` skip levels and read hot against the near-black
+ * frame). Separation is carried by the alpha `hairline-default` edge, not by lightness —
+ * the north-star's primary cue, self-normalising on any plane.
+ *
+ * PAPER. The live card is one of the designated hero surfaces, so it takes the paper
+ * accent DELIBERATELY: the shared {@link barPaper} treatment (brightness-scaled matte
+ * grain + crisp top rim-light + soft contact shadow) — the same material the ROM /
+ * velocity bars are made of, now carrying the sheet they sit on. Token-sourced fill, no
+ * hardcoded surface hex.
  */
 import { View } from 'react-native'
 import { Surface } from '../../ui/surface/Surface'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { barPaper } from '../../../theme/bar-paper'
 import { VerdictHero } from './VerdictHero'
 import { FatigueLights } from './FatigueLights'
 import { RomProgressionChart } from './RomProgressionChart'
@@ -37,7 +46,7 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
   const chartH = height != null ? Math.round(Math.min(240, Math.max(168, height * 0.4))) : 172
   return (
     <Surface
-      level="raised"
+      level="base"
       testID="live-fatigue-card"
       style={{
         width,
@@ -45,7 +54,8 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
         borderRadius: 14,
         padding: PAD,
         borderWidth: 1,
-        borderColor: t['border-default'],
+        borderColor: t['hairline-default'],
+        ...barPaper(t['surface-base']),
       }}
     >
       {/* top group — verdict hero + the three why-lights, tight together. */}

--- a/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.stories.tsx
@@ -38,7 +38,6 @@ export const LivePanelV2: Story = {
         model={FATIGUE_STATES[3].model}
         velocity={{ velocities: MOCK_MEAN_VELOCITIES, targetReps: 8 }}
         header={MOCK_HEADER}
-        revealChart
       />
     </View>
   ),
@@ -88,7 +87,6 @@ export const LiveStates: Story = {
                 liveRepIndex: liveRep,
               }}
               header={{ ...MOCK_HEADER, meta: `SET 3 · REP ${s.current + 1} / 8` }}
-              revealChart
             />
           </View>
         )

--- a/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.tsx
@@ -48,8 +48,6 @@ export interface LiveFatiguePanelProps {
   bodyHeight?: number
   /** Fixed fatigue-card column width. Default 318. */
   cardWidth?: number
-  /** Pin the ghost-spark revealed — for static screenshots. */
-  revealChart?: boolean
 }
 
 function ExerciseHeaderLite({ header }: { header: LiveFatiguePanelHeader }) {
@@ -113,7 +111,6 @@ export function LiveFatiguePanel({
   aura,
   bodyHeight = 508,
   cardWidth = 318,
-  revealChart,
 }: LiveFatiguePanelProps) {
   const category = aura ?? auraForVerdict(model.verdict?.state ?? null)
   const heroH = bodyHeight - 26 // leaves room for the hero's own eyebrow above it
@@ -146,12 +143,7 @@ export function LiveFatiguePanel({
             />
           </View>
           {/* SECONDARY — the vertical fatigue card. */}
-          <LiveFatigueCard
-            model={model}
-            width={cardWidth}
-            height={bodyHeight}
-            revealChart={revealChart}
-          />
+          <LiveFatigueCard model={model} width={cardWidth} height={bodyHeight} />
         </View>
       </View>
     </LiveAuraFrame>

--- a/packages/ui/src/components/custom/Fatigue/README.md
+++ b/packages/ui/src/components/custom/Fatigue/README.md
@@ -21,7 +21,7 @@ LiveFatiguePanel              ← the composition (Live panel v2)
    │  └─ Tooltip              (ui/tooltip — hover detail)
    ├─ RomProgressionChart     (per-rep silver/red depth bars + reference lines)
    ├─ GhostSpark              (per-rep velocity-time sparkline; tempo EMBEDDED)
-   └─ Surface                 (ui/surface — the raised/paper-accent card ground)
+   └─ Surface                 (ui/surface — the base-plane, paper-accented card ground)
 ```
 
 ## Tier map
@@ -38,8 +38,9 @@ LiveFatiguePanel              ← the composition (Live panel v2)
 - **`VelocityStrip`** (Workout/) — the hero reuses it verbatim; `VelocityHero` only adds
   the loss-relative VL20/VL30 band overlay on the strip's own peak scale.
 - **`LiveAuraFrame`** (Workout/) — the coaching flood.
-- **`Surface`** (ui/surface/) — the card ground (`level="raised"`); no hardcoded surface
-  hex, so the family inherits the surface-ramp / paper-accent refresh when it lands.
+- **`Surface`** (ui/surface/) — the card ground (`level="base"`, one step above the
+  `background` shell), separated by the alpha `hairline-default` edge and finished with
+  the shared `barPaper` accent; no hardcoded surface hex.
 - **Tokens** — colours come from `getSemanticColors` / `primitiveRamps`; formatting from
   `roundTempo`. No literal surface/status hex constants.
 

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof RomProgressionChart> = {
         component:
           'Per-rep depth bars (silver at/above working → light red below working range → deep red below the short threshold), ' +
           'with dashed working-standard + short-threshold reference lines and a faint red short-zone. ' +
-          'Data-driven from absolute metres; labelled "depth vs working range · now N%". ' +
+          'Data-driven from absolute metres; the bars carry the read alone (no caption strip). ' +
           'Composes the shared **SetBarChart** — same adaptive bar spacing as the velocity hero, and an optional ' +
           '`plannedReps` draws the remaining reps as dashed to-do placeholders (the "N of M done" read).',
       },

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.test.tsx
@@ -11,21 +11,10 @@ const points: RepRomPoint[] = [
 ]
 
 describe('RomProgressionChart', () => {
-  it('renders the caption', () => {
+  it('renders no caption strip — the bars carry the read alone', () => {
     render(<RomProgressionChart points={points} workingStandardM={0.88} shortThresholdM={0.66} />)
-    expect(screen.getByText('ROM · depth vs working range')).toBeInTheDocument()
-  })
-
-  it('computes now% against the working standard', () => {
-    render(<RomProgressionChart points={points} workingStandardM={0.9} shortThresholdM={0.675} />)
-    // current rom 0.72 / working 0.9 = 80%
-    expect(screen.getByText('now 80%')).toBeInTheDocument()
-  })
-
-  it('falls back to the tallest bar when no working standard is established', () => {
-    render(<RomProgressionChart points={points} workingStandardM={null} shortThresholdM={null} />)
-    // current rom 0.72 / max 0.9 = 80%
-    expect(screen.getByText('now 80%')).toBeInTheDocument()
+    expect(screen.queryByText(/depth vs working range/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^now /)).not.toBeInTheDocument()
   })
 
   it('renders the chart container', () => {

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
@@ -4,7 +4,7 @@
  * silver bars at-or-above the working range, light red below it, deep red below the
  * short threshold — with dashed working-standard (silver) + short-threshold (red)
  * reference lines and a faint red short-zone. Every rep reads at full colour.
- * Labelled "depth vs working range · now N%".
+ * The bars carry the whole read — no caption strip (the card's own hierarchy names it).
  *
  * Composes the shared {@link SetBarChart}: SetBarChart owns the geometry (value→height
  * scaling, the plot-width-driven adaptive bar width / gap — the same rhythm as the velocity
@@ -14,14 +14,11 @@
  * reference lines always sit on-chart; when no working standard is established yet (< 3 reps)
  * the lines drop and every bar reads silver — the bars alone carry the shape.
  */
-import { View, Text } from 'react-native'
-import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { View } from 'react-native'
 import { alpha } from '../../../utils/colors'
 import { SetBarChart, type SetSlot, type SetBarGeometry } from '../charts/SetBarChart'
-import { FONT_MONO, SILVER, RED_LIGHT, RED_DEEP } from './fatigue-tokens'
+import { SILVER, RED_LIGHT, RED_DEEP } from './fatigue-tokens'
 import type { RepRomPoint } from './fatigue-model'
-
-const t = getSemanticColors('dark')
 
 export interface RomProgressionChartProps {
   /** Per-rep ROM points (metres), ordered by rep. */
@@ -30,7 +27,7 @@ export interface RomProgressionChartProps {
   workingStandardM: number | null
   /** Short threshold (metres) — the red dashed line + short-zone. `null` = not yet established. */
   shortThresholdM: number | null
-  /** Height of the bar plot in px (the caption row sits below it). Default 44. */
+  /** Height of the bar plot in px. Default 44. */
   barHeight?: number
   /** Keep the chart to a legible recent tail. Default 12. */
   maxReps?: number
@@ -110,13 +107,6 @@ export function RomProgressionChart({
   plannedReps,
 }: RomProgressionChartProps) {
   const shown = points.slice(-maxReps)
-  const lastIndex = shown.length - 1
-  const current = shown[lastIndex]?.romM ?? 0
-  const nowPct =
-    workingStandardM != null
-      ? Math.round((current / workingStandardM) * 100)
-      : Math.round((current / Math.max(0.01, ...shown.map((p) => p.romM))) * 100)
-
   const slots: SetSlot[] = shown.map((p) => ({ kind: 'rep', value: p.romM }))
   // Scale to the tallest of {bars, working, short} so the reference lines always sit on-chart
   // (SetBarChart's own peak scale reads only the bar values). `0` → let SetBarChart use peak.
@@ -124,7 +114,7 @@ export function RomProgressionChart({
     Math.max(...shown.map((p) => p.romM), workingStandardM ?? 0, shortThresholdM ?? 0) || undefined
 
   return (
-    <View style={{ gap: 5 }} testID="rom-progression">
+    <View testID="rom-progression">
       <SetBarChart
         slots={slots}
         colorFor={(romM) => barColor(romM, workingStandardM, shortThresholdM)}
@@ -137,14 +127,6 @@ export function RomProgressionChart({
         renderReference={(g) => romReferenceOverlay(g, workingStandardM, shortThresholdM)}
         testIDPrefix="rom"
       />
-      <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-        <Text style={{ fontSize: 9, color: t['text-tertiary'], fontFamily: FONT_MONO }}>
-          ROM · depth vs working range
-        </Text>
-        <Text style={{ fontSize: 9, color: t['text-tertiary'], fontFamily: FONT_MONO }}>
-          now {nowPct}%
-        </Text>
-      </View>
     </View>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
@@ -1,0 +1,153 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+/**
+ * `Workout/Fatigue/Silver-Red Palette` — the single documented source for the fatigue
+ * family's line/quality colour language. SILVER when the rep is right, SHADES OF RED when
+ * something's wrong — no greens, no ambers (those belong to the verdict tones + velocity-
+ * loss bands, not here). Every swatch reads its value straight from `fatigue-tokens`, so
+ * this story can't drift from what the components actually render.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import {
+  SILVER,
+  DRIFT_GREY,
+  RED_LIGHT,
+  RED_MID,
+  RED_DEEP,
+  PHASE_AXIS_COLOR,
+  FONT_HEAD,
+  FONT_UI,
+  FONT_MONO,
+} from './fatigue-tokens'
+
+const PAGE_BG = primitiveColors.charcoal[900]
+const PANEL_BG = primitiveColors.charcoal[800]
+const t = getSemanticColors('dark')
+
+const meta: Meta = {
+  title: 'Workout/Fatigue/Silver-Red Palette',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The locked silver→red colour language for the live-fatigue family. SILVER = the ' +
+          'rep is controlled (dimming toward DRIFT_GREY with tempo drift); SHADES OF RED = a ' +
+          'collapse, by severity. Plus the phase-axis tones (eccentric magenta / concentric ' +
+          'cyan / idle grey) that colour the ghost band. Used by RomProgressionChart, ' +
+          'GhostSpark, and the dual ghost-line. All values sourced from `fatigue-tokens`.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj
+
+interface SwatchDef {
+  name: string
+  token: string
+  value: string
+  note?: string
+}
+
+function Swatch({ def }: { def: SwatchDef }) {
+  return (
+    <View style={{ width: 132, gap: 6 }}>
+      <View
+        style={{
+          height: 72,
+          borderRadius: 10,
+          backgroundColor: def.value,
+          borderWidth: 1,
+          borderColor: 'rgba(255,255,255,0.08)',
+        }}
+      />
+      <View style={{ gap: 2 }}>
+        <Text style={{ fontSize: 12, fontWeight: '800', fontFamily: FONT_HEAD, color: t['text-primary'] }}>
+          {def.name}
+        </Text>
+        <Text style={{ fontSize: 10, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>{def.token}</Text>
+        <Text style={{ fontSize: 11, fontFamily: FONT_MONO, color: t['text-secondary'] }}>
+          {def.value.toUpperCase()}
+        </Text>
+        {def.note && (
+          <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: t['text-tertiary'], lineHeight: 13 }}>
+            {def.note}
+          </Text>
+        )}
+      </View>
+    </View>
+  )
+}
+
+function SwatchGroup({ label, defs }: { label: string; defs: SwatchDef[] }) {
+  return (
+    <View style={{ gap: 12 }}>
+      <Text style={{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>
+        {label}
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 16, flexWrap: 'wrap' }}>
+        {defs.map((d) => (
+          <Swatch key={d.token} def={d} />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+const CONTROL: SwatchDef[] = [
+  { name: 'Silver', token: 'SILVER · neutral[300]', value: SILVER, note: 'On-track / at-or-above working.' },
+  {
+    name: 'Drift grey',
+    token: 'DRIFT_GREY · charcoal[500]',
+    value: DRIFT_GREY,
+    note: 'The quiet grey the controlled line dims toward as tempo drifts — never a colour.',
+  },
+]
+
+const COLLAPSE: SwatchDef[] = [
+  { name: 'Red light', token: 'RED_LIGHT · red[400]', value: RED_LIGHT, note: 'First flag — collapse just crossed the grind threshold.' },
+  { name: 'Red mid', token: 'RED_MID · red[600]', value: RED_MID, note: 'Sustained collapse.' },
+  { name: 'Red deep', token: 'RED_DEEP · red[800]', value: RED_DEEP, note: 'Full collapse — form breaking down.' },
+]
+
+const PHASE_AXIS: SwatchDef[] = [
+  { name: 'Eccentric', token: 'PHASE_AXIS_COLOR.eccentric · magenta[800]', value: PHASE_AXIS_COLOR.eccentric },
+  { name: 'Concentric', token: 'PHASE_AXIS_COLOR.concentric · cyan[800]', value: PHASE_AXIS_COLOR.concentric },
+  { name: 'Idle', token: 'PHASE_AXIS_COLOR.idle · charcoal[300]', value: PHASE_AXIS_COLOR.idle, note: 'Pauses / holds on the phase band.' },
+]
+
+export const Palette: Story = {
+  name: 'Silver-Red Palette',
+  render: () => (
+    <View style={{ padding: 32, backgroundColor: PAGE_BG, minHeight: '100%', gap: 28 }}>
+      <View style={{ gap: 8, maxWidth: 720 }}>
+        <Text style={{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>
+          LIVE-FATIGUE · QUALITY COLOUR LANGUAGE
+        </Text>
+        <Text style={{ fontSize: 24, fontWeight: '900', fontFamily: FONT_HEAD, color: t['text-primary'] }}>
+          Silver → Red
+        </Text>
+        <Text style={{ fontSize: 13, fontFamily: FONT_UI, color: t['text-secondary'], lineHeight: 19 }}>
+          One language for every quality readout in the family: SILVER when the rep is right (dimming toward
+          DRIFT_GREY with tempo drift), SHADES OF RED when something&apos;s wrong — by severity. No greens, no
+          ambers; those belong to the verdict tones and velocity-loss bands, not here. The phase-axis tones
+          below colour the ghost band (they carry movement phase, not quality).
+        </Text>
+      </View>
+
+      <View style={[{ borderRadius: 14, padding: 24, gap: 24, backgroundColor: PANEL_BG }]}>
+        <SwatchGroup label="CONTROLLED — SILVER" defs={CONTROL} />
+        <SwatchGroup label="COLLAPSE — SHADES OF RED (light → deep by severity)" defs={COLLAPSE} />
+        <SwatchGroup label="PHASE AXIS — ghost band tones" defs={PHASE_AXIS} />
+      </View>
+
+      <Text style={{ fontSize: 11, fontFamily: FONT_UI, color: t['text-tertiary'], fontStyle: 'italic' }}>
+        Used by: RomProgressionChart, GhostSpark, DualGhostLine (dual ghost-line). Source of truth:
+        `fatigue-tokens.ts` (SILVER, DRIFT_GREY, RED_LIGHT/MID/DEEP, PHASE_AXIS_COLOR, `ghostLineColor`).
+      </Text>
+    </View>
+  ),
+}

--- a/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
@@ -9,6 +9,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { primitiveColors } from '../../../theme/tokens/primitives'
+import { alpha } from '../../../utils/colors'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import {
   SILVER,
@@ -61,19 +62,30 @@ function Swatch({ def }: { def: SwatchDef }) {
           borderRadius: 10,
           backgroundColor: def.value,
           borderWidth: 1,
-          borderColor: 'rgba(255,255,255,0.08)',
+          borderColor: alpha(primitiveColors.white, 0.08),
         }}
       />
       <View style={{ gap: 2 }}>
-        <Text style={{ fontSize: 12, fontWeight: '800', fontFamily: FONT_HEAD, color: t['text-primary'] }}>
+        <Text
+          style={{
+            fontSize: 12,
+            fontWeight: '800',
+            fontFamily: FONT_HEAD,
+            color: t['text-primary'],
+          }}
+        >
           {def.name}
         </Text>
-        <Text style={{ fontSize: 10, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>{def.token}</Text>
+        <Text style={{ fontSize: 10, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>
+          {def.token}
+        </Text>
         <Text style={{ fontSize: 11, fontFamily: FONT_MONO, color: t['text-secondary'] }}>
           {def.value.toUpperCase()}
         </Text>
         {def.note && (
-          <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: t['text-tertiary'], lineHeight: 13 }}>
+          <Text
+            style={{ fontSize: 10, fontFamily: FONT_UI, color: t['text-tertiary'], lineHeight: 13 }}
+          >
             {def.note}
           </Text>
         )}
@@ -85,7 +97,14 @@ function Swatch({ def }: { def: SwatchDef }) {
 function SwatchGroup({ label, defs }: { label: string; defs: SwatchDef[] }) {
   return (
     <View style={{ gap: 12 }}>
-      <Text style={{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>
+      <Text
+        style={{
+          fontSize: 9,
+          letterSpacing: 1.4,
+          fontFamily: FONT_MONO,
+          color: t['text-tertiary'],
+        }}
+      >
         {label}
       </Text>
       <View style={{ flexDirection: 'row', gap: 16, flexWrap: 'wrap' }}>
@@ -98,7 +117,13 @@ function SwatchGroup({ label, defs }: { label: string; defs: SwatchDef[] }) {
 }
 
 const CONTROL: SwatchDef[] = [
-  { name: 'Silver', token: 'SILVER · neutral[300]', value: SILVER, note: 'On-track / at-or-above working.' },
+  // eslint-disable-next-line titan/no-raw-color -- 'Silver' is the token's display name, not a CSS colour
+  {
+    name: 'Silver',
+    token: 'SILVER · neutral[300]',
+    value: SILVER,
+    note: 'On-track / at-or-above working.',
+  },
   {
     name: 'Drift grey',
     token: 'DRIFT_GREY · neutral[600]',
@@ -108,15 +133,38 @@ const CONTROL: SwatchDef[] = [
 ]
 
 const COLLAPSE: SwatchDef[] = [
-  { name: 'Red light', token: 'RED_LIGHT · red[400]', value: RED_LIGHT, note: 'First flag — collapse just crossed the grind threshold.' },
+  {
+    name: 'Red light',
+    token: 'RED_LIGHT · red[400]',
+    value: RED_LIGHT,
+    note: 'First flag — collapse just crossed the grind threshold.',
+  },
   { name: 'Red mid', token: 'RED_MID · red[600]', value: RED_MID, note: 'Sustained collapse.' },
-  { name: 'Red deep', token: 'RED_DEEP · red[800]', value: RED_DEEP, note: 'Full collapse — form breaking down.' },
+  {
+    name: 'Red deep',
+    token: 'RED_DEEP · red[800]',
+    value: RED_DEEP,
+    note: 'Full collapse — form breaking down.',
+  },
 ]
 
 const PHASE_AXIS: SwatchDef[] = [
-  { name: 'Eccentric', token: 'PHASE_AXIS_COLOR.eccentric · magenta[800]', value: PHASE_AXIS_COLOR.eccentric },
-  { name: 'Concentric', token: 'PHASE_AXIS_COLOR.concentric · cyan[800]', value: PHASE_AXIS_COLOR.concentric },
-  { name: 'Idle', token: 'PHASE_AXIS_COLOR.idle · charcoal[300]', value: PHASE_AXIS_COLOR.idle, note: 'Pauses / holds on the phase band.' },
+  {
+    name: 'Eccentric',
+    token: 'PHASE_AXIS_COLOR.eccentric · magenta[800]',
+    value: PHASE_AXIS_COLOR.eccentric,
+  },
+  {
+    name: 'Concentric',
+    token: 'PHASE_AXIS_COLOR.concentric · cyan[800]',
+    value: PHASE_AXIS_COLOR.concentric,
+  },
+  {
+    name: 'Idle',
+    token: 'PHASE_AXIS_COLOR.idle · charcoal[300]',
+    value: PHASE_AXIS_COLOR.idle,
+    note: 'Pauses / holds on the phase band.',
+  },
 ]
 
 export const Palette: Story = {
@@ -124,17 +172,34 @@ export const Palette: Story = {
   render: () => (
     <View style={{ padding: 32, backgroundColor: PAGE_BG, minHeight: '100%', gap: 28 }}>
       <View style={{ gap: 8, maxWidth: 720 }}>
-        <Text style={{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: t['text-tertiary'] }}>
+        <Text
+          style={{
+            fontSize: 9,
+            letterSpacing: 1.4,
+            fontFamily: FONT_MONO,
+            color: t['text-tertiary'],
+          }}
+        >
           LIVE-FATIGUE · QUALITY COLOUR LANGUAGE
         </Text>
-        <Text style={{ fontSize: 24, fontWeight: '900', fontFamily: FONT_HEAD, color: t['text-primary'] }}>
+        <Text
+          style={{
+            fontSize: 24,
+            fontWeight: '900',
+            fontFamily: FONT_HEAD,
+            color: t['text-primary'],
+          }}
+        >
           Silver → Red
         </Text>
-        <Text style={{ fontSize: 13, fontFamily: FONT_UI, color: t['text-secondary'], lineHeight: 19 }}>
-          One language for every quality readout in the family: SILVER when the rep is right (dimming toward
-          DRIFT_GREY with tempo drift), SHADES OF RED when something&apos;s wrong — by severity. No greens, no
-          ambers; those belong to the verdict tones and velocity-loss bands, not here. The phase-axis tones
-          below colour the ghost band (they carry movement phase, not quality).
+        <Text
+          style={{ fontSize: 13, fontFamily: FONT_UI, color: t['text-secondary'], lineHeight: 19 }}
+        >
+          One language for every quality readout in the family: SILVER when the rep is right
+          (dimming toward DRIFT_GREY with tempo drift), SHADES OF RED when something&apos;s wrong —
+          by severity. No greens, no ambers; those belong to the verdict tones and velocity-loss
+          bands, not here. The phase-axis tones below colour the ghost band (they carry movement
+          phase, not quality).
         </Text>
       </View>
 
@@ -144,9 +209,17 @@ export const Palette: Story = {
         <SwatchGroup label="PHASE AXIS — ghost band tones" defs={PHASE_AXIS} />
       </View>
 
-      <Text style={{ fontSize: 11, fontFamily: FONT_UI, color: t['text-tertiary'], fontStyle: 'italic' }}>
+      <Text
+        style={{
+          fontSize: 11,
+          fontFamily: FONT_UI,
+          color: t['text-tertiary'],
+          fontStyle: 'italic',
+        }}
+      >
         Used by: RomProgressionChart, GhostSpark, DualGhostLine (dual ghost-line). Source of truth:
-        `fatigue-tokens.ts` (SILVER, DRIFT_GREY, RED_LIGHT/MID/DEEP, PHASE_AXIS_COLOR, `ghostLineColor`).
+        `fatigue-tokens.ts` (SILVER, DRIFT_GREY, RED_LIGHT/MID/DEEP, PHASE_AXIS_COLOR,
+        `ghostLineColor`).
       </Text>
     </View>
   ),

--- a/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
@@ -117,8 +117,8 @@ function SwatchGroup({ label, defs }: { label: string; defs: SwatchDef[] }) {
 }
 
 const CONTROL: SwatchDef[] = [
-  // eslint-disable-next-line titan/no-raw-color -- 'Silver' is the token's display name, not a CSS colour
   {
+    // eslint-disable-next-line titan/no-raw-color -- 'Silver' is the token's display name, not a CSS colour
     name: 'Silver',
     token: 'SILVER · neutral[300]',
     value: SILVER,

--- a/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
@@ -101,9 +101,9 @@ const CONTROL: SwatchDef[] = [
   { name: 'Silver', token: 'SILVER · neutral[300]', value: SILVER, note: 'On-track / at-or-above working.' },
   {
     name: 'Drift grey',
-    token: 'DRIFT_GREY · charcoal[500]',
+    token: 'DRIFT_GREY · neutral[600]',
     value: DRIFT_GREY,
-    note: 'The quiet grey the controlled line dims toward as tempo drifts — never a colour.',
+    note: 'The dim-silver grey the controlled line dims toward as tempo drifts — same neutral family as SILVER, never a colour.',
   },
 ]
 

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -32,11 +32,17 @@ export const STATE_LABEL: Record<FatigueVerdictState, string> = {
 /**
  * The phase-identity colours for the ghost-spark phase BAND — the TempoDisplay
  * language: eccentric magenta, concentric cyan, idle (pause/hold) a muted grey.
+ *
+ * The idle grey has to read as BAND MATERIAL (a pause the lifter held), not as a
+ * hole in the strip: at charcoal[300] it sat inside the surface-ramp's own value
+ * range (`surface-raised` #31302F) so a short pause between ECC and CON read as a
+ * gap. charcoal[200] clears every content plane while staying quieter than the two
+ * saturated phase tones, so the band reads contiguous and the phases still lead.
  */
 export const PHASE_AXIS_COLOR: Record<SamplePhase, string> = {
   eccentric: primitiveRamps.magenta[800],
   concentric: primitiveRamps.cyan[800],
-  idle: primitiveColors.charcoal[300],
+  idle: primitiveColors.charcoal[200],
 }
 
 /** Mini-tempo digit colours `[ecc, pauseBottom, con, pauseTop]` — ecc magenta / con cyan / pauses grey. */

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -59,8 +59,10 @@ export const RED_DEEP = primitiveRamps.red[800]
 
 /** Below this grind signature the rep is "controlled" → silver; at/above it goes red. */
 export const GRIND_THRESHOLD = 0.35
-/** A quiet grey the controlled line dims toward as it drifts (never a colour). */
-export const DRIFT_GREY = primitiveColors.charcoal[500]
+/** A quiet grey the controlled line dims toward as it drifts (never a colour): a dimmed
+ *  cool grey in the SAME neutral family as SILVER, so a fully-drifted line reads dim-silver
+ *  rather than sinking toward black. Shared with the ROM chart. */
+export const DRIFT_GREY = primitiveColors.neutral[600]
 
 export function clamp01(v: number): number {
   return Math.min(1, Math.max(0, v))

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -60,7 +60,7 @@ export const RED_DEEP = primitiveRamps.red[800]
 /** Below this grind signature the rep is "controlled" → silver; at/above it goes red. */
 export const GRIND_THRESHOLD = 0.35
 /** A quiet grey the controlled line dims toward as it drifts (never a colour). */
-const DRIFT_GREY = primitiveColors.charcoal[500]
+export const DRIFT_GREY = primitiveColors.charcoal[500]
 
 export function clamp01(v: number): number {
   return Math.min(1, Math.max(0, v))

--- a/packages/ui/src/components/custom/Fatigue/index.ts
+++ b/packages/ui/src/components/custom/Fatigue/index.ts
@@ -12,7 +12,7 @@ export { FatigueLights, type FatigueLightsProps } from './FatigueLights'
 export { RomProgressionChart, type RomProgressionChartProps } from './RomProgressionChart'
 export { GhostSpark, type GhostSparkProps } from './GhostSpark'
 export { GhostBand, type GhostBandProps, BAND_H, BAND_GAP } from './GhostBand'
-export { GhostBloom, type GhostBloomProps, type Pt, smoothPath } from './GhostBloom'
+export { GhostBloom, type GhostBloomProps, type Pt, type BloomTreatment, smoothPath } from './GhostBloom'
 export { VelocityHero, type VelocityHeroProps } from './VelocityHero'
 export {
   ghostLineColor,

--- a/packages/ui/src/components/custom/Fatigue/index.ts
+++ b/packages/ui/src/components/custom/Fatigue/index.ts
@@ -12,7 +12,13 @@ export { FatigueLights, type FatigueLightsProps } from './FatigueLights'
 export { RomProgressionChart, type RomProgressionChartProps } from './RomProgressionChart'
 export { GhostSpark, type GhostSparkProps } from './GhostSpark'
 export { GhostBand, type GhostBandProps, BAND_H, BAND_GAP } from './GhostBand'
-export { GhostBloom, type GhostBloomProps, type Pt, type BloomTreatment, smoothPath } from './GhostBloom'
+export {
+  GhostBloom,
+  type GhostBloomProps,
+  type Pt,
+  type BloomTreatment,
+  smoothPath,
+} from './GhostBloom'
 export { VelocityHero, type VelocityHeroProps } from './VelocityHero'
 export {
   ghostLineColor,

--- a/packages/ui/src/components/custom/Fatigue/index.ts
+++ b/packages/ui/src/components/custom/Fatigue/index.ts
@@ -11,6 +11,8 @@ export { VerdictHero, type VerdictHeroProps } from './VerdictHero'
 export { FatigueLights, type FatigueLightsProps } from './FatigueLights'
 export { RomProgressionChart, type RomProgressionChartProps } from './RomProgressionChart'
 export { GhostSpark, type GhostSparkProps } from './GhostSpark'
+export { GhostBand, type GhostBandProps, BAND_H, BAND_GAP } from './GhostBand'
+export { GhostBloom, type GhostBloomProps, type Pt, smoothPath } from './GhostBloom'
 export { VelocityHero, type VelocityHeroProps } from './VelocityHero'
 export {
   ghostLineColor,
@@ -19,9 +21,11 @@ export {
   STATE_LABEL,
   GRIND_THRESHOLD,
   SILVER,
+  DRIFT_GREY,
   RED_LIGHT,
   RED_MID,
   RED_DEEP,
+  PHASE_AXIS_COLOR,
 } from './fatigue-tokens'
 export type {
   LiveFatigueModel,

--- a/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
+++ b/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
@@ -26,13 +26,7 @@ import { getSemanticColors } from '../../theme/tokens/semantic'
 import { primitiveColors } from '../../theme/tokens/primitives'
 import { alpha } from '../../utils/colors'
 import { GRIND_THRESHOLD, ghostLineColor } from '../../components/custom/Fatigue/fatigue-tokens'
-import {
-  GhostBand,
-  GhostBloom,
-  BAND_H,
-  BAND_GAP,
-  type Pt,
-} from '../../components/custom/Fatigue'
+import { GhostBand, GhostBloom, BAND_H, BAND_GAP, type Pt } from '../../components/custom/Fatigue'
 import type { PhaseSegment } from '../../components/custom/Fatigue'
 
 const C = getSemanticColors('dark')
@@ -50,7 +44,13 @@ const PARCH = C['text-primary']
 // =================================================================================
 function perceivedLuminance(hex: string): number {
   const h = hex.replace('#', '')
-  const full = h.length === 3 ? h.split('').map((ch) => ch + ch).join('') : h
+  const full =
+    h.length === 3
+      ? h
+          .split('')
+          .map((ch) => ch + ch)
+          .join('')
+      : h
   const r = parseInt(full.slice(0, 2), 16)
   const g = parseInt(full.slice(2, 4), 16)
   const b = parseInt(full.slice(4, 6), 16)
@@ -187,13 +187,21 @@ function genSamples(s: DeviceSpec, seed = 0): Sample[] {
   return out
 }
 
-const CURRENT: Record<string, Sample[]> = { left: genSamples(LEFT_ARM), right: genSamples(RIGHT_ARM) }
+const CURRENT: Record<string, Sample[]> = {
+  left: genSamples(LEFT_ARM),
+  right: genSamples(RIGHT_ARM),
+}
 // Faded prior "ghost" reps per device — LEFT stays steady across its set; RIGHT's
 // ghosts are progressively healthier (its earlier reps, before the sticking point
 // set in), so the current (fatigued) rep visibly regresses from its own ghost fan.
 const GHOSTS_LEFT: Sample[][] = [0, 1, 2].map((g) =>
   genSamples(
-    { ...LEFT_ARM, conMs: 780 - g * 90, conVel: (u) => (1.0 - g * 0.05) * clamp01(u / (0.15 + g * 0.03)) * (1 - 0.82 * smoothstep(0.8, 1.0, u)) },
+    {
+      ...LEFT_ARM,
+      conMs: 780 - g * 90,
+      conVel: (u) =>
+        (1.0 - g * 0.05) * clamp01(u / (0.15 + g * 0.03)) * (1 - 0.82 * smoothstep(0.8, 1.0, u)),
+    },
     g + 1
   )
 )
@@ -202,7 +210,8 @@ const GHOSTS_RIGHT: Sample[][] = [0, 1, 2].map((g) =>
     {
       ...RIGHT_ARM,
       conMs: 1050 + g * 120,
-      conVel: (u) => 0.95 * clamp01(u / 0.14) * (1 - 0.6 * smoothstep(0.82, 1.0, u)) * (1 - g * 0.08),
+      conVel: (u) =>
+        0.95 * clamp01(u / 0.14) * (1 - 0.6 * smoothstep(0.82, 1.0, u)) * (1 - g * 0.08),
     },
     g + 4
   )
@@ -258,7 +267,13 @@ const TEMPLATE_BOUNDS: Record<Phase, [number, number]> = (() => {
   return { ecc: [0, b1], pauseBottom: [b1, b2], con: [b2, b3], pauseTop: [b3, 1] }
 })()
 function phaseSpans(s: DeviceSpec): Array<{ phase: Phase; t0: number; t1: number }> {
-  const b = [0, s.eccMs, s.eccMs + s.pBMs, s.eccMs + s.pBMs + s.conMs, s.eccMs + s.pBMs + s.conMs + s.pTMs]
+  const b = [
+    0,
+    s.eccMs,
+    s.eccMs + s.pBMs,
+    s.eccMs + s.pBMs + s.conMs,
+    s.eccMs + s.pBMs + s.conMs + s.pTMs,
+  ]
   return [
     { phase: 'ecc', t0: b[0], t1: b[1] },
     { phase: 'pauseBottom', t0: b[1], t1: b[2] },
@@ -285,7 +300,12 @@ const SHARED_SEGMENTS: PhaseSegment[] = (Object.keys(TEMPLATE_BOUNDS) as Phase[]
 
 // Shared magnitude scale across BOTH devices (current + ghosts) so the two blooms are
 // directly, honestly comparable.
-const ALL_SAMPLES = [...CURRENT.left, ...CURRENT.right, ...GHOSTS_LEFT.flat(), ...GHOSTS_RIGHT.flat()]
+const ALL_SAMPLES = [
+  ...CURRENT.left,
+  ...CURRENT.right,
+  ...GHOSTS_LEFT.flat(),
+  ...GHOSTS_RIGHT.flat(),
+]
 const VMAX_MAG = Math.max(0.01, ...ALL_SAMPLES.map((s) => Math.abs(s.vel))) * 1.06
 
 // =================================================================================
@@ -322,17 +342,60 @@ function MirroredDualBand({ w, h }: { w: number; h: number }) {
   return (
     <svg width={w} height={h}>
       {/* LEFT device blooms UP, RIGHT blooms DOWN — same GhostBloom, one prop flipped. */}
-      <GhostBloom current={leftCur} ghosts={leftGhosts} tint={conTone(LEFT_ARM)} baseline={baseUp} orientation="up" />
-      <GhostBloom current={rightCur} ghosts={rightGhosts} tint={conTone(RIGHT_ARM)} baseline={baseDown} orientation="down" />
+      <GhostBloom
+        current={leftCur}
+        ghosts={leftGhosts}
+        tint={conTone(LEFT_ARM)}
+        baseline={baseUp}
+        orientation="up"
+      />
+      <GhostBloom
+        current={rightCur}
+        ghosts={rightGhosts}
+        tint={conTone(RIGHT_ARM)}
+        baseline={baseDown}
+        orientation="down"
+      />
 
       {/* the single shared phase-colored band, on top — ECC/CON labelled inside. */}
-      <GhostBand segments={SHARED_SEGMENTS} x={x} top={bandTop} showLabels labelColor={alpha(PARCH, 0.92)} />
-      <rect x={padL} y={bandTop} width={w - padL - padR} height={BAND_H} rx={4} fill="none" stroke={alpha('#000000', 0.3)} strokeWidth={1} />
+      <GhostBand
+        segments={SHARED_SEGMENTS}
+        x={x}
+        top={bandTop}
+        showLabels
+        labelColor={alpha(PARCH, 0.92)}
+      />
+      <rect
+        x={padL}
+        y={bandTop}
+        width={w - padL - padR}
+        height={BAND_H}
+        rx={4}
+        fill="none"
+        stroke={alpha('#000000', 0.3)}
+        strokeWidth={1}
+      />
 
-      <text x={padL} y={padTop - 9} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
+      <text
+        x={padL}
+        y={padTop - 9}
+        fontSize={9}
+        fontWeight={800}
+        letterSpacing={1}
+        fontFamily={FONT_UI}
+        fill={C['text-tertiary']}
+      >
         LEFT ARM
       </text>
-      <text x={padL} y={h - padBot + 15} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
+      <text
+        x={padL}
+        y={h - padBot + 15}
+        fontSize={9}
+        fontWeight={800}
+        letterSpacing={1}
+        fontFamily={FONT_UI}
+        fill={C['text-tertiary']}
+      >
         RIGHT ARM
       </text>
     </svg>
@@ -349,9 +412,20 @@ function DeviceLegendRow({ device }: { device: DeviceSpec }) {
     <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
         <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: tone }} />
-        <Text style={{ fontSize: 11, fontWeight: '800', fontFamily: FONT_HEAD, color: C['text-primary'] }}>{device.label}</Text>
+        <Text
+          style={{
+            fontSize: 11,
+            fontWeight: '800',
+            fontFamily: FONT_HEAD,
+            color: C['text-primary'],
+          }}
+        >
+          {device.label}
+        </Text>
       </View>
-      <Text style={{ fontSize: 8.5, fontFamily: FONT_MONO, color: tone, fontWeight: '700' }}>{verdictWord(device)}</Text>
+      <Text style={{ fontSize: 8.5, fontFamily: FONT_MONO, color: tone, fontWeight: '700' }}>
+        {verdictWord(device)}
+      </Text>
     </View>
   )
 }
@@ -360,8 +434,18 @@ function DualGhostCard() {
   const innerW = CARD_W - CARD_PAD * 2
   const chartH = 232
   return (
-    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
-      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
+    <View
+      style={[
+        { width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 },
+        paperSheet(PANEL_BG),
+      ]}
+    >
+      <Text
+        style={[
+          { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
+          debossLabel,
+        ]}
+      >
         DUAL · TOP/BOTTOM MIRRORED · GhostBand + 2×GhostBloom
       </Text>
       <View style={{ flexDirection: 'row', gap: 14 }}>
@@ -371,11 +455,20 @@ function DualGhostCard() {
       <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
         <MirroredDualBand w={innerW - 8} h={chartH} />
       </View>
-      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
-        Two `GhostBloom`s sharing one `GhostBand` axis — the LEFT blooms up, the RIGHT is the same bloom with
-        `orientation=&quot;down&quot;`. No bespoke dual code: the paper line ground and the silver→red tint come straight from the
-        shared primitive, so any single-spark improvement lands here too. Left Arm stays silver; Right Arm warms through
-        shades of red as its concentric collapses.
+      <Text
+        style={{
+          fontSize: 10,
+          fontFamily: FONT_UI,
+          color: C['text-secondary'],
+          lineHeight: 14,
+          fontStyle: 'italic',
+        }}
+      >
+        Two `GhostBloom`s sharing one `GhostBand` axis — the LEFT blooms up, the RIGHT is the same
+        bloom with `orientation=&quot;down&quot;`. No bespoke dual code: the paper line ground and
+        the silver→red tint come straight from the shared primitive, so any single-spark improvement
+        lands here too. Left Arm stays silver; Right Arm warms through shades of red as its
+        concentric collapses.
       </Text>
     </View>
   )
@@ -383,7 +476,11 @@ function DualGhostCard() {
 
 // --- Scaffolding -----------------------------------------------------------------
 function Page({ children }: { children: ReactNode }) {
-  return <View style={{ padding: 28, backgroundColor: PAGE_BG, minHeight: '100%', gap: 22 }}>{children}</View>
+  return (
+    <View style={{ padding: 28, backgroundColor: PAGE_BG, minHeight: '100%', gap: 22 }}>
+      {children}
+    </View>
+  )
 }
 
 const meta: Meta = {
@@ -400,16 +497,31 @@ export const MirroredDual: Story = {
   render: () => (
     <Page>
       <View style={{ gap: 6, maxWidth: 920 }}>
-        <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
+        <Text
+          style={[
+            { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
+            debossLabel,
+          ]}
+        >
           DUAL-VOLTRA GHOST-SPARK · COMPOSED ON SHARED PRIMITIVES
         </Text>
-        <Text style={{ fontSize: 22, fontWeight: '900', fontFamily: FONT_HEAD, color: C['text-primary'] }}>
+        <Text
+          style={{
+            fontSize: 22,
+            fontWeight: '900',
+            fontFamily: FONT_HEAD,
+            color: C['text-primary'],
+          }}
+        >
           One axis, two blooms — the dual is a flip of the single
         </Text>
-        <Text style={{ fontSize: 13, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 19 }}>
-          Mock dual set: Left Arm on-tempo (silver), Right Arm fatiguing — concentric drifting long and sticking through a
-          mid-rep collapse (grind signature crosses the red threshold). Built exactly like the single GhostSpark: a shared
-          `GhostBand` for phase + two `GhostBloom`s for the lines, the bottom one flipped `orientation=&quot;down&quot;`.
+        <Text
+          style={{ fontSize: 13, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 19 }}
+        >
+          Mock dual set: Left Arm on-tempo (silver), Right Arm fatiguing — concentric drifting long
+          and sticking through a mid-rep collapse (grind signature crosses the red threshold). Built
+          exactly like the single GhostSpark: a shared `GhostBand` for phase + two `GhostBloom`s for
+          the lines, the bottom one flipped `orientation=&quot;down&quot;`.
         </Text>
       </View>
       <View style={{ flexDirection: 'row', gap: 24, alignItems: 'flex-start', flexWrap: 'wrap' }}>

--- a/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
+++ b/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
@@ -24,12 +24,12 @@
  *     (the fatiguing arm's concentric genuinely ran longer) is compressed away — it
  *     shows up only as a change in line shape, not axis width.
  *
- * Both candidates reuse the LOCKED "Grinding line" line-tint rule verbatim: TWO per-rep
- * signals — `tempoDeviation` (0..1) sets GREEN INTENSITY (bright green on-tempo → deep
- * green well-off-tempo, hue held); `grindSignature` (0..1, mid-concentric velocity
- * collapse) warms the HUE amber(>=0.35)→red only on an actual collapse. The eccentric is
- * always drawn on-track green (a controlled lowering); only the concentric carries the
- * tint decision.
+ * Both candidates reuse the LOCKED silver→red line-tint rule verbatim (the shared
+ * `ghostLineColor` from `fatigue-tokens`): TWO per-rep signals — a controlled rep reads
+ * SILVER, dimming slightly toward a quiet grey as `tempoDeviation` (0..1) grows; once
+ * `grindSignature` (0..1, mid-concentric velocity collapse) crosses the threshold the line
+ * warms through SHADES OF RED by severity. The eccentric is always drawn on-track silver
+ * (a controlled lowering); only the concentric carries the tint decision.
  */
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ReactNode } from 'react'
@@ -38,6 +38,11 @@ import { View, Text } from 'react-native'
 import { getSemanticColors } from '../../theme/tokens/semantic'
 import { primitiveColors, primitiveRamps } from '../../theme/tokens/primitives'
 import { alpha } from '../../utils/colors'
+import {
+  SILVER,
+  GRIND_THRESHOLD,
+  ghostLineColor,
+} from '../../components/custom/Fatigue/fatigue-tokens'
 
 const C = getSemanticColors('dark')
 const PAGE_BG = primitiveColors.charcoal[900]
@@ -48,9 +53,8 @@ const FONT_MONO = 'monospace'
 
 const PARCH = C['text-primary']
 const AXIS = alpha(C['text-primary'], 0.16)
-const ON_TRACK = C['status-success']
-const DEVIATION = C['status-warning']
-const OFF_TRACK = C['status-error']
+/** The controlled / on-track tone for eccentric + non-concentric runs — silver, not green. */
+const ON_TRACK = SILVER
 
 // =================================================================================
 // Composition-level surface helpers — inlined from the north-star `surfaces.ts`
@@ -58,13 +62,7 @@ const OFF_TRACK = C['status-error']
 // =================================================================================
 function perceivedLuminance(hex: string): number {
   const h = hex.replace('#', '')
-  const full =
-    h.length === 3
-      ? h
-          .split('')
-          .map((ch) => ch + ch)
-          .join('')
-      : h
+  const full = h.length === 3 ? h.split('').map((ch) => ch + ch).join('') : h
   const r = parseInt(full.slice(0, 2), 16)
   const g = parseInt(full.slice(2, 4), 16)
   const b = parseInt(full.slice(4, 6), 16)
@@ -102,8 +100,8 @@ const debossLabel: TextStyle = {
 // Mock dual-device data — two devices, each a real per-sample rep curve (controlled
 // eccentric shared, concentric differs), plus a few faded prior "ghost" reps. The
 // RIGHT arm is the more-fatigued device: its concentric runs longer AND collapses
-// through a sticking point (crosses the grind threshold → warms amber/red); the LEFT
-// arm stays on-tempo (bright green) so the asymmetry between devices is unambiguous.
+// through a sticking point (crosses the grind threshold → warms through shades of red);
+// the LEFT arm stays on-tempo (silver) so the asymmetry between devices is unambiguous.
 // =================================================================================
 type Phase = 'ecc' | 'pauseBottom' | 'con' | 'pauseTop'
 interface Sample {
@@ -202,10 +200,7 @@ function genSamples(s: DeviceSpec, seed = 0): Sample[] {
   return out
 }
 
-const CURRENT: Record<string, Sample[]> = {
-  left: genSamples(LEFT_ARM),
-  right: genSamples(RIGHT_ARM),
-}
+const CURRENT: Record<string, Sample[]> = { left: genSamples(LEFT_ARM), right: genSamples(RIGHT_ARM) }
 const TOTAL_MS: Record<string, number> = {
   left: LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs + LEFT_ARM.pTMs,
   right: RIGHT_ARM.eccMs + RIGHT_ARM.pBMs + RIGHT_ARM.conMs + RIGHT_ARM.pTMs,
@@ -215,12 +210,7 @@ const TOTAL_MS: Record<string, number> = {
 // set in), so the current (fatigued) rep visibly regresses from its own ghost fan.
 const GHOSTS_LEFT: Sample[][] = [0, 1, 2].map((g) =>
   genSamples(
-    {
-      ...LEFT_ARM,
-      conMs: 780 - g * 90,
-      conVel: (u) =>
-        (1.0 - g * 0.05) * clamp01(u / (0.15 + g * 0.03)) * (1 - 0.82 * smoothstep(0.8, 1.0, u)),
-    },
+    { ...LEFT_ARM, conMs: 780 - g * 90, conVel: (u) => (1.0 - g * 0.05) * clamp01(u / (0.15 + g * 0.03)) * (1 - 0.82 * smoothstep(0.8, 1.0, u)) },
     g + 1
   )
 )
@@ -229,8 +219,7 @@ const GHOSTS_RIGHT: Sample[][] = [0, 1, 2].map((g) =>
     {
       ...RIGHT_ARM,
       conMs: 1050 + g * 120,
-      conVel: (u) =>
-        0.95 * clamp01(u / 0.14) * (1 - 0.6 * smoothstep(0.82, 1.0, u)) * (1 - g * 0.08),
+      conVel: (u) => 0.95 * clamp01(u / 0.14) * (1 - 0.6 * smoothstep(0.82, 1.0, u)) * (1 - g * 0.08),
     },
     g + 4
   )
@@ -238,26 +227,10 @@ const GHOSTS_RIGHT: Sample[][] = [0, 1, 2].map((g) =>
 const GHOSTS: Record<string, Sample[][]> = { left: GHOSTS_LEFT, right: GHOSTS_RIGHT }
 
 // =================================================================================
-// The LOCKED "Grinding line" tint rule (verbatim from `GrindingLine.exploration`):
-// tempoDeviation sets green INTENSITY (hue held), grindSignature warms the HUE.
+// The LOCKED silver→red tint rule — the SHARED `ghostLineColor` from `fatigue-tokens`:
+// a controlled rep reads SILVER (dimming slightly toward a quiet grey with tempo drift),
+// a collapsing rep warms through SHADES OF RED by severity. No green, no amber.
 // =================================================================================
-function hexToRgb(hex: string): [number, number, number] {
-  const h = hex.replace('#', '')
-  const f =
-    h.length === 3
-      ? h
-          .split('')
-          .map((c) => c + c)
-          .join('')
-      : h
-  return [parseInt(f.slice(0, 2), 16), parseInt(f.slice(2, 4), 16), parseInt(f.slice(4, 6), 16)]
-}
-function mixHex(a: string, b: string, t: number): string {
-  const [ar, ag, ab] = hexToRgb(a)
-  const [br, bg, bb] = hexToRgb(b)
-  const m = (x: number, y: number) => Math.round(x + (y - x) * t)
-  return `#${[m(ar, br), m(ag, bg), m(ab, bb)].map((v) => v.toString(16).padStart(2, '0')).join('')}`
-}
 /** How far the concentric DURATION overran the prescribed tempo (0..1). */
 function tempoDeviation(s: DeviceSpec): number {
   return clamp01((s.conMs / PRESCRIBED_CON_MS - 1) / 1.3)
@@ -277,35 +250,17 @@ function grindSignature(s: DeviceSpec): number {
   if (peak <= 0) return 0
   return clamp01((peak - minMid) / peak)
 }
-const GRIND_THRESHOLD = 0.35
-const GREEN_RAMP = [
-  primitiveRamps.green[200],
-  primitiveRamps.green[300],
-  primitiveRamps.green[400],
-  primitiveRamps.green[500],
-  primitiveRamps.green[600],
-  primitiveRamps.green[700],
-]
-function greenByDeviation(dev: number): string {
-  const p = clamp01(dev / 0.5) * (GREEN_RAMP.length - 1)
-  const i = Math.min(GREEN_RAMP.length - 2, Math.floor(p))
-  return mixHex(GREEN_RAMP[i], GREEN_RAMP[i + 1], p - i)
-}
-function warmByCollapse(grind: number): string {
-  const t = clamp01((grind - GRIND_THRESHOLD) / (1 - GRIND_THRESHOLD))
-  return mixHex(DEVIATION, OFF_TRACK, t)
-}
 function isBreakdown(s: DeviceSpec): boolean {
   return grindSignature(s) >= GRIND_THRESHOLD
 }
-/** The concentric line tint for a device's current rep under the LOCKED rule. */
+/** The concentric line tint for a device's current rep — the LOCKED silver→red rule. */
 function conTone(s: DeviceSpec): string {
-  return isBreakdown(s) ? warmByCollapse(grindSignature(s)) : greenByDeviation(tempoDeviation(s))
+  return ghostLineColor(tempoDeviation(s), grindSignature(s))
 }
 function verdictWord(s: DeviceSpec): string {
   if (isBreakdown(s)) return grindSignature(s) < 0.6 ? 'collapse → warn' : 'collapse → alarm'
   const dev = tempoDeviation(s)
-  return dev < 0.12 ? 'on-tempo · bright' : 'controlled · deeper green'
+  return dev < 0.12 ? 'on-tempo · silver' : 'controlled · dimmer silver'
 }
 
 // --- SVG smoothing + phase-run splitting (lifted from the LiveFatigueCard specimen) ---
@@ -344,13 +299,7 @@ const AXIS_TONE: Record<Phase, string> = {
   pauseTop: primitiveColors.charcoal[300],
 }
 function phaseSpans(s: DeviceSpec): Array<{ phase: Phase; t0: number; t1: number }> {
-  const b = [
-    0,
-    s.eccMs,
-    s.eccMs + s.pBMs,
-    s.eccMs + s.pBMs + s.conMs,
-    s.eccMs + s.pBMs + s.conMs + s.pTMs,
-  ]
+  const b = [0, s.eccMs, s.eccMs + s.pBMs, s.eccMs + s.pBMs + s.conMs, s.eccMs + s.pBMs + s.conMs + s.pTMs]
   return [
     { phase: 'ecc', t0: b[0], t1: b[1] },
     { phase: 'pauseBottom', t0: b[1], t1: b[2] },
@@ -361,12 +310,7 @@ function phaseSpans(s: DeviceSpec): Array<{ phase: Phase; t0: number; t1: number
 
 // Shared plot scales across BOTH devices (current rep + all ghosts) so the two charts
 // (Option A) or the two blooms (Option B) are directly, honestly comparable.
-const ALL_SAMPLES = [
-  ...CURRENT.left,
-  ...CURRENT.right,
-  ...GHOSTS_LEFT.flat(),
-  ...GHOSTS_RIGHT.flat(),
-]
+const ALL_SAMPLES = [...CURRENT.left, ...CURRENT.right, ...GHOSTS_LEFT.flat(), ...GHOSTS_RIGHT.flat()]
 const VMAX_UP = Math.max(0.01, ...ALL_SAMPLES.map((s) => s.vel)) * 1.06
 const VMAX_DOWN = Math.max(0.01, ...ALL_SAMPLES.map((s) => -s.vel)) * 1.06
 const VMAX_MAG = Math.max(VMAX_UP, VMAX_DOWN)
@@ -400,14 +344,7 @@ function GhostSparkSolo({ device, w, h }: { device: DeviceSpec; w: number; h: nu
         const label = p.phase === 'ecc' ? 'ECC' : p.phase === 'con' ? 'CON' : null
         return (
           <g key={i}>
-            <rect
-              x={x(p.t0) + 0.75}
-              y={mid - 1.5}
-              width={segW}
-              height={3}
-              rx={1.5}
-              fill={AXIS_TONE[p.phase]}
-            />
+            <rect x={x(p.t0) + 0.75} y={mid - 1.5} width={segW} height={3} rx={1.5} fill={AXIS_TONE[p.phase]} />
             {label && x(p.t1) - x(p.t0) > 16 && (
               <text
                 x={(x(p.t0) + x(p.t1)) / 2}
@@ -458,14 +395,7 @@ function GhostSparkSolo({ device, w, h }: { device: DeviceSpec; w: number; h: nu
           strokeLinecap="round"
         />
       ))}
-      <circle
-        cx={x(peakS.t)}
-        cy={y(peakS.vel)}
-        r={3.5}
-        fill={conColor}
-        stroke={PANEL_BG}
-        strokeWidth={1.5}
-      />
+      <circle cx={x(peakS.t)} cy={y(peakS.vel)} r={3.5} fill={conColor} stroke={PANEL_BG} strokeWidth={1.5} />
     </svg>
   )
 }
@@ -517,34 +447,16 @@ function MirroredDual({ w, h }: { w: number; h: number }) {
   const rightColor = conTone(RIGHT_ARM)
 
   const path = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down') =>
-    smoothPath(
-      samples.map((s) => [
-        x(normalizedU(s, device)),
-        dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel)),
-      ])
-    )
+    smoothPath(samples.map((s) => [x(normalizedU(s, device)), dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel))]))
 
   const leftPeak = leftCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), leftCur[0])
   const rightPeak = rightCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), rightCur[0])
 
   /** Current-rep phase runs for a device, pre-rendered to path `d` + tint once. */
-  const runsFor = (
-    samples: Sample[],
-    device: DeviceSpec,
-    dir: 'up' | 'down',
-    color: (phase: Phase) => string
-  ) =>
-    phaseRuns(samples).map((run, i) => ({
-      key: i,
-      d: path(run.pts, device, dir),
-      color: color(run.phase),
-    }))
-  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) =>
-    phase === 'con' ? leftColor : ON_TRACK
-  )
-  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) =>
-    phase === 'con' ? rightColor : ON_TRACK
-  )
+  const runsFor = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down', color: (phase: Phase) => string) =>
+    phaseRuns(samples).map((run, i) => ({ key: i, d: path(run.pts, device, dir), color: color(run.phase) }))
+  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) => (phase === 'con' ? leftColor : ON_TRACK))
+  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) => (phase === 'con' ? rightColor : ON_TRACK))
 
   return (
     <svg width={w} height={h}>
@@ -552,127 +464,41 @@ function MirroredDual({ w, h }: { w: number; h: number }) {
       {(Object.keys(TEMPLATE_BOUNDS) as Phase[]).map((phase) => {
         const [b0, b1] = TEMPLATE_BOUNDS[phase]
         const segW = Math.max(0, x(b1) - x(b0) - 1.5)
-        return (
-          <rect
-            key={phase}
-            x={x(b0) + 0.75}
-            y={mid - 1.75}
-            width={segW}
-            height={3.5}
-            rx={1.75}
-            fill={AXIS_TONE[phase]}
-          />
-        )
+        return <rect key={phase} x={x(b0) + 0.75} y={mid - 1.75} width={segW} height={3.5} rx={1.75} fill={AXIS_TONE[phase]} />
       })}
       <line x1={padL} y1={mid} x2={w - padR} y2={mid} stroke={AXIS} strokeWidth={1} />
 
       {/* faded ghost fans, both directions. */}
       {GHOSTS_LEFT.map((samples, g) => (
-        <path
-          key={`ghl${g}`}
-          d={path(samples, LEFT_ARM, 'up')}
-          fill="none"
-          stroke={alpha(PARCH, 0.1 + g * 0.02)}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
+        <path key={`ghl${g}`} d={path(samples, LEFT_ARM, 'up')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
       ))}
       {GHOSTS_RIGHT.map((samples, g) => (
-        <path
-          key={`ghr${g}`}
-          d={path(samples, RIGHT_ARM, 'down')}
-          fill="none"
-          stroke={alpha(PARCH, 0.1 + g * 0.02)}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
+        <path key={`ghr${g}`} d={path(samples, RIGHT_ARM, 'down')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
       ))}
 
-      {/* current reps — dark halo underlay, then tinted line. Ecc stays on-track green;
+      {/* current reps — dark halo underlay, then tinted line. Ecc stays on-track silver;
           con carries the device's LOCKED-rule tint. */}
       {leftRuns.map((r) => (
-        <path
-          key={`shl${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={alpha('#000000', 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`shl${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {rightRuns.map((r) => (
-        <path
-          key={`shr${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={alpha('#000000', 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`shr${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {leftRuns.map((r) => (
-        <path
-          key={`l${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={r.color}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`l${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {rightRuns.map((r) => (
-        <path
-          key={`r${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={r.color}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`r${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
       ))}
 
-      <circle
-        cx={x(normalizedU(leftPeak, LEFT_ARM))}
-        cy={yUp(Math.abs(leftPeak.vel))}
-        r={3.5}
-        fill={leftColor}
-        stroke={PANEL_BG}
-        strokeWidth={1.5}
-      />
-      <circle
-        cx={x(normalizedU(rightPeak, RIGHT_ARM))}
-        cy={yDown(Math.abs(rightPeak.vel))}
-        r={3.5}
-        fill={rightColor}
-        stroke={PANEL_BG}
-        strokeWidth={1.5}
-      />
+      <circle cx={x(normalizedU(leftPeak, LEFT_ARM))} cy={yUp(Math.abs(leftPeak.vel))} r={3.5} fill={leftColor} stroke={PANEL_BG} strokeWidth={1.5} />
+      <circle cx={x(normalizedU(rightPeak, RIGHT_ARM))} cy={yDown(Math.abs(rightPeak.vel))} r={3.5} fill={rightColor} stroke={PANEL_BG} strokeWidth={1.5} />
 
       {/* device-identity labels — up/down now carries DEVICE, not phase. */}
-      <text
-        x={padL}
-        y={padTop - 9}
-        fontSize={9}
-        fontWeight={800}
-        letterSpacing={1}
-        fontFamily={FONT_UI}
-        fill={C['text-tertiary']}
-      >
+      <text x={padL} y={padTop - 9} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
         LEFT ARM
       </text>
-      <text
-        x={padL}
-        y={h - padBot + 15}
-        fontSize={9}
-        fontWeight={800}
-        letterSpacing={1}
-        fontFamily={FONT_UI}
-        fill={C['text-tertiary']}
-      >
+      <text x={padL} y={h - padBot + 15} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
         RIGHT ARM
       </text>
     </svg>
@@ -688,29 +514,7 @@ function MirroredDual({ w, h }: { w: number; h: number }) {
 // =================================================================================
 const BAND_H = 16
 const BAND_GAP = 4
-const SILVER = '#C4C8D0'
-const RED_RAMP = [primitiveRamps.red[400], primitiveRamps.red[600], primitiveRamps.red[800]]
-/** Severity as SHADES OF RED (no amber) — the ROM chart's silver/red scheme, extended. */
-function redBySeverity(grind: number): string {
-  const t = clamp01((grind - GRIND_THRESHOLD) / (1 - GRIND_THRESHOLD))
-  const p = t * (RED_RAMP.length - 1)
-  const i = Math.min(RED_RAMP.length - 2, Math.floor(p))
-  return mixHex(RED_RAMP[i], RED_RAMP[i + 1], p - i)
-}
-/** Silver-default tint: an on-track line reads bright SILVER (matching the ROM chart);
- *  an issue takes SHADES OF RED by severity — no green, no amber, one silver/red scheme. */
-function conToneSilver(s: DeviceSpec): string {
-  return isBreakdown(s) ? redBySeverity(grindSignature(s)) : SILVER
-}
-function MirroredDualBand({
-  w,
-  h,
-  mode = 'green',
-}: {
-  w: number
-  h: number
-  mode?: 'green' | 'silver'
-}) {
+function MirroredDualBand({ w, h }: { w: number; h: number }) {
   const padL = 14
   const padR = 14
   const padTop = 22
@@ -731,38 +535,18 @@ function MirroredDualBand({
 
   const leftCur = CURRENT.left
   const rightCur = CURRENT.right
-  const tone = (s: DeviceSpec) => (mode === 'silver' ? conToneSilver(s) : conTone(s))
-  const onTrackTone = mode === 'silver' ? SILVER : ON_TRACK
-  const leftColor = tone(LEFT_ARM)
-  const rightColor = tone(RIGHT_ARM)
+  const leftColor = conTone(LEFT_ARM)
+  const rightColor = conTone(RIGHT_ARM)
 
   const path = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down') =>
-    smoothPath(
-      samples.map((s) => [
-        x(normalizedU(s, device)),
-        dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel)),
-      ])
-    )
+    smoothPath(samples.map((s) => [x(normalizedU(s, device)), dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel))]))
 
   const leftPeak = leftCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), leftCur[0])
   const rightPeak = rightCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), rightCur[0])
-  const runsFor = (
-    samples: Sample[],
-    device: DeviceSpec,
-    dir: 'up' | 'down',
-    color: (phase: Phase) => string
-  ) =>
-    phaseRuns(samples).map((run, i) => ({
-      key: i,
-      d: path(run.pts, device, dir),
-      color: color(run.phase),
-    }))
-  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) =>
-    phase === 'con' ? leftColor : onTrackTone
-  )
-  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) =>
-    phase === 'con' ? rightColor : onTrackTone
-  )
+  const runsFor = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down', color: (phase: Phase) => string) =>
+    phaseRuns(samples).map((run, i) => ({ key: i, d: path(run.pts, device, dir), color: color(run.phase) }))
+  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) => (phase === 'con' ? leftColor : ON_TRACK))
+  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) => (phase === 'con' ? rightColor : ON_TRACK))
 
   return (
     <svg width={w} height={h}>
@@ -792,122 +576,37 @@ function MirroredDualBand({
           </g>
         )
       })}
-      <rect
-        x={padL}
-        y={bandTop}
-        width={w - padL - padR}
-        height={BAND_H}
-        rx={4}
-        fill="none"
-        stroke={alpha('#000000', 0.3)}
-        strokeWidth={1}
-      />
+      <rect x={padL} y={bandTop} width={w - padL - padR} height={BAND_H} rx={4} fill="none" stroke={alpha('#000000', 0.3)} strokeWidth={1} />
 
       {/* faded ghost fans, offset off the band, both directions. */}
       {GHOSTS_LEFT.map((samples, g) => (
-        <path
-          key={`ghl${g}`}
-          d={path(samples, LEFT_ARM, 'up')}
-          fill="none"
-          stroke={alpha(PARCH, 0.1 + g * 0.02)}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
+        <path key={`ghl${g}`} d={path(samples, LEFT_ARM, 'up')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
       ))}
       {GHOSTS_RIGHT.map((samples, g) => (
-        <path
-          key={`ghr${g}`}
-          d={path(samples, RIGHT_ARM, 'down')}
-          fill="none"
-          stroke={alpha(PARCH, 0.1 + g * 0.02)}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
+        <path key={`ghr${g}`} d={path(samples, RIGHT_ARM, 'down')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
       ))}
 
       {/* current reps — halo underlay then tinted line. */}
       {leftRuns.map((r) => (
-        <path
-          key={`shl${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={alpha('#000000', 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`shl${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {rightRuns.map((r) => (
-        <path
-          key={`shr${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={alpha('#000000', 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`shr${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {leftRuns.map((r) => (
-        <path
-          key={`l${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={r.color}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`l${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
       ))}
       {rightRuns.map((r) => (
-        <path
-          key={`r${r.key}`}
-          d={r.d}
-          fill="none"
-          stroke={r.color}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        <path key={`r${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
       ))}
 
-      <circle
-        cx={x(normalizedU(leftPeak, LEFT_ARM))}
-        cy={yUp(Math.abs(leftPeak.vel))}
-        r={3.5}
-        fill={leftColor}
-        stroke={PANEL_BG}
-        strokeWidth={1.5}
-      />
-      <circle
-        cx={x(normalizedU(rightPeak, RIGHT_ARM))}
-        cy={yDown(Math.abs(rightPeak.vel))}
-        r={3.5}
-        fill={rightColor}
-        stroke={PANEL_BG}
-        strokeWidth={1.5}
-      />
+      <circle cx={x(normalizedU(leftPeak, LEFT_ARM))} cy={yUp(Math.abs(leftPeak.vel))} r={3.5} fill={leftColor} stroke={PANEL_BG} strokeWidth={1.5} />
+      <circle cx={x(normalizedU(rightPeak, RIGHT_ARM))} cy={yDown(Math.abs(rightPeak.vel))} r={3.5} fill={rightColor} stroke={PANEL_BG} strokeWidth={1.5} />
 
-      <text
-        x={padL}
-        y={padTop - 9}
-        fontSize={9}
-        fontWeight={800}
-        letterSpacing={1}
-        fontFamily={FONT_UI}
-        fill={C['text-tertiary']}
-      >
+      <text x={padL} y={padTop - 9} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
         LEFT ARM
       </text>
-      <text
-        x={padL}
-        y={h - padBot + 15}
-        fontSize={9}
-        fontWeight={800}
-        letterSpacing={1}
-        fontFamily={FONT_UI}
-        fill={C['text-tertiary']}
-      >
+      <text x={padL} y={h - padBot + 15} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
         RIGHT ARM
       </text>
     </svg>
@@ -928,20 +627,9 @@ function DeviceLegendRow({ device }: { device: DeviceSpec }) {
     <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
         <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: tone }} />
-        <Text
-          style={{
-            fontSize: 11,
-            fontWeight: '800',
-            fontFamily: FONT_HEAD,
-            color: C['text-primary'],
-          }}
-        >
-          {device.label}
-        </Text>
+        <Text style={{ fontSize: 11, fontWeight: '800', fontFamily: FONT_HEAD, color: C['text-primary'] }}>{device.label}</Text>
       </View>
-      <Text style={{ fontSize: 8.5, fontFamily: FONT_MONO, color: tone, fontWeight: '700' }}>
-        {verdictWord(device)}
-      </Text>
+      <Text style={{ fontSize: 8.5, fontFamily: FONT_MONO, color: tone, fontWeight: '700' }}>{verdictWord(device)}</Text>
     </View>
   )
 }
@@ -952,44 +640,21 @@ function OptionCardA() {
   const chartW = (innerW - gap) / 2
   const chartH = 168
   return (
-    <View
-      style={[
-        { width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 },
-        paperSheet(PANEL_BG),
-      ]}
-    >
-      <Text
-        style={[
-          { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
-          debossLabel,
-        ]}
-      >
-        OPTION A · SIDE BY SIDE
-      </Text>
+    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
+      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>OPTION A · SIDE BY SIDE</Text>
       <View style={{ flexDirection: 'row', gap }}>
         {DEVICES.map((d) => (
           <View key={d.key} style={{ width: chartW, gap: 4 }}>
             <DeviceLegendRow device={d} />
-            <View
-              style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}
-            >
+            <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
               <GhostSparkSolo device={d} w={chartW - 8} h={chartH} />
             </View>
           </View>
         ))}
       </View>
-      <Text
-        style={{
-          fontSize: 10,
-          fontFamily: FONT_UI,
-          color: C['text-secondary'],
-          lineHeight: 14,
-          fontStyle: 'italic',
-        }}
-      >
-        Each chart keeps its own full phase axis (ECC above · CON below) — legible per arm.
-        Trade-off: at real card width, two charts halve to ~{Math.round(chartW)}px each — peak
-        markers and axis labels crowd the narrow column.
+      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
+        Each chart keeps its own full phase axis (ECC above · CON below) — legible per arm. Trade-off: at real card width, two
+        charts halve to ~{Math.round(chartW)}px each — peak markers and axis labels crowd the narrow column.
       </Text>
     </View>
   )
@@ -999,18 +664,8 @@ function OptionCardB() {
   const innerW = CARD_W - CARD_PAD * 2
   const chartH = 232
   return (
-    <View
-      style={[
-        { width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 },
-        paperSheet(PANEL_BG),
-      ]}
-    >
-      <Text
-        style={[
-          { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
-          debossLabel,
-        ]}
-      >
+    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
+      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
         OPTION B · TOP/BOTTOM MIRRORED
       </Text>
       <View style={{ flexDirection: 'row', gap: 14 }}>
@@ -1020,20 +675,11 @@ function OptionCardB() {
       <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
         <MirroredDual w={innerW - 8} h={chartH} />
       </View>
-      <Text
-        style={{
-          fontSize: 10,
-          fontFamily: FONT_UI,
-          color: C['text-secondary'],
-          lineHeight: 14,
-          fontStyle: 'italic',
-        }}
-      >
-        One shared spine reclaims full chart width per device (mirrored up/down) — no split-width
-        penalty. Trade-off: phase can no longer sit above/below (both halves are spent on device
-        identity), so it rides axis-segment COLOR alone, no ECC/CON text; and the spine is
-        phase-normalized, so Right Arm&apos;s concentric genuinely running ~79% longer (1700ms vs
-        950ms) shows only as line shape, not a wider axis segment.
+      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
+        One shared spine reclaims full chart width per device (mirrored up/down) — no split-width penalty. Trade-off: phase can no
+        longer sit above/below (both halves are spent on device identity), so it rides axis-segment COLOR alone, no ECC/CON text;
+        and the spine is phase-normalized, so Right Arm&apos;s concentric genuinely running ~79% longer (1700ms vs 950ms) shows
+        only as line shape, not a wider axis segment.
       </Text>
     </View>
   )
@@ -1043,18 +689,8 @@ function OptionCardB2() {
   const innerW = CARD_W - CARD_PAD * 2
   const chartH = 232
   return (
-    <View
-      style={[
-        { width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 },
-        paperSheet(PANEL_BG),
-      ]}
-    >
-      <Text
-        style={[
-          { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
-          debossLabel,
-        ]}
-      >
+    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
+      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
         OPTION B2 · MIRRORED + AXIS BAND
       </Text>
       <View style={{ flexDirection: 'row', gap: 14 }}>
@@ -1064,62 +700,10 @@ function OptionCardB2() {
       <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
         <MirroredDualBand w={innerW - 8} h={chartH} />
       </View>
-      <Text
-        style={{
-          fontSize: 10,
-          fontFamily: FONT_UI,
-          color: C['text-secondary'],
-          lineHeight: 14,
-          fontStyle: 'italic',
-        }}
-      >
-        The axis widens into a phase-colored BAND — it carries the ECC/CON labels INSIDE it
-        (recovering the phase text plain mirrored loses) and doubles as a gutter: both blooms are
-        offset off its edges, so the two lines never touch the axis or overlap. Phase timing becomes
-        the most legible element; each device reads as one clean stroke.
-      </Text>
-    </View>
-  )
-}
-
-function OptionCardB3() {
-  const innerW = CARD_W - CARD_PAD * 2
-  const chartH = 232
-  return (
-    <View
-      style={[
-        { width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 },
-        paperSheet(PANEL_BG),
-      ]}
-    >
-      <Text
-        style={[
-          { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
-          debossLabel,
-        ]}
-      >
-        OPTION B3 · BAND + SILVER LINE
-      </Text>
-      <View style={{ flexDirection: 'row', gap: 14 }}>
-        <DeviceLegendRow device={LEFT_ARM} />
-        <DeviceLegendRow device={RIGHT_ARM} />
-      </View>
-      <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
-        <MirroredDualBand w={innerW - 8} h={chartH} mode="silver" />
-      </View>
-      <Text
-        style={{
-          fontSize: 10,
-          fontFamily: FONT_UI,
-          color: C['text-secondary'],
-          lineHeight: 14,
-          fontStyle: 'italic',
-        }}
-      >
-        Same trimmed band, but the on-track line reads bright SILVER (matching the ROM chart)
-        instead of green — it only takes color when there&apos;s an issue to flag: Left Arm stays
-        silver (fine), Right Arm warms amber/red through the grind. Quieter until something needs
-        attention.
+      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
+        The axis widens into a phase-colored BAND — it carries the ECC/CON labels INSIDE it (recovering the phase text plain mirrored
+        loses) and doubles as a gutter: both blooms are offset off its edges, so the two lines never touch the axis or overlap. Phase
+        timing becomes the most legible element; each device reads as one clean stroke.
       </Text>
     </View>
   )
@@ -1127,11 +711,7 @@ function OptionCardB3() {
 
 // --- Scaffolding -----------------------------------------------------------------
 function Page({ children }: { children: ReactNode }) {
-  return (
-    <View style={{ padding: 28, backgroundColor: PAGE_BG, minHeight: '100%', gap: 22 }}>
-      {children}
-    </View>
-  )
+  return <View style={{ padding: 28, backgroundColor: PAGE_BG, minHeight: '100%', gap: 22 }}>{children}</View>
 }
 
 const meta: Meta = {
@@ -1148,40 +728,24 @@ export const SideBySideVsMirrored: Story = {
   render: () => (
     <Page>
       <View style={{ gap: 6, maxWidth: 920 }}>
-        <Text
-          style={[
-            { fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] },
-            debossLabel,
-          ]}
-        >
+        <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
           DUAL-VOLTRA GHOST-SPARK · LAYOUT DECISION
         </Text>
-        <Text
-          style={{
-            fontSize: 22,
-            fontWeight: '900',
-            fontFamily: FONT_HEAD,
-            color: C['text-primary'],
-          }}
-        >
+        <Text style={{ fontSize: 22, fontWeight: '900', fontFamily: FONT_HEAD, color: C['text-primary'] }}>
           Two devices, one fatigue card — where does the second ghost-spark go?
         </Text>
-        <Text
-          style={{ fontSize: 13, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 19 }}
-        >
-          Same mock dual set both columns: Left Arm on-tempo (bright green), Right Arm fatiguing —
-          concentric drifting long and sticking through a mid-rep collapse (grind signature crosses
-          the amber/red threshold). Both candidates apply the LOCKED tint rule verbatim (tempo
-          deviation → green intensity, grind signature → hue). Rendered at the established ~330px
-          card-column width so the real trade-off — cramped detail vs. lost phase labels — reads
-          honestly, not idealized.
+        <Text style={{ fontSize: 13, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 19 }}>
+          Same mock dual set both columns: Left Arm on-tempo (silver), Right Arm fatiguing — concentric drifting long and
+          sticking through a mid-rep collapse (grind signature crosses the red threshold). Both candidates apply the LOCKED
+          silver→red tint rule verbatim (tempo deviation dims the silver, grind signature warms it through shades of red).
+          Rendered at the established ~330px card-column width so the real trade-off — cramped detail vs. lost phase labels —
+          reads honestly, not idealized.
         </Text>
       </View>
       <View style={{ flexDirection: 'row', gap: 24, alignItems: 'flex-start', flexWrap: 'wrap' }}>
         <OptionCardA />
         <OptionCardB />
         <OptionCardB2 />
-        <OptionCardB3 />
       </View>
     </Page>
   ),

--- a/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
+++ b/packages/ui/src/lab/north-star/DualGhostLine.exploration.stories.tsx
@@ -2,47 +2,38 @@
 /**
  * `Lab/North Star/Dual Ghost Line` — DESIGN EXPLORATION (not shipped).
  *
- * DUAL-VOLTRA layout comparison for the ghost-spark chart at the bottom of the live
- * fatigue card. Single-voltra shows ONE ghost-spark (current rep solid, prior reps
- * faded ghosts, over a phase-colored zero axis — see `GrindingLine.exploration` and the
- * `LiveFatigueCard.exploration` specimens this is ported from). For a DUAL workout (two
- * devices, e.g. Left Arm / Right Arm) we must show BOTH devices' ghost-sparks and are
- * deciding the layout. This story renders TWO candidates, fed the SAME mock dual data,
- * at a realistic narrow card-column width, so an operator can pick:
+ * DUAL-VOLTRA ghost-spark for the bottom of the live fatigue card. The layout decision is
+ * settled: TOP/BOTTOM MIRRORED around one shared phase-colored axis band — the LEFT device
+ * blooms UP, the RIGHT device blooms DOWN. Up/down is spent on DEVICE identity, so phase
+ * rides the axis-band COLOR alone (magenta ecc / cyan con), with the ECC/CON labels INSIDE
+ * the band.
  *
- *   • Option A — SIDE BY SIDE: two independent ghost-spark charts in a row. Each keeps
- *     its own phase axis with ECC-above / CON-below labels intact — the vertical is
- *     already spent on phase, so this is the "don't touch what works" option. Trade-off:
- *     halving the card's width per chart, at real wall-card width, crowds detail.
- *   • Option B — TOP/BOTTOM MIRRORED: one shared horizontal phase-colored spine; the
- *     LEFT device blooms UP, the RIGHT device blooms DOWN. Up/down is now spent on
- *     DEVICE identity, so phase can no longer use above/below — it rides the axis-
- *     segment COLOR alone (magenta ecc / cyan con), same as the diverging velocity hero
- *     (top=left / bottom=right around a shared axis). Trade-off: the shared spine only
- *     stays coherent if it is phase-NORMALIZED (each device's phase stretched onto a
- *     common template), so a real duration difference between the two devices' reps
- *     (the fatiguing arm's concentric genuinely ran longer) is compressed away — it
- *     shows up only as a change in line shape, not axis width.
+ * The point of this specimen NOW is that it is built the SAME way the single GhostSpark is:
+ * it composes the SHARED `GhostBand` + two `GhostBloom`s — the top normal, the bottom just
+ * `orientation="down"` (a y-flip), sharing ONE band as the single axis. There is no bespoke
+ * dual component and no forked path/band/tint code; any GhostBloom improvement (the paper-
+ * inspired line ground, the silver→red tint) reaches the dual for free. This is the ghost
+ * analogue of the diverging VelocityStrip = two composed VelocityStrips.
  *
- * Both candidates reuse the LOCKED silver→red line-tint rule verbatim (the shared
- * `ghostLineColor` from `fatigue-tokens`): TWO per-rep signals — a controlled rep reads
- * SILVER, dimming slightly toward a quiet grey as `tempoDeviation` (0..1) grows; once
- * `grindSignature` (0..1, mid-concentric velocity collapse) crosses the threshold the line
- * warms through SHADES OF RED by severity. The eccentric is always drawn on-track silver
- * (a controlled lowering); only the concentric carries the tint decision.
+ * Tint is the LOCKED silver→red rule verbatim (the shared `ghostLineColor`): a controlled
+ * rep reads SILVER (dimming toward a dim-silver drift grey with tempo deviation), a
+ * collapsing rep warms through SHADES OF RED by severity. No greens, no ambers.
  */
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import type { ReactNode } from 'react'
-import type { TextStyle, ViewStyle } from 'react-native'
+import type { ReactNode, TextStyle, ViewStyle } from 'react'
 import { View, Text } from 'react-native'
 import { getSemanticColors } from '../../theme/tokens/semantic'
-import { primitiveColors, primitiveRamps } from '../../theme/tokens/primitives'
+import { primitiveColors } from '../../theme/tokens/primitives'
 import { alpha } from '../../utils/colors'
+import { GRIND_THRESHOLD, ghostLineColor } from '../../components/custom/Fatigue/fatigue-tokens'
 import {
-  SILVER,
-  GRIND_THRESHOLD,
-  ghostLineColor,
-} from '../../components/custom/Fatigue/fatigue-tokens'
+  GhostBand,
+  GhostBloom,
+  BAND_H,
+  BAND_GAP,
+  type Pt,
+} from '../../components/custom/Fatigue'
+import type { PhaseSegment } from '../../components/custom/Fatigue'
 
 const C = getSemanticColors('dark')
 const PAGE_BG = primitiveColors.charcoal[900]
@@ -52,9 +43,6 @@ const FONT_UI = '"Nunito Sans", sans-serif'
 const FONT_MONO = 'monospace'
 
 const PARCH = C['text-primary']
-const AXIS = alpha(C['text-primary'], 0.16)
-/** The controlled / on-track tone for eccentric + non-concentric runs — silver, not green. */
-const ON_TRACK = SILVER
 
 // =================================================================================
 // Composition-level surface helpers — inlined from the north-star `surfaces.ts`
@@ -163,7 +151,6 @@ const RIGHT_ARM: DeviceSpec = {
     return Math.max(0.34, spike, recover)
   },
 }
-const DEVICES: DeviceSpec[] = [LEFT_ARM, RIGHT_ARM]
 
 function hashNoise(i: number): number {
   const x = Math.sin(i * 127.1 + 11.7) * 43758.5453
@@ -201,10 +188,6 @@ function genSamples(s: DeviceSpec, seed = 0): Sample[] {
 }
 
 const CURRENT: Record<string, Sample[]> = { left: genSamples(LEFT_ARM), right: genSamples(RIGHT_ARM) }
-const TOTAL_MS: Record<string, number> = {
-  left: LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs + LEFT_ARM.pTMs,
-  right: RIGHT_ARM.eccMs + RIGHT_ARM.pBMs + RIGHT_ARM.conMs + RIGHT_ARM.pTMs,
-}
 // Faded prior "ghost" reps per device — LEFT stays steady across its set; RIGHT's
 // ghosts are progressively healthier (its earlier reps, before the sticking point
 // set in), so the current (fatigued) rep visibly regresses from its own ghost fan.
@@ -224,12 +207,11 @@ const GHOSTS_RIGHT: Sample[][] = [0, 1, 2].map((g) =>
     g + 4
   )
 )
-const GHOSTS: Record<string, Sample[][]> = { left: GHOSTS_LEFT, right: GHOSTS_RIGHT }
 
 // =================================================================================
-// The LOCKED silver→red tint rule — the SHARED `ghostLineColor` from `fatigue-tokens`:
-// a controlled rep reads SILVER (dimming slightly toward a quiet grey with tempo drift),
-// a collapsing rep warms through SHADES OF RED by severity. No green, no amber.
+// The LOCKED silver→red tint rule — the SHARED `ghostLineColor` from `fatigue-tokens`.
+// The whole current line takes ONE control-aware tint (phase is carried by the band,
+// not the line) — the same model the single GhostSpark uses.
 // =================================================================================
 /** How far the concentric DURATION overran the prescribed tempo (0..1). */
 function tempoDeviation(s: DeviceSpec): number {
@@ -253,7 +235,7 @@ function grindSignature(s: DeviceSpec): number {
 function isBreakdown(s: DeviceSpec): boolean {
   return grindSignature(s) >= GRIND_THRESHOLD
 }
-/** The concentric line tint for a device's current rep — the LOCKED silver→red rule. */
+/** The device's current-rep line tint — the LOCKED silver→red rule. */
 function conTone(s: DeviceSpec): string {
   return ghostLineColor(tempoDeviation(s), grindSignature(s))
 }
@@ -263,41 +245,18 @@ function verdictWord(s: DeviceSpec): string {
   return dev < 0.12 ? 'on-tempo · silver' : 'controlled · dimmer silver'
 }
 
-// --- SVG smoothing + phase-run splitting (lifted from the LiveFatigueCard specimen) ---
-type Pt = [number, number]
-function smoothPath(pts: Pt[]): string {
-  if (pts.length < 2) return pts.length ? `M ${pts[0][0]} ${pts[0][1]}` : ''
-  let d = `M ${pts[0][0].toFixed(1)} ${pts[0][1].toFixed(1)}`
-  for (let i = 0; i < pts.length - 1; i++) {
-    const p0 = pts[i - 1] ?? pts[i]
-    const p1 = pts[i]
-    const p2 = pts[i + 1]
-    const p3 = pts[i + 2] ?? p2
-    const c1x = p1[0] + (p2[0] - p0[0]) / 6
-    const c1y = p1[1] + (p2[1] - p0[1]) / 6
-    const c2x = p2[0] - (p3[0] - p1[0]) / 6
-    const c2y = p2[1] - (p3[1] - p1[1]) / 6
-    d += ` C ${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${p2[0].toFixed(1)} ${p2[1].toFixed(1)}`
-  }
-  return d
-}
-function phaseRuns(samples: Sample[]): Array<{ phase: Phase; pts: Sample[] }> {
-  const runs: Array<{ phase: Phase; pts: Sample[] }> = []
-  samples.forEach((s) => {
-    const last = runs[runs.length - 1]
-    if (!last || last.phase !== s.phase) {
-      if (last) last.pts.push(s)
-      runs.push({ phase: s.phase, pts: [s] })
-    } else last.pts.push(s)
-  })
-  return runs
-}
-const AXIS_TONE: Record<Phase, string> = {
-  ecc: primitiveRamps.magenta[800],
-  pauseBottom: primitiveColors.charcoal[300],
-  con: primitiveRamps.cyan[800],
-  pauseTop: primitiveColors.charcoal[300],
-}
+// =================================================================================
+// Phase-NORMALIZED shared spine — each device's own phase durations are stretched onto
+// one canonical template (the on-tempo / prescribed LEFT-arm timing) so the two blooms
+// share one coherent x-axis regardless of the devices' actual (differing) rep durations.
+// =================================================================================
+const TEMPLATE_TOTAL = LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs + LEFT_ARM.pTMs
+const TEMPLATE_BOUNDS: Record<Phase, [number, number]> = (() => {
+  const b1 = LEFT_ARM.eccMs / TEMPLATE_TOTAL
+  const b2 = (LEFT_ARM.eccMs + LEFT_ARM.pBMs) / TEMPLATE_TOTAL
+  const b3 = (LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs) / TEMPLATE_TOTAL
+  return { ecc: [0, b1], pauseBottom: [b1, b2], con: [b2, b3], pauseTop: [b3, 1] }
+})()
 function phaseSpans(s: DeviceSpec): Array<{ phase: Phase; t0: number; t1: number }> {
   const b = [0, s.eccMs, s.eccMs + s.pBMs, s.eccMs + s.pBMs + s.conMs, s.eccMs + s.pBMs + s.conMs + s.pTMs]
   return [
@@ -307,213 +266,32 @@ function phaseSpans(s: DeviceSpec): Array<{ phase: Phase; t0: number; t1: number
     { phase: 'pauseTop', t0: b[3], t1: b[4] },
   ]
 }
-
-// Shared plot scales across BOTH devices (current rep + all ghosts) so the two charts
-// (Option A) or the two blooms (Option B) are directly, honestly comparable.
-const ALL_SAMPLES = [...CURRENT.left, ...CURRENT.right, ...GHOSTS_LEFT.flat(), ...GHOSTS_RIGHT.flat()]
-const VMAX_UP = Math.max(0.01, ...ALL_SAMPLES.map((s) => s.vel)) * 1.06
-const VMAX_DOWN = Math.max(0.01, ...ALL_SAMPLES.map((s) => -s.vel)) * 1.06
-const VMAX_MAG = Math.max(VMAX_UP, VMAX_DOWN)
-const AXIS_MAX_T = Math.max(TOTAL_MS.left, TOTAL_MS.right) * 1.04
-
-// =================================================================================
-// OPTION A — independent ghost-spark per device, full phase axis (ECC above / CON
-// below) intact. Real elapsed-ms x-scale, shared across both charts (so a device
-// that runs long is honestly wider, not silently normalized away).
-// =================================================================================
-function GhostSparkSolo({ device, w, h }: { device: DeviceSpec; w: number; h: number }) {
-  const padL = 12
-  const padR = 10
-  const padTop = 12
-  const padBot = 12
-  const plotH = h - padTop - padBot
-  const upH = plotH * (VMAX_UP / (VMAX_UP + VMAX_DOWN))
-  const downH = plotH - upH
-  const mid = padTop + upH
-  const x = (t: number) => padL + (t / AXIS_MAX_T) * (w - padL - padR)
-  const y = (v: number) => (v >= 0 ? mid - (v / VMAX_UP) * upH : mid + (-v / VMAX_DOWN) * downH)
-  const cur = CURRENT[device.key]
-  const ghosts = GHOSTS[device.key]
-  const conColor = conTone(device)
-  const runColor = (phase: Phase) => (phase === 'con' ? conColor : ON_TRACK)
-  const peakS = cur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), cur[0])
-  return (
-    <svg width={w} height={h}>
-      {phaseSpans(device).map((p, i) => {
-        const segW = Math.max(0, x(p.t1) - x(p.t0) - 1.5)
-        const label = p.phase === 'ecc' ? 'ECC' : p.phase === 'con' ? 'CON' : null
-        return (
-          <g key={i}>
-            <rect x={x(p.t0) + 0.75} y={mid - 1.5} width={segW} height={3} rx={1.5} fill={AXIS_TONE[p.phase]} />
-            {label && x(p.t1) - x(p.t0) > 16 && (
-              <text
-                x={(x(p.t0) + x(p.t1)) / 2}
-                y={p.phase === 'con' ? mid + 14 : mid - 7}
-                textAnchor="middle"
-                fill={C['text-tertiary']}
-                fontSize={8}
-                fontWeight={800}
-                letterSpacing={1}
-                fontFamily={FONT_UI}
-              >
-                {label}
-              </text>
-            )}
-          </g>
-        )
-      })}
-      <line x1={padL} y1={mid} x2={w - padR} y2={mid} stroke={AXIS} strokeWidth={1} />
-      {ghosts.map((samples, g) => (
-        <path
-          key={`gh${g}`}
-          d={smoothPath(samples.map((s) => [x(s.t), y(s.vel)]))}
-          fill="none"
-          stroke={alpha(PARCH, 0.1 + g * 0.02)}
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-        />
-      ))}
-      {phaseRuns(cur).map((run, i) => (
-        <path
-          key={`sh${i}`}
-          d={smoothPath(run.pts.map((s) => [x(s.t), y(s.vel)]))}
-          fill="none"
-          stroke={alpha('#000000', 0.55)}
-          strokeWidth={7}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-      ))}
-      {phaseRuns(cur).map((run, i) => (
-        <path
-          key={i}
-          d={smoothPath(run.pts.map((s) => [x(s.t), y(s.vel)]))}
-          fill="none"
-          stroke={runColor(run.phase)}
-          strokeWidth={3.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-      ))}
-      <circle cx={x(peakS.t)} cy={y(peakS.vel)} r={3.5} fill={conColor} stroke={PANEL_BG} strokeWidth={1.5} />
-    </svg>
-  )
-}
-
-// =================================================================================
-// OPTION B — one shared spine. LEFT device blooms UP, RIGHT blooms DOWN. Phase can no
-// longer use above/below (both halves are spent on device identity), so it rides the
-// axis-segment COLOR alone. The spine is phase-NORMALIZED — each device's own phase
-// durations are stretched onto a shared canonical template (the on-tempo / prescribed
-// LEFT-arm timing) so the two blooms share one coherent x-axis regardless of the
-// devices' actual (differing) rep durations.
-// =================================================================================
-const TEMPLATE_TOTAL = LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs + LEFT_ARM.pTMs
-const TEMPLATE_BOUNDS: Record<Phase, [number, number]> = (() => {
-  const b0 = 0
-  const b1 = LEFT_ARM.eccMs / TEMPLATE_TOTAL
-  const b2 = (LEFT_ARM.eccMs + LEFT_ARM.pBMs) / TEMPLATE_TOTAL
-  const b3 = (LEFT_ARM.eccMs + LEFT_ARM.pBMs + LEFT_ARM.conMs) / TEMPLATE_TOTAL
-  const b4 = 1
-  return { ecc: [b0, b1], pauseBottom: [b1, b2], con: [b2, b3], pauseTop: [b3, b4] }
-})()
-/** Map a device sample's real elapsed ms to the shared [0,1] phase-normalized spine:
- *  the sample's LOCAL progress within its own phase is stretched onto that phase's
- *  canonical (template) fraction of the spine. */
+/** Map a device sample's real elapsed ms to the shared [0,1] phase-normalized spine. */
 function normalizedU(sample: Sample, device: DeviceSpec): number {
-  const spans = phaseSpans(device)
-  const span = spans.find((s) => s.phase === sample.phase)
+  const span = phaseSpans(device).find((s) => s.phase === sample.phase)
   if (!span) return 0
   const localU = span.t1 > span.t0 ? clamp01((sample.t - span.t0) / (span.t1 - span.t0)) : 0
   const [b0, b1] = TEMPLATE_BOUNDS[sample.phase]
   return b0 + localU * (b1 - b0)
 }
 
-function MirroredDual({ w, h }: { w: number; h: number }) {
-  const padL = 14
-  const padR = 14
-  const padTop = 22
-  const padBot = 22
-  const plotH = h - padTop - padBot
-  const halfH = plotH / 2
-  const mid = padTop + halfH
-  const x = (u: number) => padL + u * (w - padL - padR)
-  const yUp = (mag: number) => mid - clamp01(mag / VMAX_MAG) * halfH
-  const yDown = (mag: number) => mid + clamp01(mag / VMAX_MAG) * halfH
+/** The band's phase runs as the shared component `PhaseSegment[]` (0..1 domain), pause
+ *  phases collapsing to `idle` (unlabelled) so GhostBand labels only ECC / CON. */
+const SHARED_SEGMENTS: PhaseSegment[] = (Object.keys(TEMPLATE_BOUNDS) as Phase[]).map((phase) => ({
+  phase: phase === 'ecc' ? 'eccentric' : phase === 'con' ? 'concentric' : 'idle',
+  startMs: TEMPLATE_BOUNDS[phase][0],
+  endMs: TEMPLATE_BOUNDS[phase][1],
+}))
 
-  const leftCur = CURRENT.left
-  const rightCur = CURRENT.right
-  const leftColor = conTone(LEFT_ARM)
-  const rightColor = conTone(RIGHT_ARM)
-
-  const path = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down') =>
-    smoothPath(samples.map((s) => [x(normalizedU(s, device)), dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel))]))
-
-  const leftPeak = leftCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), leftCur[0])
-  const rightPeak = rightCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), rightCur[0])
-
-  /** Current-rep phase runs for a device, pre-rendered to path `d` + tint once. */
-  const runsFor = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down', color: (phase: Phase) => string) =>
-    phaseRuns(samples).map((run, i) => ({ key: i, d: path(run.pts, device, dir), color: color(run.phase) }))
-  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) => (phase === 'con' ? leftColor : ON_TRACK))
-  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) => (phase === 'con' ? rightColor : ON_TRACK))
-
-  return (
-    <svg width={w} height={h}>
-      {/* shared phase-colored spine — the ONLY carrier of phase in this layout. */}
-      {(Object.keys(TEMPLATE_BOUNDS) as Phase[]).map((phase) => {
-        const [b0, b1] = TEMPLATE_BOUNDS[phase]
-        const segW = Math.max(0, x(b1) - x(b0) - 1.5)
-        return <rect key={phase} x={x(b0) + 0.75} y={mid - 1.75} width={segW} height={3.5} rx={1.75} fill={AXIS_TONE[phase]} />
-      })}
-      <line x1={padL} y1={mid} x2={w - padR} y2={mid} stroke={AXIS} strokeWidth={1} />
-
-      {/* faded ghost fans, both directions. */}
-      {GHOSTS_LEFT.map((samples, g) => (
-        <path key={`ghl${g}`} d={path(samples, LEFT_ARM, 'up')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
-      ))}
-      {GHOSTS_RIGHT.map((samples, g) => (
-        <path key={`ghr${g}`} d={path(samples, RIGHT_ARM, 'down')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
-      ))}
-
-      {/* current reps — dark halo underlay, then tinted line. Ecc stays on-track silver;
-          con carries the device's LOCKED-rule tint. */}
-      {leftRuns.map((r) => (
-        <path key={`shl${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {rightRuns.map((r) => (
-        <path key={`shr${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {leftRuns.map((r) => (
-        <path key={`l${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {rightRuns.map((r) => (
-        <path key={`r${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-
-      <circle cx={x(normalizedU(leftPeak, LEFT_ARM))} cy={yUp(Math.abs(leftPeak.vel))} r={3.5} fill={leftColor} stroke={PANEL_BG} strokeWidth={1.5} />
-      <circle cx={x(normalizedU(rightPeak, RIGHT_ARM))} cy={yDown(Math.abs(rightPeak.vel))} r={3.5} fill={rightColor} stroke={PANEL_BG} strokeWidth={1.5} />
-
-      {/* device-identity labels — up/down now carries DEVICE, not phase. */}
-      <text x={padL} y={padTop - 9} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
-        LEFT ARM
-      </text>
-      <text x={padL} y={h - padBot + 15} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
-        RIGHT ARM
-      </text>
-    </svg>
-  )
-}
+// Shared magnitude scale across BOTH devices (current + ghosts) so the two blooms are
+// directly, honestly comparable.
+const ALL_SAMPLES = [...CURRENT.left, ...CURRENT.right, ...GHOSTS_LEFT.flat(), ...GHOSTS_RIGHT.flat()]
+const VMAX_MAG = Math.max(0.01, ...ALL_SAMPLES.map((s) => Math.abs(s.vel))) * 1.06
 
 // =================================================================================
-// OPTION B2 — TOP/BOTTOM MIRRORED, but the central axis WIDENS into a phase-colored
-// BAND. The band (a) makes phase timing the most legible element, (b) hosts the ECC/CON
-// labels INSIDE it — recovering the phase text the plain mirrored layout loses — and
-// (c) doubles as a gutter: both blooms are OFFSET off the band edges (a small gap) so the
-// two lines can never touch the axis or overlap each other. Same phase-normalized spine.
+// The mirrored dual — GhostBand + two GhostBlooms (top normal, bottom flipped), sharing
+// ONE band. This is the whole component: no bespoke dual machinery.
 // =================================================================================
-const BAND_H = 16
-const BAND_GAP = 4
 function MirroredDualBand({ w, h }: { w: number; h: number }) {
   const padL = 14
   const padR = 14
@@ -524,84 +302,32 @@ function MirroredDualBand({ w, h }: { w: number; h: number }) {
   const bandTop = mid - BAND_H / 2
   const bandBot = mid + BAND_H / 2
   // Bloom baselines are OFFSET off the band edges by BAND_GAP, so a zero-velocity moment
-  // (a pause) still sits clear of the band rather than kissing it.
+  // still sits clear of the band rather than kissing it.
   const baseUp = bandTop - BAND_GAP
   const baseDown = bandBot + BAND_GAP
   const upH = baseUp - padTop
   const downH = h - padBot - baseDown
   const x = (u: number) => padL + u * (w - padL - padR)
-  const yUp = (mag: number) => baseUp - clamp01(mag / VMAX_MAG) * upH
-  const yDown = (mag: number) => baseDown + clamp01(mag / VMAX_MAG) * downH
+  const magUp = (v: number) => clamp01(Math.abs(v) / VMAX_MAG) * upH
+  const magDown = (v: number) => clamp01(Math.abs(v) / VMAX_MAG) * downH
 
-  const leftCur = CURRENT.left
-  const rightCur = CURRENT.right
-  const leftColor = conTone(LEFT_ARM)
-  const rightColor = conTone(RIGHT_ARM)
+  const pts = (samples: Sample[], device: DeviceSpec, magFn: (v: number) => number): Pt[] =>
+    samples.map((s): Pt => [x(normalizedU(s, device)), magFn(s.vel)])
 
-  const path = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down') =>
-    smoothPath(samples.map((s) => [x(normalizedU(s, device)), dir === 'up' ? yUp(Math.abs(s.vel)) : yDown(Math.abs(s.vel))]))
-
-  const leftPeak = leftCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), leftCur[0])
-  const rightPeak = rightCur.reduce((acc, s) => (s.vel > acc.vel ? s : acc), rightCur[0])
-  const runsFor = (samples: Sample[], device: DeviceSpec, dir: 'up' | 'down', color: (phase: Phase) => string) =>
-    phaseRuns(samples).map((run, i) => ({ key: i, d: path(run.pts, device, dir), color: color(run.phase) }))
-  const leftRuns = runsFor(leftCur, LEFT_ARM, 'up', (phase) => (phase === 'con' ? leftColor : ON_TRACK))
-  const rightRuns = runsFor(rightCur, RIGHT_ARM, 'down', (phase) => (phase === 'con' ? rightColor : ON_TRACK))
+  const leftCur = pts(CURRENT.left, LEFT_ARM, magUp)
+  const rightCur = pts(CURRENT.right, RIGHT_ARM, magDown)
+  const leftGhosts = GHOSTS_LEFT.map((g) => pts(g, LEFT_ARM, magUp))
+  const rightGhosts = GHOSTS_RIGHT.map((g) => pts(g, RIGHT_ARM, magDown))
 
   return (
     <svg width={w} height={h}>
-      {/* the wide phase-colored central BAND — carries phase timing + ECC/CON labels,
-          and separates the two blooms. */}
-      {(Object.keys(TEMPLATE_BOUNDS) as Phase[]).map((phase) => {
-        const [b0, b1] = TEMPLATE_BOUNDS[phase]
-        const segW = Math.max(0, x(b1) - x(b0))
-        const label = phase === 'ecc' ? 'ECC' : phase === 'con' ? 'CON' : null
-        return (
-          <g key={phase}>
-            <rect x={x(b0)} y={bandTop} width={segW} height={BAND_H} fill={AXIS_TONE[phase]} />
-            {label && segW > 22 && (
-              <text
-                x={(x(b0) + x(b1)) / 2}
-                y={mid + 2.8}
-                textAnchor="middle"
-                fill={alpha(PARCH, 0.92)}
-                fontSize={8}
-                fontWeight={800}
-                letterSpacing={1.2}
-                fontFamily={FONT_UI}
-              >
-                {label}
-              </text>
-            )}
-          </g>
-        )
-      })}
+      {/* LEFT device blooms UP, RIGHT blooms DOWN — same GhostBloom, one prop flipped. */}
+      <GhostBloom current={leftCur} ghosts={leftGhosts} tint={conTone(LEFT_ARM)} baseline={baseUp} orientation="up" />
+      <GhostBloom current={rightCur} ghosts={rightGhosts} tint={conTone(RIGHT_ARM)} baseline={baseDown} orientation="down" />
+
+      {/* the single shared phase-colored band, on top — ECC/CON labelled inside. */}
+      <GhostBand segments={SHARED_SEGMENTS} x={x} top={bandTop} showLabels labelColor={alpha(PARCH, 0.92)} />
       <rect x={padL} y={bandTop} width={w - padL - padR} height={BAND_H} rx={4} fill="none" stroke={alpha('#000000', 0.3)} strokeWidth={1} />
-
-      {/* faded ghost fans, offset off the band, both directions. */}
-      {GHOSTS_LEFT.map((samples, g) => (
-        <path key={`ghl${g}`} d={path(samples, LEFT_ARM, 'up')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
-      ))}
-      {GHOSTS_RIGHT.map((samples, g) => (
-        <path key={`ghr${g}`} d={path(samples, RIGHT_ARM, 'down')} fill="none" stroke={alpha(PARCH, 0.1 + g * 0.02)} strokeWidth={1.5} strokeLinejoin="round" />
-      ))}
-
-      {/* current reps — halo underlay then tinted line. */}
-      {leftRuns.map((r) => (
-        <path key={`shl${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {rightRuns.map((r) => (
-        <path key={`shr${r.key}`} d={r.d} fill="none" stroke={alpha('#000000', 0.55)} strokeWidth={7} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {leftRuns.map((r) => (
-        <path key={`l${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-      {rightRuns.map((r) => (
-        <path key={`r${r.key}`} d={r.d} fill="none" stroke={r.color} strokeWidth={3.5} strokeLinejoin="round" strokeLinecap="round" />
-      ))}
-
-      <circle cx={x(normalizedU(leftPeak, LEFT_ARM))} cy={yUp(Math.abs(leftPeak.vel))} r={3.5} fill={leftColor} stroke={PANEL_BG} strokeWidth={1.5} />
-      <circle cx={x(normalizedU(rightPeak, RIGHT_ARM))} cy={yDown(Math.abs(rightPeak.vel))} r={3.5} fill={rightColor} stroke={PANEL_BG} strokeWidth={1.5} />
 
       <text x={padL} y={padTop - 9} fontSize={9} fontWeight={800} letterSpacing={1} fontFamily={FONT_UI} fill={C['text-tertiary']}>
         LEFT ARM
@@ -613,11 +339,7 @@ function MirroredDualBand({ w, h }: { w: number; h: number }) {
   )
 }
 
-// =================================================================================
-// Layout — the card mockups at a REALISTIC narrow card-column width (~330px; the
-// established `FatigueCard` width in the shipped specimen is 300–340px, ~1/4 of a
-// wide wall display), so Option A's cramping trade-off is honest, not idealized.
-// =================================================================================
+// --- Layout ----------------------------------------------------------------------
 const CARD_W = 332
 const CARD_PAD = 18
 
@@ -634,64 +356,13 @@ function DeviceLegendRow({ device }: { device: DeviceSpec }) {
   )
 }
 
-function OptionCardA() {
-  const innerW = CARD_W - CARD_PAD * 2
-  const gap = 8
-  const chartW = (innerW - gap) / 2
-  const chartH = 168
-  return (
-    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
-      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>OPTION A · SIDE BY SIDE</Text>
-      <View style={{ flexDirection: 'row', gap }}>
-        {DEVICES.map((d) => (
-          <View key={d.key} style={{ width: chartW, gap: 4 }}>
-            <DeviceLegendRow device={d} />
-            <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
-              <GhostSparkSolo device={d} w={chartW - 8} h={chartH} />
-            </View>
-          </View>
-        ))}
-      </View>
-      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
-        Each chart keeps its own full phase axis (ECC above · CON below) — legible per arm. Trade-off: at real card width, two
-        charts halve to ~{Math.round(chartW)}px each — peak markers and axis labels crowd the narrow column.
-      </Text>
-    </View>
-  )
-}
-
-function OptionCardB() {
+function DualGhostCard() {
   const innerW = CARD_W - CARD_PAD * 2
   const chartH = 232
   return (
     <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
       <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
-        OPTION B · TOP/BOTTOM MIRRORED
-      </Text>
-      <View style={{ flexDirection: 'row', gap: 14 }}>
-        <DeviceLegendRow device={LEFT_ARM} />
-        <DeviceLegendRow device={RIGHT_ARM} />
-      </View>
-      <View style={[{ borderRadius: 8, padding: 4 }, insetWell(primitiveColors.charcoal[900])]}>
-        <MirroredDual w={innerW - 8} h={chartH} />
-      </View>
-      <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
-        One shared spine reclaims full chart width per device (mirrored up/down) — no split-width penalty. Trade-off: phase can no
-        longer sit above/below (both halves are spent on device identity), so it rides axis-segment COLOR alone, no ECC/CON text;
-        and the spine is phase-normalized, so Right Arm&apos;s concentric genuinely running ~79% longer (1700ms vs 950ms) shows
-        only as line shape, not a wider axis segment.
-      </Text>
-    </View>
-  )
-}
-
-function OptionCardB2() {
-  const innerW = CARD_W - CARD_PAD * 2
-  const chartH = 232
-  return (
-    <View style={[{ width: CARD_W, borderRadius: 14, padding: CARD_PAD, gap: 10 }, paperSheet(PANEL_BG)]}>
-      <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
-        OPTION B2 · MIRRORED + AXIS BAND
+        DUAL · TOP/BOTTOM MIRRORED · GhostBand + 2×GhostBloom
       </Text>
       <View style={{ flexDirection: 'row', gap: 14 }}>
         <DeviceLegendRow device={LEFT_ARM} />
@@ -701,9 +372,10 @@ function OptionCardB2() {
         <MirroredDualBand w={innerW - 8} h={chartH} />
       </View>
       <Text style={{ fontSize: 10, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 14, fontStyle: 'italic' }}>
-        The axis widens into a phase-colored BAND — it carries the ECC/CON labels INSIDE it (recovering the phase text plain mirrored
-        loses) and doubles as a gutter: both blooms are offset off its edges, so the two lines never touch the axis or overlap. Phase
-        timing becomes the most legible element; each device reads as one clean stroke.
+        Two `GhostBloom`s sharing one `GhostBand` axis — the LEFT blooms up, the RIGHT is the same bloom with
+        `orientation=&quot;down&quot;`. No bespoke dual code: the paper line ground and the silver→red tint come straight from the
+        shared primitive, so any single-spark improvement lands here too. Left Arm stays silver; Right Arm warms through
+        shades of red as its concentric collapses.
       </Text>
     </View>
   )
@@ -721,31 +393,27 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj
 
-/** The head-to-head: same dual mock data (Left Arm on-tempo, Right Arm fatiguing/grinding),
- *  two candidate layouts, at realistic narrow card-column width. */
-export const SideBySideVsMirrored: Story = {
-  name: 'Side-by-side vs top/bottom mirrored',
+/** The resolved dual: top/bottom mirrored, composed on the shared GhostBand + GhostBloom
+ *  (the ghost analogue of the diverging VelocityStrip = two composed VelocityStrips). */
+export const MirroredDual: Story = {
+  name: 'Mirrored dual (GhostBand + 2×GhostBloom)',
   render: () => (
     <Page>
       <View style={{ gap: 6, maxWidth: 920 }}>
         <Text style={[{ fontSize: 9, letterSpacing: 1.4, fontFamily: FONT_MONO, color: C['text-tertiary'] }, debossLabel]}>
-          DUAL-VOLTRA GHOST-SPARK · LAYOUT DECISION
+          DUAL-VOLTRA GHOST-SPARK · COMPOSED ON SHARED PRIMITIVES
         </Text>
         <Text style={{ fontSize: 22, fontWeight: '900', fontFamily: FONT_HEAD, color: C['text-primary'] }}>
-          Two devices, one fatigue card — where does the second ghost-spark go?
+          One axis, two blooms — the dual is a flip of the single
         </Text>
         <Text style={{ fontSize: 13, fontFamily: FONT_UI, color: C['text-secondary'], lineHeight: 19 }}>
-          Same mock dual set both columns: Left Arm on-tempo (silver), Right Arm fatiguing — concentric drifting long and
-          sticking through a mid-rep collapse (grind signature crosses the red threshold). Both candidates apply the LOCKED
-          silver→red tint rule verbatim (tempo deviation dims the silver, grind signature warms it through shades of red).
-          Rendered at the established ~330px card-column width so the real trade-off — cramped detail vs. lost phase labels —
-          reads honestly, not idealized.
+          Mock dual set: Left Arm on-tempo (silver), Right Arm fatiguing — concentric drifting long and sticking through a
+          mid-rep collapse (grind signature crosses the red threshold). Built exactly like the single GhostSpark: a shared
+          `GhostBand` for phase + two `GhostBloom`s for the lines, the bottom one flipped `orientation=&quot;down&quot;`.
         </Text>
       </View>
       <View style={{ flexDirection: 'row', gap: 24, alignItems: 'flex-start', flexWrap: 'wrap' }}>
-        <OptionCardA />
-        <OptionCardB />
-        <OptionCardB2 />
+        <DualGhostCard />
       </View>
     </Page>
   ),


### PR DESCRIPTION
Operator design feedback on the rendered live fatigue card, as one pass over the same component family. Three tickets, one commit each.

### TD-07.06 — Drop the text strip under the ROM chart
Removed the two-`Text` row (`ROM · depth vs working range` / `now N%`) beneath the bars, and with it the now-dead `nowPct` computation and the imports it was the last consumer of. The chart already composed the shared `SetBarChart` (that alignment landed earlier); this is the text removal only.

### TD-07.07 — Contiguous, axis-aligned phase band
Three structural causes, all fixed:
- each run drew at `segW - 1` — a deliberate 1px inset per segment;
- each run carried its own `rx={2}`, rounding off internal boundaries;
- the sample-derived phase runs are **not time-contiguous** (one sample interval of seam between them), which the per-run rects rendered as background holes.

The band is now one silhouette: a rounded clip, an idle-toned floor spanning the rep, and square runs painted inside it, each butted against the **next run's start** so a seam cannot open. `PHASE_AXIS_COLOR.idle` moves charcoal[300] → [200] so a pause clears the surface ramp's own value range and reads as band material.

Adds `GhostBand.test.tsx` (contiguity is pure geometry — unit-testable) and a `PausedRepBand` story: the mock's pauses collapse to zero width, so nothing in Storybook exercised the idle tone.

### TD-07.08 — Correct surface + real paper treatment
The doc comment claimed a "paper-accent hero surface" that did not exist. The card sat on `Surface level="raised"` — a flat token near the top of the ramp, no paper — and read hot against the near-black frame.

Per the surface north-star's pairing matrix a card is parent+1, so on the `background` shell the live stage paints, the card belongs on **`base`** (`raised` skips a level). Separation moves onto the alpha `hairline-default` edge — the north-star's primary cue — instead of lightness. The paper claim is now true: the card composes the shared `barPaper` treatment (matte grain + top rim-light + contact shadow), the same material the ROM and velocity bars are made of.

The stories framed the card on a raw `charcoal[900]` hex that is not a plane in the shipped ramp, which is why brightness could not be judged; they now frame it on `Surface level="background"`.

### Verification
Rendered and inspected in Storybook (index confirmed fresh — the new story ID appeared before screenshotting). Band contiguity verified by pixel-sampling the strip: ECC ends at x=435, CON begins at x=436, single antialiased pixel, no gap.

Gates: `CI=true npx vitest run` 2767 passed / 141 files · `npx tsc --noEmit` clean · `npx eslint src` 0 errors (89 warnings, baseline).

Base branch is `agent/TD-07/TD-07.01`, not `main` — it carries the ghost-iteration port these files depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)