### PR TITLE
Brighten the fatigue-lights dimension labels one step

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/FatigueLights.tsx
+++ b/packages/ui/src/components/custom/Fatigue/FatigueLights.tsx
@@ -54,7 +54,7 @@ function Light({
             fontSize: 9,
             letterSpacing: 0.6,
             fontFamily: FONT_MONO,
-            color: t['text-tertiary'],
+            color: t['text-secondary'],
           }}
         >
           {label}


### PR DESCRIPTION
Wall-verified during the 2026-07-26 bench session.

The `VEL`/`ROM`/`TEMPO` labels rendered `text-tertiary` (`neutral[500]`), which read underweight on the wall display at demo distance. Moved one step to `text-secondary` (`neutral[400]`).

Deliberately NOT `text-primary` (`neutral[100]`) — operator's instruction was "a shade or two brighter but keep it grey, don't go straight to white", and near-white would compete with the verdict hero.

Before/after screenshots compared on the wall; operator approved the after.

Gates: 2773 tests / 141 files passing, tsc clean, eslint 0 errors (89 pre-existing warnings).

Part of the VW-85 tag — all six gate rows passed, this and the plannedReps wiring land before the release.