### PR TITLE
Fatigue card design pass: ROM text, band alignment, surface grounding

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { GhostBand, BAND_H } from './GhostBand'
+import { PHASE_AXIS_COLOR } from './fatigue-tokens'
+import type { PhaseSegment } from './fatigue-model'
+
+/** Phase runs with SEAMS between them — the shape the sample-derived model actually produces. */
+const segments: PhaseSegment[] = [
+  { phase: 'eccentric', startMs: 0, endMs: 1182 },
+  { phase: 'idle', startMs: 1273, endMs: 1600 },
+  { phase: 'concentric', startMs: 1691, endMs: 3545 },
+]
+
+const x = (ms: number) => 12 + (ms / 4000) * 300
+
+const band = (segs: PhaseSegment[] = segments) =>
+  render(
+    <svg>
+      <GhostBand segments={segs} x={x} top={0} height={BAND_H} />
+    </svg>
+  ).container
+
+const geom = (r: Element) => ({
+  x: Number(r.getAttribute('x')),
+  width: Number(r.getAttribute('width')),
+  fill: r.getAttribute('fill'),
+})
+
+/** The strip floor — the one rect sitting directly in the clipped group. */
+const floorOf = (c: HTMLElement) => geom(c.querySelector('g[clip-path] > rect')!)
+/** The phase runs — one rect per run, each in its own group. */
+const runsOf = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('g[clip-path] > g > rect')).map(geom)
+
+describe('GhostBand', () => {
+  it('draws a contiguous strip — each run butts against the next with no gap', () => {
+    const runs = runsOf(band())
+    runs.forEach((r, i) => {
+      const next = runs[i + 1]
+      if (next) expect(r.x + r.width).toBeCloseTo(next.x, 5)
+    })
+  })
+
+  it('floors the whole rep with the idle tone so a pause reads as band, not a hole', () => {
+    const floor = floorOf(band())
+    expect(floor.fill).toBe(PHASE_AXIS_COLOR.idle)
+    expect(floor.x).toBeCloseTo(x(0), 5)
+    expect(floor.x + floor.width).toBeCloseTo(x(3545), 5)
+  })
+
+  it('paints the pause run in the idle tone', () => {
+    const runs = runsOf(band())
+    expect(runs.map((r) => r.fill)).toEqual([
+      PHASE_AXIS_COLOR.eccentric,
+      PHASE_AXIS_COLOR.idle,
+      PHASE_AXIS_COLOR.concentric,
+    ])
+  })
+
+  it('renders nothing when every run is zero-width', () => {
+    const c = band([{ phase: 'idle', startMs: 500, endMs: 500 }])
+    expect(c.querySelectorAll('rect')).toHaveLength(0)
+  })
+
+  it('rounds the band once, as a clip — never per run', () => {
+    const c = band()
+    expect(c.querySelector('clipPath rect')?.getAttribute('rx')).toBe('2')
+    const runRects = Array.from(c.querySelectorAll('g[clip-path] > g > rect'))
+    expect(runRects.every((r) => r.getAttribute('rx') == null)).toBe(true)
+  })
+})

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -8,6 +8,7 @@
  * It is a pure SVG group: the caller owns the x-scale (`x`) and the band's vertical
  * placement (`top`), so the same band serves a bottom-pinned single or a centred dual.
  */
+import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FONT_UI, PHASE_AXIS_COLOR } from './fatigue-tokens'
 import type { PhaseSegment } from './fatigue-model'
@@ -34,7 +35,15 @@ export interface GhostBandProps {
   labelColor?: string
 }
 
-/** The phase-coloured axis band — one rounded rect per phase run, ECC/CON labelled inside. */
+/**
+ * The phase-coloured axis band — ONE contiguous strip whose internal boundaries land
+ * exactly on the sparkline's phase transitions.
+ *
+ * Contiguity is structural, not incidental: the band is a single rounded silhouette
+ * (clipped), floored with the idle tone across its whole time extent, and each phase run
+ * paints SQUARE inside that clip, extended to the next run's start. No per-segment inset
+ * and no per-segment rounding — those read as gaps between sections.
+ */
 export function GhostBand({
   segments,
   x,
@@ -43,40 +52,69 @@ export function GhostBand({
   showLabels = false,
   labelColor = t['text-primary'],
 }: GhostBandProps) {
+  const rawId = useId()
+  const clipId = `ghost-band-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+
+  const drawn = segments.filter((seg) => x(seg.endMs) - x(seg.startMs) > 0)
+  if (drawn.length === 0) return null
+
+  const bandLeft = x(drawn[0].startMs)
+  const bandRight = x(drawn[drawn.length - 1].endMs)
+  const bandW = bandRight - bandLeft
+  if (bandW <= 0) return null
+
   return (
-    <>
-      {segments.map((seg, i) => {
-        const segW = x(seg.endMs) - x(seg.startMs)
-        if (segW <= 0) return null
-        const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
-        return (
-          <g key={i}>
-            <rect
-              x={x(seg.startMs)}
-              y={top}
-              width={Math.max(0, segW - 1)}
-              height={height}
-              rx={2}
-              fill={PHASE_AXIS_COLOR[seg.phase]}
-            />
-            {showLabels && label && segW > 20 && (
-              <text
-                x={(x(seg.startMs) + x(seg.endMs)) / 2}
-                y={top + height / 2}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={labelColor}
-                fontSize={8}
-                fontWeight={800}
-                letterSpacing={1}
-                fontFamily={FONT_UI}
-              >
-                {label}
-              </text>
-            )}
-          </g>
-        )
-      })}
-    </>
+    <g>
+      <defs>
+        <clipPath id={clipId}>
+          <rect x={bandLeft} y={top} width={bandW} height={height} rx={2} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>
+        {/* the strip floor — the idle tone spans the rep so a pause is band, not a hole. */}
+        <rect
+          x={bandLeft}
+          y={top}
+          width={bandW}
+          height={height}
+          fill={PHASE_AXIS_COLOR.idle}
+          data-testid="ghost-band-floor"
+        />
+        {drawn.map((seg, i) => {
+          const left = x(seg.startMs)
+          // Butt each run against the next run's start (not its own end) so rounding
+          // between the two can never open a seam; the last run runs to the band edge.
+          const right = i === drawn.length - 1 ? bandRight : x(drawn[i + 1].startMs)
+          const segW = Math.max(0, right - left)
+          const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
+          return (
+            <g key={i}>
+              <rect
+                x={left}
+                y={top}
+                width={segW}
+                height={height}
+                fill={PHASE_AXIS_COLOR[seg.phase]}
+              />
+              {showLabels && label && segW > 20 && (
+                <text
+                  x={left + segW / 2}
+                  y={top + height / 2}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fill={labelColor}
+                  fontSize={8}
+                  fontWeight={800}
+                  letterSpacing={1}
+                  fontFamily={FONT_UI}
+                >
+                  {label}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </g>
+    </g>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -7,6 +7,7 @@ import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FATIGUE_STATES } from './fatigue-mock'
+import type { PhaseSegment } from './fatigue-model'
 
 const PANEL_BG = primitiveColors.charcoal[800]
 const PAGE_BG = primitiveColors.charcoal[900]
@@ -150,4 +151,36 @@ export const LineTreatmentSoft: Story = {
       <TreatmentDemo treatment="soft" />
     </View>
   ),
+}
+
+/**
+ * A rep with REAL pauses (the sample-derived mock collapses its pauses to zero width, so
+ * the idle tone never shows there). Segments are handed in with SEAMS between the runs —
+ * the shape the model actually produces — to prove the band closes them: one contiguous
+ * strip, boundaries on the phase transitions, the pause reading as band material.
+ */
+const PAUSED_SEGMENTS: PhaseSegment[] = [
+  { phase: 'eccentric', startMs: 0, endMs: 2100 },
+  { phase: 'idle', startMs: 2190, endMs: 2900 },
+  { phase: 'concentric', startMs: 2990, endMs: 4050 },
+  { phase: 'idle', startMs: 4140, endMs: 4600 },
+]
+
+export const PausedRepBand: Story = {
+  render: () => {
+    const w = 360
+    const h = 60
+    const bandTop = 22
+    const x = (ms: number) => 12 + (ms / 4800) * (w - 20)
+    return (
+      <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
+        {label('PHASE BAND · REP WITH REAL PAUSES (bottom hold + top hold)')}
+        <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+          <svg width={w} height={h}>
+            <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels />
+          </svg>
+        </View>
+      </View>
+    )
+  },
 }

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { LiveFatigueCard } from './LiveFatigueCard'
-import { primitiveColors } from '../../../theme/tokens/primitives'
+import { Surface } from '../../ui/surface/Surface'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { FATIGUE_STATES, WARMING_UP_MODEL } from './fatigue-mock'
 
-const PAGE_BG = primitiveColors.charcoal[900]
 const t = getSemanticColors('dark')
 
 const meta: Meta<typeof LiveFatigueCard> = {
@@ -18,7 +17,10 @@ const meta: Meta<typeof LiveFatigueCard> = {
         component:
           'The vertical live fatigue card — consumes one `LiveFatigueModel`. Composes `VerdictHero` ' +
           '(RPE + verdict word) · `FatigueLights` (VEL/ROM/TEMPO dots) · `RomProgressionChart` · ' +
-          '`GhostSpark` (tempo embedded), grounded on a `Surface` raised plane.',
+          '`GhostSpark` (tempo embedded). Grounded on the `Surface` **base** plane — one step ' +
+          'above the `background` shell the live stage paints — separated by the alpha ' +
+          '`hairline-default` edge and finished with the shared **paper** accent (matte grain + ' +
+          'top rim-light + contact shadow), the hero-surface treatment from the surface north-star.',
       },
     },
   },
@@ -29,10 +31,11 @@ const meta: Meta<typeof LiveFatigueCard> = {
 export default meta
 type Story = StoryObj<typeof LiveFatigueCard>
 
+/** The live stage the card actually sits on — the `background` shell plane, not a raw hex. */
 const Frame = ({ children }: { children: React.ReactNode }) => (
-  <View style={{ backgroundColor: PAGE_BG, padding: 28, alignItems: 'flex-start' }}>
+  <Surface level="background" style={{ padding: 28, alignItems: 'flex-start' }}>
     {children}
-  </View>
+  </Surface>
 )
 
 /** The default (form breaking down) card. */
@@ -48,9 +51,9 @@ export const Default: Story = {
 /** The four verdict states side by side — the whole spectrum. */
 export const States: Story = {
   render: () => (
-    <View
+    <Surface
+      level="background"
       style={{
-        backgroundColor: PAGE_BG,
         padding: 28,
         flexDirection: 'row',
         gap: 20,
@@ -72,7 +75,7 @@ export const States: Story = {
           <LiveFatigueCard model={s.model} width={300} height={500} />
         </View>
       ))}
-    </View>
+    </Surface>
   ),
 }
 

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
@@ -5,13 +5,22 @@
  * (tempo embedded), the last two spread through the leftover height. Consumes ONE
  * {@link LiveFatigueModel}.
  *
- * The card grounds on a {@link Surface} `raised` plane (the paper-accent hero surface)
- * — it never hardcodes a surface hex, so it inherits the surface-ramp / paper-accent
- * refresh when that ships.
+ * SURFACE (TD-07.08). The card grounds on the `base` plane — ONE step above the
+ * `background` shell the live stage paints, per the surface north-star's pairing matrix
+ * (a card is parent+1; `raised`/`overlay` skip levels and read hot against the near-black
+ * frame). Separation is carried by the alpha `hairline-default` edge, not by lightness —
+ * the north-star's primary cue, self-normalising on any plane.
+ *
+ * PAPER. The live card is one of the designated hero surfaces, so it takes the paper
+ * accent DELIBERATELY: the shared {@link barPaper} treatment (brightness-scaled matte
+ * grain + crisp top rim-light + soft contact shadow) — the same material the ROM /
+ * velocity bars are made of, now carrying the sheet they sit on. Token-sourced fill, no
+ * hardcoded surface hex.
  */
 import { View } from 'react-native'
 import { Surface } from '../../ui/surface/Surface'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { barPaper } from '../../../theme/bar-paper'
 import { VerdictHero } from './VerdictHero'
 import { FatigueLights } from './FatigueLights'
 import { RomProgressionChart } from './RomProgressionChart'
@@ -37,7 +46,7 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
   const chartH = height != null ? Math.round(Math.min(240, Math.max(168, height * 0.4))) : 172
   return (
     <Surface
-      level="raised"
+      level="base"
       testID="live-fatigue-card"
       style={{
         width,
@@ -45,7 +54,8 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
         borderRadius: 14,
         padding: PAD,
         borderWidth: 1,
-        borderColor: t['border-default'],
+        borderColor: t['hairline-default'],
+        ...barPaper(t['surface-base']),
       }}
     >
       {/* top group — verdict hero + the three why-lights, tight together. */}

--- a/packages/ui/src/components/custom/Fatigue/README.md
+++ b/packages/ui/src/components/custom/Fatigue/README.md
@@ -21,7 +21,7 @@ LiveFatiguePanel              ← the composition (Live panel v2)
    │  └─ Tooltip              (ui/tooltip — hover detail)
    ├─ RomProgressionChart     (per-rep silver/red depth bars + reference lines)
    ├─ GhostSpark              (per-rep velocity-time sparkline; tempo EMBEDDED)
-   └─ Surface                 (ui/surface — the raised/paper-accent card ground)
+   └─ Surface                 (ui/surface — the base-plane, paper-accented card ground)
 ```
 
 ## Tier map
@@ -38,8 +38,9 @@ LiveFatiguePanel              ← the composition (Live panel v2)
 - **`VelocityStrip`** (Workout/) — the hero reuses it verbatim; `VelocityHero` only adds
   the loss-relative VL20/VL30 band overlay on the strip's own peak scale.
 - **`LiveAuraFrame`** (Workout/) — the coaching flood.
-- **`Surface`** (ui/surface/) — the card ground (`level="raised"`); no hardcoded surface
-  hex, so the family inherits the surface-ramp / paper-accent refresh when it lands.
+- **`Surface`** (ui/surface/) — the card ground (`level="base"`, one step above the
+  `background` shell), separated by the alpha `hairline-default` edge and finished with
+  the shared `barPaper` accent; no hardcoded surface hex.
 - **Tokens** — colours come from `getSemanticColors` / `primitiveRamps`; formatting from
   `roundTempo`. No literal surface/status hex constants.
 

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof RomProgressionChart> = {
         component:
           'Per-rep depth bars (silver at/above working → light red below working range → deep red below the short threshold), ' +
           'with dashed working-standard + short-threshold reference lines and a faint red short-zone. ' +
-          'Data-driven from absolute metres; labelled "depth vs working range · now N%". ' +
+          'Data-driven from absolute metres; the bars carry the read alone (no caption strip). ' +
           'Composes the shared **SetBarChart** — same adaptive bar spacing as the velocity hero, and an optional ' +
           '`plannedReps` draws the remaining reps as dashed to-do placeholders (the "N of M done" read).',
       },

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.test.tsx
@@ -11,21 +11,10 @@ const points: RepRomPoint[] = [
 ]
 
 describe('RomProgressionChart', () => {
-  it('renders the caption', () => {
+  it('renders no caption strip — the bars carry the read alone', () => {
     render(<RomProgressionChart points={points} workingStandardM={0.88} shortThresholdM={0.66} />)
-    expect(screen.getByText('ROM · depth vs working range')).toBeInTheDocument()
-  })
-
-  it('computes now% against the working standard', () => {
-    render(<RomProgressionChart points={points} workingStandardM={0.9} shortThresholdM={0.675} />)
-    // current rom 0.72 / working 0.9 = 80%
-    expect(screen.getByText('now 80%')).toBeInTheDocument()
-  })
-
-  it('falls back to the tallest bar when no working standard is established', () => {
-    render(<RomProgressionChart points={points} workingStandardM={null} shortThresholdM={null} />)
-    // current rom 0.72 / max 0.9 = 80%
-    expect(screen.getByText('now 80%')).toBeInTheDocument()
+    expect(screen.queryByText(/depth vs working range/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^now /)).not.toBeInTheDocument()
   })
 
   it('renders the chart container', () => {

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
@@ -4,7 +4,7 @@
  * silver bars at-or-above the working range, light red below it, deep red below the
  * short threshold — with dashed working-standard (silver) + short-threshold (red)
  * reference lines and a faint red short-zone. Every rep reads at full colour.
- * Labelled "depth vs working range · now N%".
+ * The bars carry the whole read — no caption strip (the card's own hierarchy names it).
  *
  * Composes the shared {@link SetBarChart}: SetBarChart owns the geometry (value→height
  * scaling, the plot-width-driven adaptive bar width / gap — the same rhythm as the velocity
@@ -14,14 +14,11 @@
  * reference lines always sit on-chart; when no working standard is established yet (< 3 reps)
  * the lines drop and every bar reads silver — the bars alone carry the shape.
  */
-import { View, Text } from 'react-native'
-import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { View } from 'react-native'
 import { alpha } from '../../../utils/colors'
 import { SetBarChart, type SetSlot, type SetBarGeometry } from '../charts/SetBarChart'
-import { FONT_MONO, SILVER, RED_LIGHT, RED_DEEP } from './fatigue-tokens'
+import { SILVER, RED_LIGHT, RED_DEEP } from './fatigue-tokens'
 import type { RepRomPoint } from './fatigue-model'
-
-const t = getSemanticColors('dark')
 
 export interface RomProgressionChartProps {
   /** Per-rep ROM points (metres), ordered by rep. */
@@ -30,7 +27,7 @@ export interface RomProgressionChartProps {
   workingStandardM: number | null
   /** Short threshold (metres) — the red dashed line + short-zone. `null` = not yet established. */
   shortThresholdM: number | null
-  /** Height of the bar plot in px (the caption row sits below it). Default 44. */
+  /** Height of the bar plot in px. Default 44. */
   barHeight?: number
   /** Keep the chart to a legible recent tail. Default 12. */
   maxReps?: number
@@ -110,13 +107,6 @@ export function RomProgressionChart({
   plannedReps,
 }: RomProgressionChartProps) {
   const shown = points.slice(-maxReps)
-  const lastIndex = shown.length - 1
-  const current = shown[lastIndex]?.romM ?? 0
-  const nowPct =
-    workingStandardM != null
-      ? Math.round((current / workingStandardM) * 100)
-      : Math.round((current / Math.max(0.01, ...shown.map((p) => p.romM))) * 100)
-
   const slots: SetSlot[] = shown.map((p) => ({ kind: 'rep', value: p.romM }))
   // Scale to the tallest of {bars, working, short} so the reference lines always sit on-chart
   // (SetBarChart's own peak scale reads only the bar values). `0` → let SetBarChart use peak.
@@ -124,7 +114,7 @@ export function RomProgressionChart({
     Math.max(...shown.map((p) => p.romM), workingStandardM ?? 0, shortThresholdM ?? 0) || undefined
 
   return (
-    <View style={{ gap: 5 }} testID="rom-progression">
+    <View testID="rom-progression">
       <SetBarChart
         slots={slots}
         colorFor={(romM) => barColor(romM, workingStandardM, shortThresholdM)}
@@ -137,14 +127,6 @@ export function RomProgressionChart({
         renderReference={(g) => romReferenceOverlay(g, workingStandardM, shortThresholdM)}
         testIDPrefix="rom"
       />
-      <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-        <Text style={{ fontSize: 9, color: t['text-tertiary'], fontFamily: FONT_MONO }}>
-          ROM · depth vs working range
-        </Text>
-        <Text style={{ fontSize: 9, color: t['text-tertiary'], fontFamily: FONT_MONO }}>
-          now {nowPct}%
-        </Text>
-      </View>
     </View>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -32,11 +32,17 @@ export const STATE_LABEL: Record<FatigueVerdictState, string> = {
 /**
  * The phase-identity colours for the ghost-spark phase BAND — the TempoDisplay
  * language: eccentric magenta, concentric cyan, idle (pause/hold) a muted grey.
+ *
+ * The idle grey has to read as BAND MATERIAL (a pause the lifter held), not as a
+ * hole in the strip: at charcoal[300] it sat inside the surface-ramp's own value
+ * range (`surface-raised` #31302F) so a short pause between ECC and CON read as a
+ * gap. charcoal[200] clears every content plane while staying quieter than the two
+ * saturated phase tones, so the band reads contiguous and the phases still lead.
  */
 export const PHASE_AXIS_COLOR: Record<SamplePhase, string> = {
   eccentric: primitiveRamps.magenta[800],
   concentric: primitiveRamps.cyan[800],
-  idle: primitiveColors.charcoal[300],
+  idle: primitiveColors.charcoal[200],
 }
 
 /** Mini-tempo digit colours `[ecc, pauseBottom, con, pauseTop]` — ecc magenta / con cyan / pauses grey. */


### PR DESCRIPTION
Operator design review on the rendered card. Three fixes, one per commit.

1. **Drop the ROM caption strip** (TD-07.06) — the `ROM · depth vs working range` / `now N%` row is removed, and `nowPct`'s computation with it. The chart already composed the shared `SetBarChart` (sizing, spacing, to-do treatment), so only the text needed removing.

2. **Contiguous, axis-aligned phase band** (TD-07.07) — removed the per-segment `segW - 1` inset and made pause segments visually coherent with the band. Previously a short pause between ECC and CON read as an empty gap twice over. New `GhostBand.test.tsx` plus a dedicated real-pauses story.

3. **Ground the card correctly** (TD-07.08) — `raised` → `base` per the surface north-star's parent+1 pairing rule (`raised`/`overlay` skip levels and read hot against the near-black frame — the brightness the operator flagged). Border moved to the alpha `hairline-default` so separation comes from alpha, not lightness. `barPaper` now actually applied; the previous doc comment claimed a paper accent that was never implemented.

Replaces #135, which was stacked on #133 and orphaned when that squash-merged. Same three commits, rebuilt on main.

Gates: 2767 tests, tsc clean, eslint 0 errors (89 warnings = main baseline). Screenshots reviewed by the operator.