### PR TITLE
Tighten raw-colour baseline 475 → 463

### DIFF
--- a/packages/ui/eslint-rules/raw-color-baseline.json
+++ b/packages/ui/eslint-rules/raw-color-baseline.json
@@ -449,11 +449,8 @@
     "text-white": 1
   },
   "src/lab/north-star/DualGhostLine.exploration.stories.tsx": {
-    "#000000": 6,
-    "#c4c8d0": 1,
-    "green": 2,
-    "rgba(": 5,
-    "silver": 4
+    "#000000": 1,
+    "rgba(": 5
   },
   "src/lab/north-star/LiveWallDashboard.stories.tsx": {
     "#0e0e0e": 1


### PR DESCRIPTION
The colour ratchet baseline on main was computed before #141 (Foundations/Color story rebuild) removed 12 raw colours from `DualGhostLine.exploration.stories.tsx`. Permissive drift is CI-green but silently gives back ground the ratchet already won.

Regenerated via `node scripts/update-raw-color-baseline.mjs`. Only file affected is the one whose violations genuinely disappeared.

Verified: `eslint src` → 0 errors, 89 pre-existing warnings.

Follow-up from VW-87 (VelocityStrip 3-way split, #130/#131/#132 all merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)