### PR TITLE
Add DualGhostSpark (one band, two mirrored blooms)

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { View, Text } from 'react-native'
+import { DualGhostSpark } from './DualGhostSpark'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { buildMockModel } from './fatigue-mock'
+import type { RepVelocityCurve } from './fatigue-model'
+
+const PANEL_BG = primitiveColors.charcoal[800]
+const PAGE_BG = primitiveColors.charcoal[900]
+const t = getSemanticColors('dark')
+
+const meta: Meta<typeof DualGhostSpark> = {
+  title: 'Workout/Fatigue/Dual Ghost Spark',
+  component: DualGhostSpark,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Dual-Voltra ghost sparkline: ONE shared phase-coloured band with two mirrored blooms — the ' +
+          'LEFT device grows UP, the RIGHT device is the SAME bloom flipped `orientation="down"`. Both ' +
+          'wings share one time scale and one magnitude scale, so an L/R imbalance reads as bloom size ' +
+          'rather than as two independently normalized charts.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof DualGhostSpark>
+
+const CURVES = buildMockModel(5).velocityCurves
+
+/** A weaker device: the same reps at a fraction of the velocity (the imbalance under test). */
+function weaken(curves: RepVelocityCurve[], factor: number): RepVelocityCurve[] {
+  return curves.map((c) => ({
+    ...c,
+    samples: c.samples.map((s) => ({ ...s, velocityMps: s.velocityMps * factor })),
+  }))
+}
+
+/** A device still mid-rep: its current rep's stream is cut short. */
+function lagging(curves: RepVelocityCurve[], fraction: number): RepVelocityCurve[] {
+  const cur = curves[curves.length - 1]
+  const keep = Math.max(2, Math.round(cur.samples.length * fraction))
+  const samples = cur.samples.slice(0, keep)
+  const endMs = samples[samples.length - 1].tMs
+  return [
+    ...curves.slice(0, -1),
+    {
+      ...cur,
+      samples,
+      phaseSegments: cur.phaseSegments
+        .filter((s) => s.startMs < endMs)
+        .map((s) => ({ ...s, endMs: Math.min(s.endMs, endMs) })),
+    },
+  ]
+}
+
+const label = (s: string) => (
+  <Text
+    style={{ fontSize: 9, letterSpacing: 1, fontFamily: 'monospace', color: t['text-tertiary'] }}
+  >
+    {s}
+  </Text>
+)
+
+const panel = (caption: string, child: React.ReactNode) => (
+  <View style={{ gap: 8, alignItems: 'flex-start' }}>
+    {label(caption)}
+    <View style={{ width: 400, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+      {child}
+    </View>
+  </View>
+)
+
+const page = (children: React.ReactNode) => (
+  <View
+    style={{
+      backgroundColor: PAGE_BG,
+      padding: 28,
+      gap: 24,
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      alignItems: 'flex-start',
+    }}
+  >
+    {children}
+  </View>
+)
+
+/** Both devices moving the same load the same way — the blooms mirror each other. */
+export const Symmetric: Story = {
+  render: () =>
+    page(
+      panel(
+        'SYMMETRIC · MATCHED DEVICES',
+        <DualGhostSpark left={CURVES} right={CURVES} width={360} height={232} />
+      )
+    ),
+}
+
+/** A real imbalance: the right device runs ~55% of the left's velocity. Because both wings
+ *  share ONE magnitude scale, the lower bloom is visibly smaller instead of re-normalizing. */
+export const AsymmetricLeftRight: Story = {
+  render: () =>
+    page(
+      panel(
+        'ASYMMETRIC · RIGHT AT ~55% VELOCITY',
+        <DualGhostSpark
+          left={CURVES}
+          right={weaken(CURVES, 0.55)}
+          width={360}
+          height={232}
+          leftLabel="LEFT ARM"
+          rightLabel="RIGHT ARM"
+        />
+      )
+    ),
+}
+
+/** One side lagging: the right device is still mid-rep, so its line stops short of the
+ *  left's and the band goes idle where the two devices no longer share a phase. */
+export const OneSideLagging: Story = {
+  render: () =>
+    page(
+      panel(
+        'LAGGING · RIGHT STILL MID-REP',
+        <DualGhostSpark left={CURVES} right={lagging(CURVES, 0.6)} width={360} height={232} />
+      )
+    ),
+}
+
+/** No data on either device — a reserved empty box, no axis furniture. */
+export const Empty: Story = {
+  render: () =>
+    page(
+      <>
+        {panel(
+          'EMPTY · NO REPS ON EITHER DEVICE',
+          <DualGhostSpark left={[]} right={[]} width={360} height={232} />
+        )}
+        {panel(
+          'SINGLE-SIDED · ONLY THE LEFT DEVICE BOUND',
+          <DualGhostSpark left={CURVES} right={[]} width={360} height={232} />
+        )}
+      </>
+    ),
+}

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
@@ -4,6 +4,7 @@ import { DualGhostSpark } from './DualGhostSpark'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { buildMockModel } from './fatigue-mock'
+import { GRIND_THRESHOLD } from './fatigue-tokens'
 import type { RepVelocityCurve } from './fatigue-model'
 
 const PANEL_BG = primitiveColors.charcoal[800]
@@ -21,7 +22,9 @@ const meta: Meta<typeof DualGhostSpark> = {
           'Dual-Voltra ghost sparkline: ONE shared phase-coloured band with two mirrored blooms — the ' +
           'LEFT device grows UP, the RIGHT device is the SAME bloom flipped `orientation="down"`. Both ' +
           'wings share one time scale and one magnitude scale, so an L/R imbalance reads as bloom size ' +
-          'rather than as two independently normalized charts.',
+          'rather than as two independently normalized charts. Each wing is tinted INDEPENDENTLY by its ' +
+          'own current rep — silver while the rep stays controlled, warming through shades of red once ' +
+          'that side crosses the grind threshold — so one arm can go red while the other stays silver.',
       },
     },
   },
@@ -29,9 +32,43 @@ const meta: Meta<typeof DualGhostSpark> = {
 export default meta
 type Story = StoryObj<typeof DualGhostSpark>
 
-const CURVES = buildMockModel(5).velocityCurves
+/**
+ * The HEALTHY baseline both stories start from: an early, controlled, on-tempo stretch of
+ * the mock set (through rep 3), whose current rep sits well under `GRIND_THRESHOLD` and so
+ * tints SILVER. The deep end of the mock set is already grinding, so starting there would
+ * paint every story red regardless of what the story is trying to say.
+ */
+const HEALTHY = buildMockModel(2).velocityCurves
 
-/** A weaker device: the same reps at a fraction of the velocity (the imbalance under test). */
+/**
+ * A device that is GRINDING: its concentric collapses AND its grind signature crosses
+ * `GRIND_THRESHOLD` — the signal `ghostLineColor` reads to warm the line silver → red.
+ * Magnitude and tint move together because on the wall they have ONE cause: the rep is
+ * failing. Degradation ramps across the set so the ghost fan shows the side fading, and
+ * the current rep carries the full `grind`.
+ *
+ * @param grind the current rep's grindSignature. Below {@link GRIND_THRESHOLD} (0.35) the
+ *   line stays silver; 1 is a full collapse and the deepest red.
+ */
+function grinding(curves: RepVelocityCurve[], grind: number): RepVelocityCurve[] {
+  const last = Math.max(1, curves.length - 1)
+  return curves.map((c, i) => {
+    const g = grind * (i / last)
+    return {
+      ...c,
+      // Only the concentric slows — a grind is a failure to move the load, not a slow lower.
+      samples: c.samples.map((s) => ({
+        ...s,
+        velocityMps: s.phase === 'concentric' ? s.velocityMps * (1 - 0.6 * g) : s.velocityMps,
+      })),
+      grindSignature: Math.max(c.grindSignature, g),
+      tempoDeviation: Math.max(c.tempoDeviation ?? 0, g),
+    }
+  })
+}
+
+/** A weaker but still CONTROLLED device: the same reps at a fraction of the velocity —
+ *  a strength imbalance, not a collapse, so the tint signals stay untouched and silver. */
 function weaken(curves: RepVelocityCurve[], factor: number): RepVelocityCurve[] {
   return curves.map((c) => ({
     ...c,
@@ -89,27 +126,50 @@ const page = (children: React.ReactNode) => (
   </View>
 )
 
-/** Both devices moving the same load the same way — the blooms mirror each other. */
+/** Both devices moving the same load the same way, both still in control — the blooms
+ *  mirror each other and BOTH wings read silver. This is the healthy baseline. */
 export const Symmetric: Story = {
   render: () =>
     page(
       panel(
-        'SYMMETRIC · MATCHED DEVICES',
-        <DualGhostSpark left={CURVES} right={CURVES} width={360} height={232} />
+        'SYMMETRIC · MATCHED DEVICES · BOTH SILVER',
+        <DualGhostSpark left={HEALTHY} right={HEALTHY} width={360} height={232} />
       )
     ),
 }
 
-/** A real imbalance: the right device runs ~55% of the left's velocity. Because both wings
- *  share ONE magnitude scale, the lower bloom is visibly smaller instead of re-normalizing. */
+/** The money shot: the LEFT arm holds its rep and stays SILVER while the RIGHT arm's
+ *  concentric collapses — it crosses the grind threshold, so its wing warms into RED and,
+ *  because both wings share ONE magnitude scale, shrinks at the same time. */
 export const AsymmetricLeftRight: Story = {
   render: () =>
     page(
       panel(
-        'ASYMMETRIC · RIGHT AT ~55% VELOCITY',
+        'ASYMMETRIC · LEFT SILVER · RIGHT GRINDING RED',
         <DualGhostSpark
-          left={CURVES}
-          right={weaken(CURVES, 0.55)}
+          left={HEALTHY}
+          right={grinding(HEALTHY, 0.85)}
+          width={360}
+          height={232}
+          leftLabel="LEFT ARM"
+          rightLabel="RIGHT ARM"
+        />
+      )
+    ),
+}
+
+/** A strength imbalance with control intact: the right device only reaches ~55% of the
+ *  left's velocity, so its bloom is visibly smaller — but nothing is FAILING, so both
+ *  wings stay silver. The contrast with {@link AsymmetricLeftRight} is the point: bloom
+ *  size reads output, tint reads control, and they are independent readouts. */
+export const AsymmetricControlled: Story = {
+  render: () =>
+    page(
+      panel(
+        'ASYMMETRIC · RIGHT AT ~55% VELOCITY · BOTH STILL SILVER',
+        <DualGhostSpark
+          left={HEALTHY}
+          right={weaken(HEALTHY, 0.55)}
           width={360}
           height={232}
           leftLabel="LEFT ARM"
@@ -120,14 +180,42 @@ export const AsymmetricLeftRight: Story = {
 }
 
 /** One side lagging: the right device is still mid-rep, so its line stops short of the
- *  left's and the band goes idle where the two devices no longer share a phase. */
+ *  left's and the band goes idle where the two devices no longer share a phase. Both sides
+ *  are CONTROLLED, so both read silver — the only difference here is temporal. */
 export const OneSideLagging: Story = {
   render: () =>
     page(
       panel(
-        'LAGGING · RIGHT STILL MID-REP',
-        <DualGhostSpark left={CURVES} right={lagging(CURVES, 0.6)} width={360} height={232} />
+        'LAGGING · RIGHT STILL MID-REP · BOTH CONTROLLED',
+        <DualGhostSpark left={HEALTHY} right={lagging(HEALTHY, 0.6)} width={360} height={232} />
       )
+    ),
+}
+
+/** The tint ramp itself, one panel per step: the LEFT arm is held healthy as a silver
+ *  reference while the RIGHT arm's grind signature is walked from controlled up to a full
+ *  collapse. The first two steps sit BELOW `GRIND_THRESHOLD` and stay silver (dimming a
+ *  touch as tempo drifts); every step at or above it is a shade of red. */
+export const TintRange: Story = {
+  render: () =>
+    page(
+      <>
+        {[0, 0.2, GRIND_THRESHOLD, 0.55, 0.8, 1].map((grind) => (
+          <View key={grind}>
+            {panel(
+              `RIGHT GRIND ${grind.toFixed(2)} · ${grind < GRIND_THRESHOLD ? 'CONTROLLED · SILVER' : 'GRINDING · RED'}`,
+              <DualGhostSpark
+                left={HEALTHY}
+                right={grinding(HEALTHY, grind)}
+                width={360}
+                height={232}
+                leftLabel="LEFT · HEALTHY"
+                rightLabel={`RIGHT · GRIND ${grind.toFixed(2)}`}
+              />
+            )}
+          </View>
+        ))}
+      </>
     ),
 }
 
@@ -142,7 +230,7 @@ export const Empty: Story = {
         )}
         {panel(
           'SINGLE-SIDED · ONLY THE LEFT DEVICE BOUND',
-          <DualGhostSpark left={CURVES} right={[]} width={360} height={232} />
+          <DualGhostSpark left={HEALTHY} right={[]} width={360} height={232} />
         )}
       </>
     ),

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.test.tsx
@@ -82,6 +82,15 @@ describe('DualGhostSpark', () => {
     expect(xMax(wingLine(container, 'right'))).toBeLessThan(xMax(wingLine(container, 'left')) * 0.7)
   })
 
+  it('draws no band furniture past the end of the phase runs', () => {
+    const { container } = renderDual(CURVES, CURVES)
+    const right = (r: Element) =>
+      Number(r.getAttribute('x') ?? 0) + Number(r.getAttribute('width') ?? 0)
+    const floor = container.querySelector('[data-testid="ghost-band-floor"]')!
+    const rects = Array.from(container.querySelectorAll('rect'))
+    expect(Math.max(...rects.map(right))).toBeCloseTo(right(floor), 1)
+  })
+
   it('renders an empty box when neither device has reps', () => {
     const { container } = renderDual([], [])
     expect(screen.getByTestId('dual-ghost-spark')).toBeInTheDocument()

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DualGhostSpark, mergePhaseSegments } from './DualGhostSpark'
+import { buildMockModel } from './fatigue-mock'
+import type { PhaseSegment, RepVelocityCurve } from './fatigue-model'
+
+const CURVES = buildMockModel(5).velocityCurves
+
+function scaled(curves: RepVelocityCurve[], factor: number): RepVelocityCurve[] {
+  return curves.map((c) => ({
+    ...c,
+    samples: c.samples.map((s) => ({ ...s, velocityMps: s.velocityMps * factor })),
+  }))
+}
+
+/** On-curve points of a smoothPath `d`: the `M` point then each cubic's endpoint. */
+function anchors(d: string): Array<[number, number]> {
+  const nums = (d.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number)
+  const pairs: Array<[number, number]> = []
+  for (let i = 0; i + 1 < nums.length; i += 2) pairs.push([nums[i], nums[i + 1]])
+  return pairs.filter((_, i) => i === 0 || i % 3 === 0)
+}
+
+/** The current (tinted) line of one wing — the last path drawn in its group. */
+function wingLine(container: HTMLElement, side: 'left' | 'right'): Array<[number, number]> {
+  const paths = container.querySelectorAll(`[data-testid="dual-ghost-bloom-${side}"] path`)
+  const d = paths[paths.length - 1].getAttribute('d') ?? ''
+  return anchors(d)
+}
+
+const ySpan = (pts: Array<[number, number]>) =>
+  Math.max(...pts.map((p) => p[1])) - Math.min(...pts.map((p) => p[1]))
+const xMax = (pts: Array<[number, number]>) => Math.max(...pts.map((p) => p[0]))
+
+function renderDual(left: RepVelocityCurve[], right: RepVelocityCurve[]) {
+  return render(<DualGhostSpark left={left} right={right} width={360} height={232} />)
+}
+
+describe('DualGhostSpark', () => {
+  it('renders both device blooms for a populated dual set', () => {
+    const { container } = renderDual(CURVES, CURVES)
+    expect(screen.getByTestId('dual-ghost-spark')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="dual-ghost-bloom-left"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="dual-ghost-bloom-right"]')).toBeInTheDocument()
+  })
+
+  it('draws exactly ONE shared band for the two blooms', () => {
+    const { container } = renderDual(CURVES, CURVES)
+    expect(container.querySelectorAll('[data-testid="ghost-band-floor"]')).toHaveLength(1)
+    expect(screen.getByText('ECC')).toBeInTheDocument()
+    expect(screen.getByText('CON')).toBeInTheDocument()
+  })
+
+  it('mirrors the wings: the left bloom stays above the band, the right below', () => {
+    const { container } = renderDual(CURVES, CURVES)
+    const l = wingLine(container, 'left')
+    const r = wingLine(container, 'right')
+    expect(Math.max(...l.map((p) => p[1]))).toBeLessThan(Math.min(...r.map((p) => p[1])))
+    // Each wing starts at zero velocity ON its baseline and grows away from the band.
+    expect(l[0][1]).toBe(Math.max(...l.map((p) => p[1])))
+    expect(r[0][1]).toBe(Math.min(...r.map((p) => p[1])))
+  })
+
+  it('gives matched devices identical bloom extents (one magnitude scale)', () => {
+    const { container } = renderDual(CURVES, CURVES)
+    expect(ySpan(wingLine(container, 'left'))).toBeCloseTo(ySpan(wingLine(container, 'right')), 1)
+  })
+
+  it('scales a weaker device DOWN instead of re-normalizing it to its own wing', () => {
+    const { container } = renderDual(CURVES, scaled(CURVES, 0.5))
+    const ratio = ySpan(wingLine(container, 'left')) / ySpan(wingLine(container, 'right'))
+    expect(ratio).toBeGreaterThan(1.9)
+    expect(ratio).toBeLessThan(2.1)
+  })
+
+  it('shares one time scale — a shorter side ends earlier, it is not stretched to full width', () => {
+    const short = CURVES.map((c) => ({
+      ...c,
+      samples: c.samples.slice(0, Math.round(c.samples.length * 0.5)),
+    }))
+    const { container } = renderDual(CURVES, short)
+    expect(xMax(wingLine(container, 'right'))).toBeLessThan(xMax(wingLine(container, 'left')) * 0.7)
+  })
+
+  it('renders an empty box when neither device has reps', () => {
+    const { container } = renderDual([], [])
+    expect(screen.getByTestId('dual-ghost-spark')).toBeInTheDocument()
+    expect(container.querySelectorAll('path')).toHaveLength(0)
+  })
+
+  it('renders the bound side alone when only one device has reps', () => {
+    const { container } = renderDual(CURVES, [])
+    expect(container.querySelector('[data-testid="dual-ghost-bloom-left"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="dual-ghost-bloom-right"]')).toBeNull()
+  })
+})
+
+describe('mergePhaseSegments', () => {
+  const a: PhaseSegment[] = [
+    { phase: 'eccentric', startMs: 0, endMs: 1000 },
+    { phase: 'concentric', startMs: 1000, endMs: 2000 },
+  ]
+
+  it('keeps a phase both devices agree on', () => {
+    expect(mergePhaseSegments(a, a)).toEqual(a)
+  })
+
+  it('reads idle where the devices are in different phases', () => {
+    const b: PhaseSegment[] = [
+      { phase: 'eccentric', startMs: 0, endMs: 1400 },
+      { phase: 'concentric', startMs: 1400, endMs: 2000 },
+    ]
+    expect(mergePhaseSegments(a, b)).toEqual([
+      { phase: 'eccentric', startMs: 0, endMs: 1000 },
+      { phase: 'idle', startMs: 1000, endMs: 1400 },
+      { phase: 'concentric', startMs: 1400, endMs: 2000 },
+    ])
+  })
+
+  it('lets the covered side speak where the other has no stream yet', () => {
+    const short: PhaseSegment[] = [{ phase: 'eccentric', startMs: 0, endMs: 1000 }]
+    expect(mergePhaseSegments(a, short)).toEqual(a)
+  })
+
+  it('falls back to the only populated side', () => {
+    expect(mergePhaseSegments(a, [])).toEqual(a)
+    expect(mergePhaseSegments([], a)).toEqual(a)
+  })
+})

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
@@ -20,7 +20,6 @@
  * (`lab/north-star/DualGhostLine.exploration.stories.tsx`): centred band + silver line.
  */
 import { View } from 'react-native'
-import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 import { FONT_UI, ghostLineColor, clamp01 } from './fatigue-tokens'
@@ -172,17 +171,6 @@ export function DualGhostSpark({
           showLabels
           labelColor={alpha(t['text-primary'], 0.92)}
         />
-        <rect
-          x={padL}
-          y={bandTop}
-          width={w - padL - padR}
-          height={BAND_H}
-          rx={4}
-          fill="none"
-          stroke={alpha(primitiveColors.black, 0.3)}
-          strokeWidth={1}
-        />
-
         {showDeviceLabels && (
           <>
             <text

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
@@ -1,0 +1,215 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+/**
+ * DualGhostSpark — the DUAL-VOLTRA ghost sparkline: ONE shared {@link GhostBand} with TWO
+ * {@link GhostBloom}s mirrored around it, the LEFT device blooming UP and the RIGHT device
+ * blooming DOWN. Up/down is spent on DEVICE identity, so phase rides the band COLOUR alone
+ * (magenta ecc / cyan con) with the ECC / CON labels INSIDE the band.
+ *
+ * It is built exactly the way the single {@link GhostSpark} is — the same band, the same
+ * bloom, the bottom one just `orientation="down"`. There is no forked path / band / tint
+ * code, so any bloom improvement (the paper-inspired line ground, the silver→red tint)
+ * reaches the dual for free; single↔dual drift is structurally impossible rather than
+ * merely avoided. (The ghost analogue of the diverging VelocityStrip = two composed
+ * VelocityStrips.)
+ *
+ * Both wings share ONE time scale and ONE magnitude scale (a single `vmax` over every
+ * sample on both sides, and equal wing heights), so an L/R asymmetry reads as BLOOM SIZE.
+ * Per-side scales would let a weak side fill its wing and hide the imbalance.
+ *
+ * Layout is the locked B3 exploration
+ * (`lab/north-star/DualGhostLine.exploration.stories.tsx`): centred band + silver line.
+ */
+import { View } from 'react-native'
+import { primitiveColors } from '../../../theme/tokens/primitives'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { alpha } from '../../../utils/colors'
+import { FONT_UI, ghostLineColor, clamp01 } from './fatigue-tokens'
+import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
+import { GhostBloom, type Pt } from './GhostBloom'
+import type { PhaseSegment, RepVelocityCurve } from './fatigue-model'
+
+const t = getSemanticColors('dark')
+
+export interface DualGhostSparkProps {
+  /** LEFT device per-rep curves, oldest first (last = current rep) — blooms UP. */
+  left: RepVelocityCurve[]
+  /** RIGHT device per-rep curves, oldest first (last = current rep) — blooms DOWN. */
+  right: RepVelocityCurve[]
+  width: number
+  /** Plot height in px. Default 232. */
+  height?: number
+  /** Caption above the upper wing. Default `LEFT`. */
+  leftLabel?: string
+  /** Caption below the lower wing. Default `RIGHT`. */
+  rightLabel?: string
+  /** Reveal the device captions. Default `true`. */
+  showDeviceLabels?: boolean
+}
+
+/** The phase covering `ms`, or `null` where the side has no coverage. */
+function phaseAt(segments: PhaseSegment[], ms: number): PhaseSegment['phase'] | null {
+  const hit = segments.find((s) => ms >= s.startMs && ms < s.endMs)
+  return hit ? hit.phase : null
+}
+
+/**
+ * The SHARED band's phase runs: the two devices' current-rep runs reconciled onto one
+ * timeline. Where both sides are in the same phase the band takes it; where they are in
+ * DIFFERENT phases it reads `idle`, so the band never claims a phase the devices are not
+ * actually sharing. Where only one side has a stream at all (the other lags, or is still
+ * mid-rep), the covered side speaks for the band — a lagging device shouldn't grey out the
+ * phase the other device is genuinely in.
+ */
+export function mergePhaseSegments(a: PhaseSegment[], b: PhaseSegment[]): PhaseSegment[] {
+  if (a.length === 0) return b
+  if (b.length === 0) return a
+  const bounds = Array.from(new Set([...a, ...b].flatMap((s) => [s.startMs, s.endMs]))).sort(
+    (p, q) => p - q
+  )
+
+  const out: PhaseSegment[] = []
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const startMs = bounds[i]
+    const endMs = bounds[i + 1]
+    if (endMs <= startMs) continue
+    const mid = (startMs + endMs) / 2
+    const pa = phaseAt(a, mid)
+    const pb = phaseAt(b, mid)
+    const phase = pa == null ? (pb ?? 'idle') : pb == null ? pa : pa === pb ? pa : 'idle'
+    const last = out[out.length - 1]
+    if (last && last.phase === phase && last.endMs === startMs) last.endMs = endMs
+    else out.push({ phase, startMs, endMs })
+  }
+  return out
+}
+
+/** Last sample time across a curve set, 0 when there is nothing to draw. */
+function lastTMs(curves: RepVelocityCurve[]): number {
+  return Math.max(0, ...curves.map((c) => c.samples[c.samples.length - 1]?.tMs ?? 0))
+}
+
+export function DualGhostSpark({
+  left,
+  right,
+  width,
+  height = 232,
+  leftLabel = 'LEFT',
+  rightLabel = 'RIGHT',
+  showDeviceLabels = true,
+}: DualGhostSparkProps) {
+  const w = width
+  const h = height
+  const padL = 14
+  const padR = 14
+  const padTop = 22
+  const padBot = 22
+
+  if (left.length === 0 && right.length === 0) {
+    return <View testID="dual-ghost-spark" style={{ width: w, height: h }} />
+  }
+
+  // The band sits on the vertical midline; each bloom's baseline is offset off a band edge
+  // by BAND_GAP so a zero-velocity moment still sits clear of the band.
+  const mid = padTop + (h - padTop - padBot) / 2
+  const bandTop = mid - BAND_H / 2
+  const baseUp = bandTop - BAND_GAP
+  const baseDown = mid + BAND_H / 2 + BAND_GAP
+  // ONE wing height for both sides — the second half of the shared magnitude scale.
+  const wingH = Math.max(1, Math.min(baseUp - padTop, h - padBot - baseDown))
+
+  const allSamples = [...left, ...right].flatMap((c) => c.samples)
+  const vmax = Math.max(0.01, ...allSamples.map((s) => s.velocityMps)) * 1.06
+  const axisMaxT = Math.max(1, lastTMs(left), lastTMs(right)) * 1.04
+  const x = (ms: number) => padL + (ms / axisMaxT) * (w - padL - padR)
+  const mag = (v: number) => clamp01(v / vmax) * wingH
+
+  const toPts = (c: RepVelocityCurve): Pt[] => c.samples.map((s) => [x(s.tMs), mag(s.velocityMps)])
+  const wing = (curves: RepVelocityCurve[]) => {
+    const cur = curves[curves.length - 1]
+    return {
+      cur,
+      current: cur ? toPts(cur) : [],
+      ghosts: curves.slice(0, -1).map(toPts),
+      tint: cur ? ghostLineColor(cur.tempoDeviation, cur.grindSignature) : t['text-tertiary'],
+    }
+  }
+  const up = wing(left)
+  const down = wing(right)
+  const segments = mergePhaseSegments(up.cur?.phaseSegments ?? [], down.cur?.phaseSegments ?? [])
+
+  return (
+    <View testID="dual-ghost-spark" style={{ paddingHorizontal: 4 }}>
+      <svg width={w} height={h}>
+        {/* Same bloom, one prop flipped: LEFT grows UP, RIGHT grows DOWN. */}
+        {up.current.length > 0 && (
+          <g data-testid="dual-ghost-bloom-left">
+            <GhostBloom
+              current={up.current}
+              ghosts={up.ghosts}
+              tint={up.tint}
+              baseline={baseUp}
+              orientation="up"
+            />
+          </g>
+        )}
+        {down.current.length > 0 && (
+          <g data-testid="dual-ghost-bloom-right">
+            <GhostBloom
+              current={down.current}
+              ghosts={down.ghosts}
+              tint={down.tint}
+              baseline={baseDown}
+              orientation="down"
+            />
+          </g>
+        )}
+
+        {/* the ONE shared phase-coloured band, on top — ECC / CON labelled inside. */}
+        <GhostBand
+          segments={segments}
+          x={x}
+          top={bandTop}
+          showLabels
+          labelColor={alpha(t['text-primary'], 0.92)}
+        />
+        <rect
+          x={padL}
+          y={bandTop}
+          width={w - padL - padR}
+          height={BAND_H}
+          rx={4}
+          fill="none"
+          stroke={alpha(primitiveColors.black, 0.3)}
+          strokeWidth={1}
+        />
+
+        {showDeviceLabels && (
+          <>
+            <text
+              x={padL}
+              y={padTop - 9}
+              fontSize={9}
+              fontWeight={800}
+              letterSpacing={1}
+              fontFamily={FONT_UI}
+              fill={t['text-tertiary']}
+            >
+              {leftLabel}
+            </text>
+            <text
+              x={padL}
+              y={h - padBot + 15}
+              fontSize={9}
+              fontWeight={800}
+              letterSpacing={1}
+              fontFamily={FONT_UI}
+              fill={t['text-tertiary']}
+            >
+              {rightLabel}
+            </text>
+          </>
+        )}
+      </svg>
+    </View>
+  )
+}

--- a/packages/ui/src/components/custom/Fatigue/README.md
+++ b/packages/ui/src/components/custom/Fatigue/README.md
@@ -21,13 +21,19 @@ LiveFatiguePanel              ← the composition (Live panel v2)
    │  └─ Tooltip              (ui/tooltip — hover detail)
    ├─ RomProgressionChart     (per-rep silver/red depth bars + reference lines)
    ├─ GhostSpark              (per-rep velocity-time sparkline; tempo EMBEDDED)
+   │  ├─ GhostBand            (the phase-coloured axis band — ECC/CON labelled inside)
+   │  └─ GhostBloom           (the ghost fan + silver→red current line; orientation up/down)
+   ├─ DualGhostSpark          (dual-Voltra: ONE GhostBand + TWO mirrored GhostBlooms)
+   │  ├─ GhostBand            (the SAME band, centred, shared by both devices)
+   │  └─ GhostBloom ×2        (left up / right down — a one-prop flip, one shared scale)
    └─ Surface                 (ui/surface — the base-plane, paper-accented card ground)
 ```
 
 ## Tier map
 
-**Atoms** — `VerdictHero` · `FatigueLights` · `RomProgressionChart` · `GhostSpark`
-**Molecules** — `VelocityHero` (VelocityStrip + VL bands)
+**Atoms** — `VerdictHero` · `FatigueLights` · `RomProgressionChart` · `GhostBand` · `GhostBloom`
+**Molecules** — `VelocityHero` (VelocityStrip + VL bands) · `GhostSpark` (band + one bloom) ·
+`DualGhostSpark` (one band + two mirrored blooms)
 **Organisms** — `LiveFatigueCard` (the card, one data contract) · `LiveFatiguePanel` (hero + card + aura)
 
 ## Reuse audit — composed, not hand-rolled
@@ -41,6 +47,9 @@ LiveFatiguePanel              ← the composition (Live panel v2)
 - **`Surface`** (ui/surface/) — the card ground (`level="base"`, one step above the
   `background` shell), separated by the alpha `hairline-default` edge and finished with
   the shared `barPaper` accent; no hardcoded surface hex.
+- **`GhostBand` / `GhostBloom`** — the single `GhostSpark` and the dual `DualGhostSpark`
+  compose the SAME band + bloom; the dual is the bloom with `orientation="down"`, not a
+  second renderer. No forked path / band / tint code, so a bloom improvement reaches both.
 - **Tokens** — colours come from `getSemanticColors` / `primitiveRamps`; formatting from
   `roundTempo`. No literal surface/status hex constants.
 
@@ -53,7 +62,7 @@ The reusable pure helpers (`ghostLineColor`, `auraForVerdict`, `mixHex`) live in
 ## Locked design calls (applied)
 
 - **Velocity hero = loss-relative** — VL20/VL30 decision bands (not absolute velocity
-  zones). See *deferred* below for the bar-fill recolour.
+  zones). See _deferred_ below for the bar-fill recolour.
 - **ROM chart + ghost line = ONE silver/red scheme** — silver when right, only SHADES OF
   RED when there's an issue (no greens, no ambers). Shared constants `SILVER` /
   `RED_LIGHT|MID|DEEP` live in `fatigue-tokens.ts`; both consumers import them. The ghost

--- a/packages/ui/src/components/custom/Fatigue/index.ts
+++ b/packages/ui/src/components/custom/Fatigue/index.ts
@@ -11,6 +11,7 @@ export { VerdictHero, type VerdictHeroProps } from './VerdictHero'
 export { FatigueLights, type FatigueLightsProps } from './FatigueLights'
 export { RomProgressionChart, type RomProgressionChartProps } from './RomProgressionChart'
 export { GhostSpark, type GhostSparkProps } from './GhostSpark'
+export { DualGhostSpark, type DualGhostSparkProps, mergePhaseSegments } from './DualGhostSpark'
 export { GhostBand, type GhostBandProps, BAND_H, BAND_GAP } from './GhostBand'
 export {
   GhostBloom,


### PR DESCRIPTION
**TD-07.03** — the dual-Voltra ghost sparkline.

## What
`DualGhostSpark` takes `left` / `right` `RepVelocityCurve[]` (mirroring how `GhostSpark` takes `curves`) and renders **ONE shared `GhostBand`** with **TWO `GhostBloom`s** mirrored around it: the left device grows UP, the right is the *same* bloom with `orientation="down"`.

- **Composed, not hand-rolled.** No duplicated bloom/band/tint drawing code, so single↔dual drift is structurally impossible and any `GhostBloom` improvement (paper line ground, silver→red tint) reaches the dual for free. Same pattern as the `DualVelocityStrip` rewrite.
- **One scale, both wings.** A single `vmax` over every sample on both sides, one shared `x(ms)`, and equal wing heights — an L/R imbalance reads as *bloom size*, not as two independently normalized charts.
- **Shared band reconciliation** (`mergePhaseSegments`, exported + unit-tested): the two current reps agree → the band takes the phase; both moving in *different* phases → `idle`; only one side has a stream (the other lags) → the covered side speaks, so a lagging device doesn't grey out the phase the other is genuinely in.
- Layout is the **locked B3** exploration (`lab/north-star/DualGhostLine.exploration.stories.tsx`): centred band + silver line, band outline, device captions.

## Stories
`Workout/Fatigue/Dual Ghost Spark` — Symmetric · AsymmetricLeftRight (right at ~55% velocity) · OneSideLagging (right still mid-rep) · Empty (both sides empty + single-sided).

## Screenshots (rendered from this branch; index.json verified fresh)
- `/private/tmp/claude-501/-Users-hjewkes-Library-Application-Support-active-work-voltras-workspace/13f2101d-fdf7-4ef7-8e47-b33911001b5e/scratchpad/dualghost-symmetric.png`
- `/private/tmp/claude-501/-Users-hjewkes-Library-Application-Support-active-work-voltras-workspace/13f2101d-fdf7-4ef7-8e47-b33911001b5e/scratchpad/dualghost-asymmetric-left-right.png`
- `/private/tmp/claude-501/-Users-hjewkes-Library-Application-Support-active-work-voltras-workspace/13f2101d-fdf7-4ef7-8e47-b33911001b5e/scratchpad/dualghost-one-side-lagging.png`
- `/private/tmp/claude-501/-Users-hjewkes-Library-Application-Support-active-work-voltras-workspace/13f2101d-fdf7-4ef7-8e47-b33911001b5e/scratchpad/dualghost-empty.png`

## Gates
- `CI=true npx vitest run` — 142 files / 2789 tests pass (12 new)
- `npx tsc --noEmit` — clean
- `npx eslint src` — **0 errors**, 89 warnings (main's baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)