### PR TITLE
Remove the dead mini-tempo digit colour token

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/README.md
+++ b/packages/ui/src/components/custom/Fatigue/README.md
@@ -64,8 +64,8 @@ The reusable pure helpers (`ghostLineColor`, `auraForVerdict`, `mixHex`) live in
   VL20/VL30 bands are a SEPARATE language — unchanged.)
 - **RPE only** — no reps-in-reserve line; the number + verdict word carry exertion state.
 - **No separate top alert** — the card covers exertion state.
-- **Tempo embedded in the ghost-spark** (mini-tempo digits on hover) — there is no
-  standalone hero-tempo component.
+- **Tempo carried by the ghost-spark phase BAND** (`PHASE_AXIS_COLOR`) — no mini-tempo
+  digits, and no standalone hero-tempo component.
 
 ## Data plan / follow-ups
 

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -45,14 +45,6 @@ export const PHASE_AXIS_COLOR: Record<SamplePhase, string> = {
   idle: primitiveColors.charcoal[200],
 }
 
-/** Mini-tempo digit colours `[ecc, pauseBottom, con, pauseTop]` — ecc magenta / con cyan / pauses grey. */
-export const TEMPO_DIGIT_COLOR: [string, string, string, string] = [
-  primitiveRamps.magenta[400],
-  primitiveColors.charcoal[400],
-  primitiveRamps.cyan[300],
-  primitiveColors.charcoal[400],
-]
-
 // --- shared silver/red scheme (ROM chart + ghost-spark line) --------------------
 // One source of truth for the two quality readouts: SILVER when the rep is right,
 // SHADES OF RED when there's an issue. No greens, no ambers — those languages belong


### PR DESCRIPTION
TD-07.09. The band-model rewrite deliberately removed the tempo digits from the ghost rendering, which left `TEMPO_DIGIT_COLOR` in `fatigue-tokens.ts` with no consumer. This removes it. The digits are **not** re-added.

## Dead-code proof

Repo-wide `rg` (excluding `node_modules`/`dist`) for `TEMPO_DIGIT_COLOR` returns exactly one hit — its own definition:

```
./packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts:49:export const TEMPO_DIGIT_COLOR: ...
```

It was never re-exported from `Fatigue/index.ts` either, so it had no public surface.

**Positive control** (same command, same files, sibling export `PHASE_AXIS_COLOR`) returns 16 hits across `GhostBand.tsx`, `GhostBand.test.tsx`, `SilverRedPalette.stories.tsx` and `index.ts` — the scan is working. A second control on `DRIFT_GREY` returns 9 hits.

A case-insensitive `tempo.?digit` sweep found only unrelated `TempoDisplay` references in `custom/Workout/`, untouched here.

## Token layers

No orphaned entries: every ramp step the dead token referenced (`magenta[400]`, `cyan[300]`, `charcoal[400]`) is still consumed elsewhere (`TempoDisplay.tsx:96-98`, `semantic.ts:303/331`, `primitives.ts:256/309`). So `global.css`, `primitives.ts`, `semantic.ts` and `tailwind.config` are unchanged — no hand-aligned token file was reformatted.

Also corrects the stale `Fatigue/README.md` bullet that still described "mini-tempo digits on hover".

## Gates

- `CI=true npx vitest run` (packages/ui): **141 files / 2773 tests passed**
- `src/theme/config.completeness.test.ts`: **5 passed**
- `npx tsc --noEmit`: exit 0
- `npx eslint src/components/custom/Fatigue/fatigue-tokens.ts`: exit 0, clean (the 18 warnings in a wider `src/theme` sweep are pre-existing in `shadows.ts`/`shadows.stories.tsx`, untouched)

No tag cut, nothing published.