### PR TITLE
Name holds on the ghost band; give ROM the velocity strip's to-do treatment

### DIFF
--- a/packages/ui/REJECTED.md
+++ b/packages/ui/REJECTED.md
@@ -19,7 +19,7 @@ entry is the point — deletion alone loses the reasoning, and the same idea get
 re-proposed. If the code must stay for reference, it belongs in `src/lab/` with
 a `status:` tag, never in the barrel.
 
-An entry should say what was tried, what was chosen instead, and *why* — enough
+An entry should say what was tried, what was chosen instead, and _why_ — enough
 that someone can tell whether a future change invalidates the reasoning.
 
 ---
@@ -27,13 +27,13 @@ that someone can tell whether a future change invalidates the reasoning.
 ## Dual at the session-rail level — rejected 2026-07-25
 
 **Tried:** `DualSessionRail` — a rail that split into left/right slot columns,
-carrying the dual-Voltra distinction at the level of the *exercise list*.
+carrying the dual-Voltra distinction at the level of the _exercise list_.
 
 **Chosen instead:** one consistent session rail over the exercises, with the
 dual distinction surfaced at the **per-set / per-rep** level of detail. That
 decision is what produced `DualVelocityStrip`.
 
-**Why:** bilateral asymmetry is a property of how a *set* was performed, not of
+**Why:** bilateral asymmetry is a property of how a _set_ was performed, not of
 the session's structure. Splitting the rail made every exercise pay layout cost
 for a distinction that only matters inside the active set, and it doubled the
 rail's width budget — the rail is the persistent frame, so it is the wrong place
@@ -49,3 +49,31 @@ become published API that nothing used.
 pointed at, and `SessionRail`'s `expandedIndex` (the current exercise expands in
 place) — the rail stays single and consistent, and detail is revealed by depth
 rather than by splitting the frame.
+
+---
+
+## Per-phase progress fill on the ghost band (2026-07-27)
+
+**What it was:** the phase band doubling as a progress bar by filling each phase
+run dark→bright across its own duration, so the leading edge of every phase read
+brightest.
+
+**Rejected because it re-opens the seam.** A per-phase ramp restarts dark at
+every boundary, which butts a dark leading edge against the previous run's bright
+tail. That reads as a visible step between sections — the exact "gap between
+sections" failure `GhostBand` was built to close and that VW-85 row 5 exists to
+catch. It also duplicates a signal the band already carries: the strip GROWS
+left-to-right as the rep runs, so extent is already the progress encoding.
+
+**Also learned, and worth not relearning:** the band is inherently a LAGGING
+readout. A phase only becomes visible once it has accumulated width, so a 400 ms
+bottom hold is still invisible while it is being held and a 280 ms top hold is
+~18 px arriving at the very end of the rep. The band is a record of the rep, not
+a live cue a lifter can act on mid-rep — do not spend effort trying to make it
+one.
+
+**Chosen instead:** ONE ramp across the whole band (`GhostBand progressRamp`),
+dark at the rep's start → full tone at the leading edge. Contiguity survives
+because there are no interior gradient restarts, and it still reads as "this rep
+has been building". Holds became their own `hold` phase in amber, which is what
+actually made a hold legible — not the fill.

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
-import { GhostBand, BAND_H } from './GhostBand'
+import { GhostBand, BAND_H, type GhostBandProps } from './GhostBand'
 import { PHASE_AXIS_COLOR } from './fatigue-tokens'
 import type { PhaseSegment } from './fatigue-model'
 
@@ -13,10 +13,10 @@ const segments: PhaseSegment[] = [
 
 const x = (ms: number) => 12 + (ms / 4000) * 300
 
-const band = (segs: PhaseSegment[] = segments) =>
+const band = (segs: PhaseSegment[] = segments, props: Partial<GhostBandProps> = {}) =>
   render(
     <svg>
-      <GhostBand segments={segs} x={x} top={0} height={BAND_H} />
+      <GhostBand segments={segs} x={x} top={0} height={BAND_H} {...props} />
     </svg>
   ).container
 
@@ -60,6 +60,70 @@ describe('GhostBand', () => {
   it('renders nothing when every run is zero-width', () => {
     const c = band([{ phase: 'idle', startMs: 500, endMs: 500 }])
     expect(c.querySelectorAll('rect')).toHaveLength(0)
+  })
+
+  it('paints a hold in the amber hold tone — a deliberate hold is not idle dead time', () => {
+    const runs = runsOf(
+      band([
+        { phase: 'eccentric', startMs: 0, endMs: 1000 },
+        { phase: 'hold', startMs: 1000, endMs: 1500 },
+        { phase: 'concentric', startMs: 1500, endMs: 3000 },
+      ])
+    )
+    expect(runs[1].fill).toBe(PHASE_AXIS_COLOR.hold)
+    expect(runs[1].fill).not.toBe(PHASE_AXIS_COLOR.idle)
+  })
+
+  it('labels a hold run wide enough to hold the word', () => {
+    const c = band(
+      [
+        { phase: 'eccentric', startMs: 0, endMs: 1000 },
+        { phase: 'hold', startMs: 1000, endMs: 1500 },
+        { phase: 'concentric', startMs: 1500, endMs: 3000 },
+      ],
+      { showLabels: true }
+    )
+    expect(Array.from(c.querySelectorAll('text')).map((t) => t.textContent)).toEqual([
+      'ECC',
+      'HOLD',
+      'CON',
+    ])
+  })
+
+  it('DROPS a label that will not fit rather than clipping it', () => {
+    // A 300 ms hold is ~22 px here — over the old flat 20 px floor, which rendered a
+    // 'HOLD' that ran past its own run and clipped to 'HOL'.
+    const c = band(
+      [
+        { phase: 'eccentric', startMs: 0, endMs: 1000 },
+        { phase: 'hold', startMs: 1000, endMs: 1300 },
+        { phase: 'concentric', startMs: 1300, endMs: 3000 },
+      ],
+      { showLabels: true }
+    )
+    const labels = Array.from(c.querySelectorAll('text')).map((t) => t.textContent)
+    expect(labels).not.toContain('HOLD')
+    expect(labels).toEqual(['ECC', 'CON'])
+  })
+
+  it('never labels idle — dead time has no name', () => {
+    const c = band(segments, { showLabels: true })
+    expect(Array.from(c.querySelectorAll('text')).map((t) => t.textContent)).toEqual(['ECC', 'CON'])
+  })
+
+  it('draws NO progress ramp by default', () => {
+    expect(band().querySelector('[data-testid="ghost-band-ramp"]')).toBeNull()
+  })
+
+  it('ramps ONCE across the whole band — a per-run ramp would step dark at every seam', () => {
+    const c = band(segments, { progressRamp: true })
+    const ramps = c.querySelectorAll('[data-testid="ghost-band-ramp"]')
+    expect(ramps).toHaveLength(1)
+    // Spans the full strip, so no interior boundary can restart the gradient.
+    const floor = floorOf(c)
+    expect(geom(ramps[0]).x).toBeCloseTo(floor.x, 5)
+    expect(geom(ramps[0]).width).toBeCloseTo(floor.width, 5)
+    expect(c.querySelectorAll('linearGradient')).toHaveLength(1)
   })
 
   it('rounds the band once, as a clip — never per run', () => {

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -1,15 +1,16 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 /**
  * GhostBand — the wide phase-coloured AXIS BAND that carries movement phase for the
- * ghost family (eccentric magenta / concentric cyan / idle grey), with the ECC / CON
- * labels rendered INSIDE it. Extracted from GhostSpark so the single sparkline and a
- * future top/bottom dual compose the SAME band instead of re-rolling it.
+ * ghost family (eccentric magenta / concentric cyan / hold amber / idle grey), with the
+ * ECC / HOLD / CON labels rendered INSIDE it. Extracted from GhostSpark so the single
+ * sparkline and a future top/bottom dual compose the SAME band instead of re-rolling it.
  *
  * It is a pure SVG group: the caller owns the x-scale (`x`) and the band's vertical
  * placement (`top`), so the same band serves a bottom-pinned single or a centred dual.
  */
 import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { primitiveColors } from '../../../theme/tokens/primitives'
 import { FONT_UI, PHASE_AXIS_COLOR } from './fatigue-tokens'
 import type { PhaseSegment } from './fatigue-model'
 
@@ -20,6 +21,30 @@ export const BAND_H = 16
 /** Gap between the band's near edge and a bloom's baseline. */
 export const BAND_GAP = 4
 
+/** Phase → the word rendered inside its run. `idle` stays unnamed: dead time has no name. */
+const PHASE_LABEL: Partial<Record<PhaseSegment['phase'], string>> = {
+  eccentric: 'ECC',
+  concentric: 'CON',
+  hold: 'HOLD',
+}
+
+/** Label glyph advance at fontSize 8 + letterSpacing 1, plus a little side padding. */
+const LABEL_CH_PX = 7
+const LABEL_PAD_PX = 6
+
+/** How far back the {@link GhostBandProps.progressRamp} pulls the strip's start. */
+const RAMP_START_OPACITY = 0.62
+/** The ramp shades toward black so it darkens every phase tone identically. */
+const RAMP_SHADE = primitiveColors.black
+
+/**
+ * Does `label` fit inside a run `segW` px wide? Sized per WORD, not a flat floor — a flat
+ * 20 px clipped 'HOLD' to 'HOL' on exactly the short top-hold runs the label exists for.
+ */
+function labelFits(label: string, segW: number): boolean {
+  return segW >= label.length * LABEL_CH_PX + LABEL_PAD_PX
+}
+
 export interface GhostBandProps {
   /** The current rep's phase runs, in stream order. */
   segments: PhaseSegment[]
@@ -29,10 +54,20 @@ export interface GhostBandProps {
   top: number
   /** Band height, px. Default {@link BAND_H}. */
   height?: number
-  /** Reveal the ECC / CON labels inside the band. */
+  /** Reveal the ECC / HOLD / CON labels inside the band. */
   showLabels?: boolean
   /** Label colour. Default the primary text token. */
   labelColor?: string
+  /**
+   * Shade the strip with ONE dark→full ramp across its whole extent, so the rep's start sits
+   * back and the leading edge reads at full tone — the band doubling as a progress bar.
+   *
+   * Deliberately one ramp over the WHOLE band, never a ramp per phase: a per-phase ramp
+   * restarts dark at every boundary, which butts a dark leading edge against the previous
+   * run's bright tail and reads as a SEAM — reopening the very gap this band is built to
+   * close. Off by default; the band is otherwise flat-toned.
+   */
+  progressRamp?: boolean
 }
 
 /**
@@ -51,9 +86,12 @@ export function GhostBand({
   height = BAND_H,
   showLabels = false,
   labelColor = t['text-primary'],
+  progressRamp = false,
 }: GhostBandProps) {
   const rawId = useId()
-  const clipId = `ghost-band-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+  const safeId = rawId.replace(/[^a-zA-Z0-9]/g, '')
+  const clipId = `ghost-band-${safeId}`
+  const rampId = `ghost-band-ramp-${safeId}`
 
   const drawn = segments.filter((seg) => x(seg.endMs) - x(seg.startMs) > 0)
   if (drawn.length === 0) return null
@@ -63,12 +101,26 @@ export function GhostBand({
   const bandW = bandRight - bandLeft
   if (bandW <= 0) return null
 
+  // Butt each run against the NEXT run's start (not its own end) so rounding between the
+  // two can never open a seam; the last run runs to the band edge.
+  const runs = drawn.map((seg, i) => {
+    const left = x(seg.startMs)
+    const right = i === drawn.length - 1 ? bandRight : x(drawn[i + 1].startMs)
+    return { phase: seg.phase, left, width: Math.max(0, right - left) }
+  })
+
   return (
     <g>
       <defs>
         <clipPath id={clipId}>
           <rect x={bandLeft} y={top} width={bandW} height={height} rx={2} />
         </clipPath>
+        {progressRamp && (
+          <linearGradient id={rampId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor={RAMP_SHADE} stopOpacity={RAMP_START_OPACITY} />
+            <stop offset="100%" stopColor={RAMP_SHADE} stopOpacity={0} />
+          </linearGradient>
+        )}
       </defs>
       <g clipPath={`url(#${clipId})`}>
         {/* the strip floor — the idle tone spans the rep so a pause is band, not a hole. */}
@@ -80,40 +132,50 @@ export function GhostBand({
           fill={PHASE_AXIS_COLOR.idle}
           data-testid="ghost-band-floor"
         />
-        {drawn.map((seg, i) => {
-          const left = x(seg.startMs)
-          // Butt each run against the next run's start (not its own end) so rounding
-          // between the two can never open a seam; the last run runs to the band edge.
-          const right = i === drawn.length - 1 ? bandRight : x(drawn[i + 1].startMs)
-          const segW = Math.max(0, right - left)
-          const label = seg.phase === 'eccentric' ? 'ECC' : seg.phase === 'concentric' ? 'CON' : null
-          return (
-            <g key={i}>
-              <rect
-                x={left}
-                y={top}
-                width={segW}
-                height={height}
-                fill={PHASE_AXIS_COLOR[seg.phase]}
-              />
-              {showLabels && label && segW > 20 && (
-                <text
-                  x={left + segW / 2}
-                  y={top + height / 2}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fill={labelColor}
-                  fontSize={8}
-                  fontWeight={800}
-                  letterSpacing={1}
-                  fontFamily={FONT_UI}
-                >
-                  {label}
-                </text>
-              )}
-            </g>
-          )
-        })}
+        {runs.map((run, i) => (
+          <g key={i}>
+            <rect
+              x={run.left}
+              y={top}
+              width={run.width}
+              height={height}
+              fill={PHASE_AXIS_COLOR[run.phase]}
+            />
+          </g>
+        ))}
+        {/* ONE ramp over the finished strip — never per run, or every boundary steps dark. */}
+        {progressRamp && (
+          <rect
+            x={bandLeft}
+            y={top}
+            width={bandW}
+            height={height}
+            fill={`url(#${rampId})`}
+            data-testid="ghost-band-ramp"
+          />
+        )}
+        {/* Labels last so the ramp shades the BAND, never the words. */}
+        {showLabels &&
+          runs.map((run, i) => {
+            const label = PHASE_LABEL[run.phase]
+            if (!label || !labelFits(label, run.width)) return null
+            return (
+              <text
+                key={i}
+                x={run.left + run.width / 2}
+                y={top + height / 2}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill={labelColor}
+                fontSize={8}
+                fontWeight={800}
+                letterSpacing={1}
+                fontFamily={FONT_UI}
+              >
+                {label}
+              </text>
+            )
+          })}
       </g>
     </g>
   )

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -154,16 +154,21 @@ export const LineTreatmentSoft: Story = {
 }
 
 /**
- * A rep with REAL pauses (the sample-derived mock collapses its pauses to zero width, so
- * the idle tone never shows there). Segments are handed in with SEAMS between the runs —
+ * A rep with REAL holds (the sample-derived mock collapses its pauses to zero width, so
+ * the hold tone never shows there). Segments are handed in with SEAMS between the runs —
  * the shape the model actually produces — to prove the band closes them: one contiguous
- * strip, boundaries on the phase transitions, the pause reading as band material.
+ * strip, boundaries on the phase transitions, the hold reading as band material.
+ *
+ * The two prescribed pauses are `hold` (deliberate, under load) and take the amber tone;
+ * the trailing run is `idle` — undirected dead time after the rep — and stays grey. That
+ * contrast is the point of the story: amber vs grey is hold vs nothing.
  */
 const PAUSED_SEGMENTS: PhaseSegment[] = [
   { phase: 'eccentric', startMs: 0, endMs: 2100 },
-  { phase: 'idle', startMs: 2190, endMs: 2900 },
+  { phase: 'hold', startMs: 2190, endMs: 2900 },
   { phase: 'concentric', startMs: 2990, endMs: 4050 },
-  { phase: 'idle', startMs: 4140, endMs: 4600 },
+  { phase: 'hold', startMs: 4140, endMs: 4600 },
+  { phase: 'idle', startMs: 4690, endMs: 5200 },
 ]
 
 export const PausedRepBand: Story = {
@@ -171,13 +176,19 @@ export const PausedRepBand: Story = {
     const w = 360
     const h = 60
     const bandTop = 22
-    const x = (ms: number) => 12 + (ms / 4800) * (w - 20)
+    const x = (ms: number) => 12 + (ms / 5400) * (w - 20)
     return (
-      <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
-        {label('PHASE BAND · REP WITH REAL PAUSES (bottom hold + top hold)')}
+      <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 16, alignItems: 'flex-start' }}>
+        {label('PHASE BAND · HOLDS (amber) VS TRAILING IDLE (grey) · FLAT')}
         <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
           <svg width={w} height={h}>
             <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels />
+          </svg>
+        </View>
+        {label('SAME BAND · PROGRESS RAMP (one ramp, no interior steps)')}
+        <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+          <svg width={w} height={h}>
+            <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels progressRamp />
           </svg>
         </View>
       </View>

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
@@ -4,8 +4,8 @@
  * the mirrored dual: single = one bloom + band; dual = two blooms sharing one band).
  *
  * A WIDE phase-coloured AXIS BAND ({@link GhostBand}) sits at the BOTTOM, filled per the
- * current rep's phase runs (eccentric magenta / concentric cyan / idle grey), each sized
- * to its time extent, with the ECC / CON labels always shown INSIDE the band. Velocity is
+ * current rep's phase runs (eccentric magenta / concentric cyan / hold amber / idle grey),
+ * each sized to its time extent, with the ECC / HOLD / CON labels shown INSIDE it. Velocity is
  * drawn as MAGNITUDE blooming UP from just above the band ({@link GhostBloom}) — the current
  * rep SOLID over faded grey GHOSTS of the prior reps. Phase is carried by the band colour
  * beneath the line (no ecc-below / con-above split), so single and dual read the same.
@@ -27,9 +27,14 @@ export interface GhostSparkProps {
   width: number
   /** Plot height in px. Default 172. */
   height?: number
+  /**
+   * Shade the phase band with one dark→full ramp so it doubles as a progress bar for the
+   * rep in flight. Default on — see {@link GhostBand.progressRamp}.
+   */
+  progressRamp?: boolean
 }
 
-export function GhostSpark({ curves, width, height = 172 }: GhostSparkProps) {
+export function GhostSpark({ curves, width, height = 172, progressRamp = true }: GhostSparkProps) {
   const w = width
   const h = height
   const padL = 12
@@ -75,8 +80,14 @@ export function GhostSpark({ curves, width, height = 172 }: GhostSparkProps) {
         />
 
         {/* the WIDE phase-colored axis band at the bottom — the sole carrier of phase,
-            filled per the current rep's phase runs, ECC/CON labelled INSIDE. */}
-        <GhostBand segments={cur.phaseSegments} x={x} top={bandTop} showLabels />
+            filled per the current rep's phase runs, ECC/HOLD/CON labelled INSIDE. */}
+        <GhostBand
+          segments={cur.phaseSegments}
+          x={x}
+          top={bandTop}
+          showLabels
+          progressRamp={progressRamp}
+        />
       </svg>
     </View>
   )

--- a/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
+++ b/packages/ui/src/components/custom/Fatigue/RomProgressionChart.tsx
@@ -9,8 +9,9 @@
  * Composes the shared {@link SetBarChart}: SetBarChart owns the geometry (value→height
  * scaling, the plot-width-driven adaptive bar width / gap — the same rhythm as the velocity
  * hero) and paints the reference overlay this chart hands it. When `plannedReps` exceeds the
- * performed count the remaining reps draw as dashed to-do placeholders (the velocity "N of M"
- * read). Bars scale to the tallest of {bars, working standard, short threshold} so the
+ * performed count the remaining reps draw as SetBarChart's default solid to-do sections — the
+ * same upcoming-rep treatment the velocity strip uses, so "3 of 8 done" reads identically in
+ * both charts. Bars scale to the tallest of {bars, working standard, short threshold} so the
  * reference lines always sit on-chart; when no working standard is established yet (< 3 reps)
  * the lines drop and every bar reads silver — the bars alone carry the shape.
  */
@@ -32,8 +33,8 @@ export interface RomProgressionChartProps {
   /** Keep the chart to a legible recent tail. Default 12. */
   maxReps?: number
   /**
-   * Planned rep count. Reps beyond the performed count draw as dashed to-do placeholders (the
-   * velocity "3 of 8 done" read). Ignored when absent or ≤ the performed-rep count.
+   * Planned rep count. Reps beyond the performed count draw as solid to-do sections — the
+   * velocity strip's "3 of 8 done" read. Ignored when absent or ≤ the performed-rep count.
    */
   plannedReps?: number
 }
@@ -122,7 +123,6 @@ export function RomProgressionChart({
         scaleMax={scaleMax}
         barRadius={2}
         hideBaseline
-        todoVariant="dashed"
         targetReps={plannedReps}
         renderReference={(g) => romReferenceOverlay(g, workingStandardM, shortThresholdM)}
         testIDPrefix="rom"

--- a/packages/ui/src/components/custom/Fatigue/fatigue-mock.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-mock.ts
@@ -46,11 +46,13 @@ export const TARGET_TEMPO_SECONDS: [number, number, number, number] = [
 ]
 
 type LabPhase = 'ecc' | 'pauseBottom' | 'con' | 'pauseTop'
+// Both prescribed pauses are HOLDS (deliberate, under load), not idle dead time — the
+// lab's tempo prescribes them, so the band names them.
 const LAB_TO_MODEL: Record<LabPhase, SamplePhase> = {
   ecc: 'eccentric',
-  pauseBottom: 'idle',
+  pauseBottom: 'hold',
   con: 'concentric',
-  pauseTop: 'idle',
+  pauseTop: 'hold',
 }
 
 function clamp(v: number, lo: number, hi: number): number {

--- a/packages/ui/src/components/custom/Fatigue/fatigue-model.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-model.ts
@@ -18,8 +18,15 @@ export type DimensionTone = 'ok' | 'warn' | 'alarm'
 /** Aggregated verdict state (drives the hero word). Mirrors WA's `FatigueVerdictState`. */
 export type FatigueVerdictState = 'good' | 'slowing' | 'grinding' | 'form-breakdown'
 
-/** Movement phase of one per-sample point — colours the ghost-spark zero-axis. */
-export type SamplePhase = 'concentric' | 'eccentric' | 'idle'
+/**
+ * Movement phase of one per-sample point — colours the ghost-spark zero-axis.
+ *
+ * `hold` is a DELIBERATE pause under load (WA's `MovementPhase.HOLD`) — the bottom/top
+ * holds a tempo prescription asks for. `idle` is undirected dead time. They were folded
+ * together until the band needed to name a hold; keep them apart, because "the lifter held
+ * the bottom for 400 ms" and "nothing happened" are different facts.
+ */
+export type SamplePhase = 'concentric' | 'eccentric' | 'hold' | 'idle'
 
 /** One per-sample point of a rep's velocity-time curve. */
 export interface VelocitySample {

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -31,17 +31,25 @@ export const STATE_LABEL: Record<FatigueVerdictState, string> = {
 
 /**
  * The phase-identity colours for the ghost-spark phase BAND — the TempoDisplay
- * language: eccentric magenta, concentric cyan, idle (pause/hold) a muted grey.
+ * language: eccentric magenta, concentric cyan, hold amber, idle a muted grey.
  *
  * The idle grey has to read as BAND MATERIAL (a pause the lifter held), not as a
  * hole in the strip: at charcoal[300] it sat inside the surface-ramp's own value
  * range (`surface-raised` #31302F) so a short pause between ECC and CON read as a
  * gap. charcoal[200] clears every content plane while staying quieter than the two
  * saturated phase tones, so the band reads contiguous and the phases still lead.
+ *
+ * `hold` takes amber at ramp step 700 — one step LIGHTER than the two phase tones at
+ * 800. The asymmetry is deliberate: holds are the NARROWEST runs on the band (a
+ * prescribed top hold is ~280 ms against a ~4.2 s rep, ~18 px at card width), so they
+ * drop under the label floor first and the TONE has to carry the read alone. At
+ * amber[800] the hold sank toward the idle grey and read as dead time again — the
+ * exact confusion this phase was split out to end.
  */
 export const PHASE_AXIS_COLOR: Record<SamplePhase, string> = {
   eccentric: primitiveRamps.magenta[800],
   concentric: primitiveRamps.cyan[800],
+  hold: primitiveRamps.amber[700],
   idle: primitiveColors.charcoal[200],
 }
 


### PR DESCRIPTION
Two changes to the live-fatigue family, both from direct user direction after a specimen comparison.

## 1. Holds are their own phase

The band folded a deliberate `HOLD` into `idle`, so a prescribed bottom/top hold rendered the same grey as dead air. `hold` is now its own `SamplePhase` in amber, labelled `HOLD` inside the run.

Amber sits at ramp step **700** — one step lighter than the two phase tones at 800 — because holds are the narrowest runs on the band (a 280 ms top hold is ~18 px at card width). They drop under the label floor first, so the tone has to carry the read alone; at 800 the hold sank back toward the idle grey.

The label floor was a flat 20 px, which clipped `HOLD` to `HOL` on exactly the short runs the label was added for. It now sizes per word.

## 2. `progressRamp` — the band doubles as a progress bar

ONE dark→full gradient across the whole strip. Deliberately **not** a ramp per phase: that restarts dark at every boundary and butts a dark leading edge against the previous run's bright tail, reading as the seam `GhostBand` exists to close — the same failure VW-85 row 5 catches. The rejected per-phase variant is recorded in `REJECTED.md`, along with the finding that the band is inherently a *lagging* readout (a 400 ms hold is invisible while it is being held), so it should not be pushed toward being a live cue.

## 3. ROM to-do treatment

The ROM progression drew its planned remainder as dashed outline stubs while the velocity strip drew solid sections, so the same "3 of 8 done" fact read two different ways on one card. Drops the `todoVariant="dashed"` override. ROM was the variant's only consumer; the prop stays for future callers.

## Verification

- typecheck ✅ · lint 0 errors ✅ · prettier ✅ · 2792 tests pass
- Every new test was **mutation-checked**: reverting the label floor, folding hold onto the idle tone, and moving the ramp per-run each fail exactly their intended test and nothing else.

## Ordering

⚠️ Merging this does **not** ship it — publish is tag-gated and **VW-85 still holds the tag**. The paired `voltras-mcp` change (`feat/emit-hold-phase`, which stops discarding `MovementPhase.HOLD`) must NOT merge until this is published and the SPA range is widened: an older titan has no `PHASE_AXIS_COLOR['hold']` entry.

Note VW-85 row 5's earlier screenshots are now **stale** — the band changed and that row needs re-judging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)