### PR TITLE
Thread plannedReps through the live fatigue card

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
@@ -79,6 +79,35 @@ export const States: Story = {
   ),
 }
 
+/**
+ * Mid-set WITH a plan attached — 3 of 10 done, so the ROM chart draws the remaining 7 reps as
+ * dashed to-do placeholders. `plannedReps` rides the model straight through to
+ * `RomProgressionChart`.
+ */
+export const WithPlannedReps: Story = {
+  render: () => (
+    <Frame>
+      <LiveFatigueCard
+        model={{ ...FATIGUE_STATES[1].model, plannedReps: 10 }}
+        width={318}
+        height={508}
+      />
+    </Frame>
+  ),
+}
+
+/**
+ * The SAME mid-set model with NO plan attached (`plannedReps` undefined) — no target exists, so
+ * the chart shows the performed reps only. The gap reads as a gap; nothing is defaulted in.
+ */
+export const WithoutPlannedReps: Story = {
+  render: () => (
+    <Frame>
+      <LiveFatigueCard model={FATIGUE_STATES[1].model} width={318} height={508} />
+    </Frame>
+  ),
+}
+
 /** Warming up — a cold-start set (< 2 reps): neutral verdict, em-dash RPE, no reference lines. */
 export const WarmingUp: Story = {
   render: () => (

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
@@ -70,6 +70,7 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
         points={model.romProgression}
         workingStandardM={model.romWorkingStandardM}
         shortThresholdM={model.romShortThresholdM}
+        plannedReps={model.plannedReps}
       />
 
       <View style={{ flex: 1, minHeight: 16 }} />

--- a/packages/ui/src/components/custom/Fatigue/fatigue-model.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-model.ts
@@ -103,6 +103,12 @@ export interface LiveFatigueModel {
   verdict: FatigueVerdict | null
   /** ROM progression: per-rep ROM points (metres), ordered by rep. */
   romProgression: RepRomPoint[]
+  /**
+   * Planned rep count from the prescription — the ROM chart draws the remainder as dashed
+   * to-do placeholders (the "N of M done" read). Absent/`undefined` when no plan is attached:
+   * there is genuinely no target then, and the gap must read as a gap — never defaulted.
+   */
+  plannedReps?: number
   /** Working-range standard the ROM chart draws its reference line at (metres). `null` until ≥ 3 reps. */
   romWorkingStandardM: number | null
   /** Short-threshold line (metres) = 0.75 × working standard. `null` until the standard exists. */


### PR DESCRIPTION
## What

`RomProgressionChart` already supported `plannedReps?: number` — reps beyond the performed count draw as dashed to-do placeholders (the "N of M done" read). The live path never passed it, so upcoming planned reps never appeared on the live fatigue card. Confirmed on the wall.

- `LiveFatigueModel` gains an **optional** `plannedReps?: number`.
- `LiveFatigueCard` threads it to `RomProgressionChart`.
- Two stories on `LiveFatigueCard`: `WithPlannedReps` (3 of 10 done, remainder dashed) and `WithoutPlannedReps` (same model, `plannedReps` undefined).

Optional/undefined by design: with no plan attached there is genuinely no target, and the gap must read as a gap. Nothing is defaulted — a hardcoded `targetReps=8` was a real bug in this project.

## Gates

- `CI=true npx vitest run` — 141 files / **2775 passed** (baseline 2773; +2 from the new stories' smoke coverage)
- `npx tsc --noEmit -p tsconfig.json` — clean, exit 0
- `npx eslint src` — **0 errors**, 89 pre-existing warnings

Both states screenshotted from a fresh Storybook (port 6077) after verifying the story IDs in `/index.json`.

Touched only `fatigue-model.ts`, `LiveFatigueCard.tsx`, `LiveFatigueCard.stories.tsx`. No `FatigueLights.tsx` edit, no raw hex, no tempo digits re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)