### PR TITLE
Drive the panel stories from one rep count

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.stories.tsx
@@ -3,7 +3,7 @@ import { View, Text } from 'react-native'
 import { LiveFatigueCard } from './LiveFatigueCard'
 import { Surface } from '../../ui/surface/Surface'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { FATIGUE_STATES, WARMING_UP_MODEL } from './fatigue-mock'
+import { FATIGUE_STATES, WARMING_UP_MODEL, buildMockModel } from './fatigue-mock'
 
 const t = getSemanticColors('dark')
 
@@ -80,30 +80,38 @@ export const States: Story = {
 }
 
 /**
- * Mid-set WITH a plan attached — 3 of 10 done, so the ROM chart draws the remaining 7 reps as
- * dashed to-do placeholders. `plannedReps` rides the model straight through to
- * `RomProgressionChart`.
+ * Mid-set WITH a plan attached — the ROM chart draws the remaining reps as solid to-do sections,
+ * the same upcoming-rep treatment the velocity strip uses. `plannedReps` rides the model straight
+ * through to `RomProgressionChart`, and comes from the mock's ONE rep count, so it agrees with
+ * the velocity side when the two sit together in the panel.
  */
 export const WithPlannedReps: Story = {
   render: () => (
     <Frame>
-      <LiveFatigueCard
-        model={{ ...FATIGUE_STATES[1].model, plannedReps: 10 }}
-        width={318}
-        height={508}
-      />
+      <LiveFatigueCard model={FATIGUE_STATES[1].model} width={318} height={508} />
     </Frame>
   ),
 }
 
 /**
- * The SAME mid-set model with NO plan attached (`plannedReps` undefined) — no target exists, so
- * the chart shows the performed reps only. The gap reads as a gap; nothing is defaulted in.
+ * The SAME mid-set model with NO plan attached — no target exists, so the chart shows the
+ * performed reps only. The gap reads as a gap; nothing is defaulted in.
+ *
+ * `plannedReps` is stripped EXPLICITLY rather than just left off: the mock now supplies it by
+ * default, so "no plan attached" has to be stated to stay true.
  */
 export const WithoutPlannedReps: Story = {
   render: () => (
     <Frame>
-      <LiveFatigueCard model={FATIGUE_STATES[1].model} width={318} height={508} />
+      <LiveFatigueCard
+        model={buildMockModel(FATIGUE_STATES[1].current, {
+          rpe: FATIGUE_STATES[1].model.rpe,
+          verdict: FATIGUE_STATES[1].model.verdict,
+          plannedReps: undefined,
+        })}
+        width={318}
+        height={508}
+      />
     </Frame>
   ),
 }

--- a/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatiguePanel.stories.tsx
@@ -3,7 +3,7 @@ import { View, Text } from 'react-native'
 import { LiveFatiguePanel } from './LiveFatiguePanel'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { FATIGUE_STATES, MOCK_MEAN_VELOCITIES, MOCK_HEADER } from './fatigue-mock'
+import { FATIGUE_STATES, buildMockPanelState } from './fatigue-mock'
 
 const PAGE_BG = primitiveColors.charcoal[900]
 const t = getSemanticColors('dark')
@@ -32,15 +32,17 @@ type Story = StoryObj<typeof LiveFatiguePanel>
 /** THE aligned direction — a breaking-down rep 8, ghost-spark revealed. */
 export const LivePanelV2: Story = {
   name: 'Live panel v2 (composition)',
-  render: () => (
-    <View style={{ backgroundColor: PAGE_BG, padding: 24 }}>
-      <LiveFatiguePanel
-        model={FATIGUE_STATES[3].model}
-        velocity={{ velocities: MOCK_MEAN_VELOCITIES, targetReps: 8 }}
-        header={MOCK_HEADER}
-      />
-    </View>
-  ),
+  render: () => {
+    const { model, velocity, header } = buildMockPanelState(FATIGUE_STATES[3].current, {
+      rpe: 10,
+      verdict: FATIGUE_STATES[3].model.verdict,
+    })
+    return (
+      <View style={{ backgroundColor: PAGE_BG, padding: 24 }}>
+        <LiveFatiguePanel model={model} velocity={velocity} header={header} />
+      </View>
+    )
+  },
 }
 
 /** The whole system across the verdict spectrum — GOOD → SLOWING → GRINDING → FORM BREAKING DOWN. */
@@ -62,11 +64,16 @@ export const LiveStates: Story = {
         <Text style={{ fontSize: 12, color: t['text-secondary'], maxWidth: 860, lineHeight: 18 }}>
           The live panel rendered per verdict state, each driven by a full plausible model — RPE,
           the three status dots, the control-aware ghost line, and the ROM progression all respond
-          together. The aura flood tracks the state.
+          together. The aura flood tracks the state. Every panel is built from ONE truncation point,
+          so the ROM chart&apos;s upcoming reps and the velocity strip&apos;s beside it always agree
+          on the rep count.
         </Text>
       </View>
       {FATIGUE_STATES.map((s) => {
-        const liveRep = s.model.velocityCurves.length - 1
+        const { model, velocity, header } = buildMockPanelState(s.current, {
+          rpe: s.model.rpe,
+          verdict: s.model.verdict,
+        })
         return (
           <View key={s.name} style={{ gap: 6, paddingHorizontal: 28, paddingBottom: 22 }}>
             <Text
@@ -79,15 +86,7 @@ export const LiveStates: Story = {
             >
               {s.name}
             </Text>
-            <LiveFatiguePanel
-              model={s.model}
-              velocity={{
-                velocities: MOCK_MEAN_VELOCITIES.slice(0, s.current + 1),
-                targetReps: 8,
-                liveRepIndex: liveRep,
-              }}
-              header={{ ...MOCK_HEADER, meta: `SET 3 · REP ${s.current + 1} / 8` }}
-            />
+            <LiveFatiguePanel model={model} velocity={velocity} header={header} />
           </View>
         )
       })}

--- a/packages/ui/src/components/custom/Fatigue/fatigue-mock.test.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-mock.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildMockModel,
+  buildMockPanelState,
+  MOCK_PLANNED_REPS,
+  MOCK_MEAN_VELOCITIES,
+  FATIGUE_STATES,
+} from './fatigue-mock'
+
+/**
+ * The panel puts the ROM chart and the velocity strip side by side, and each draws its own
+ * upcoming-rep remainder from a SEPARATE prop. These lock the two to one number — the drift
+ * they prevent is visible on screen as two different rep counts on one panel.
+ */
+describe('buildMockPanelState', () => {
+  it('gives the ROM chart and the velocity strip the SAME planned rep count', () => {
+    const { model, velocity } = buildMockPanelState(2)
+    expect(model.plannedReps).toBe(velocity.targetReps)
+  })
+
+  it('truncates the model and the velocities at the same point', () => {
+    for (const current of [0, 2, 5, 7]) {
+      const { model, velocity } = buildMockPanelState(current)
+      expect(model.romProgression).toHaveLength(current + 1)
+      expect(model.velocityCurves).toHaveLength(current + 1)
+      expect(velocity.velocities).toHaveLength(current + 1)
+      expect(velocity.liveRepIndex).toBe(current)
+    }
+  })
+
+  it('never plans fewer reps than it has performed', () => {
+    for (const s of FATIGUE_STATES) {
+      const { model, velocity } = buildMockPanelState(s.current)
+      expect(model.plannedReps!).toBeGreaterThanOrEqual(model.romProgression.length)
+      expect(velocity.targetReps).toBeGreaterThanOrEqual(velocity.velocities.length)
+    }
+  })
+
+  it('counts the header rep out of the same planned total', () => {
+    const { header } = buildMockPanelState(3)
+    expect(header.meta).toBe(`SET 3 · REP 4 / ${MOCK_PLANNED_REPS}`)
+  })
+
+  it('derives the planned count from the rep data, not a literal', () => {
+    expect(MOCK_PLANNED_REPS).toBe(MOCK_MEAN_VELOCITIES.length)
+  })
+})
+
+describe('buildMockModel plannedReps', () => {
+  it('attaches the mock plan by default', () => {
+    expect(buildMockModel(2).plannedReps).toBe(MOCK_PLANNED_REPS)
+  })
+
+  it('honours an EXPLICIT undefined as "no plan attached"', () => {
+    const model = buildMockModel(2, { plannedReps: undefined })
+    expect(model.plannedReps).toBeUndefined()
+    expect('plannedReps' in model).toBe(true)
+  })
+})

--- a/packages/ui/src/components/custom/Fatigue/fatigue-mock.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-mock.ts
@@ -146,12 +146,19 @@ function workingStandard(current: number): number | null {
  */
 export function buildMockModel(
   current: number,
-  overrides?: { rpe?: number | null; verdict?: FatigueVerdict | null }
+  overrides?: {
+    rpe?: number | null
+    verdict?: FatigueVerdict | null
+    /** Override the plan. Pass `undefined` explicitly for the no-plan-attached case. */
+    plannedReps?: number
+  }
 ): LiveFatigueModel {
   const spec = SPECS[current]
   const working = workingStandard(current)
   const rpe = overrides && 'rpe' in overrides ? (overrides.rpe ?? null) : (RPE[current] ?? null)
   const verdict = overrides && 'verdict' in overrides ? (overrides.verdict ?? null) : null
+  const plannedReps =
+    overrides && 'plannedReps' in overrides ? overrides.plannedReps : MOCK_PLANNED_REPS
   return {
     rpe,
     repsInReserve: rpe == null ? null : Math.max(0, Math.round(10 - rpe)),
@@ -160,6 +167,7 @@ export function buildMockModel(
       repNumber: i + 1,
       romM: s.romMm / 1000,
     })),
+    plannedReps,
     romWorkingStandardM: working,
     romShortThresholdM: working != null ? working * 0.75 : null,
     velocityCurves: CURVES.slice(0, current + 1),
@@ -168,8 +176,48 @@ export function buildMockModel(
   }
 }
 
+/**
+ * The WHOLE panel's input for a set truncated at `current` — model, velocity and header
+ * from one rep count and one truncation point.
+ *
+ * The panel feeds two components that each draw their own upcoming-rep remainder, so
+ * assembling their props separately is how the two halves drift apart. Build both here
+ * or they will disagree again.
+ */
+export function buildMockPanelState(
+  current: number,
+  overrides?: { rpe?: number | null; verdict?: FatigueVerdict | null }
+): {
+  model: LiveFatigueModel
+  velocity: { velocities: number[]; targetReps: number; liveRepIndex: number }
+  header: typeof MOCK_HEADER
+} {
+  const model = buildMockModel(current, overrides)
+  return {
+    model,
+    velocity: {
+      // Same truncation as the model's romProgression / velocityCurves.
+      velocities: MOCK_MEAN_VELOCITIES.slice(0, current + 1),
+      targetReps: MOCK_PLANNED_REPS,
+      liveRepIndex: current,
+    },
+    header: { ...MOCK_HEADER, meta: `SET 3 · REP ${current + 1} / ${MOCK_PLANNED_REPS}` },
+  }
+}
+
 /** Per-rep MEAN concentric velocity (m/s) for the velocity hero (mm/ms == m/s). */
 export const MOCK_MEAN_VELOCITIES: number[] = SPECS.map((s) => s.romMm / s.conMs)
+
+/**
+ * The prescribed rep count for the mock set — ONE number for the whole family.
+ *
+ * The fatigue card's ROM chart and the velocity hero beside it both draw an
+ * upcoming-rep remainder, from `plannedReps` and `targetReps` respectively. Those
+ * are separate props on separate components, so a story that hardcodes one and
+ * leaves the other unset puts two different rep counts side by side on one panel.
+ * Derive both from here.
+ */
+export const MOCK_PLANNED_REPS = SPECS.length
 
 const V = (
   state: FatigueVerdict['state'],
@@ -215,6 +263,6 @@ export const WARMING_UP_MODEL: LiveFatigueModel = buildMockModel(0, { rpe: null,
 
 export const MOCK_HEADER = {
   title: 'Cable Chest Press',
-  subtitle: 'Push A · Hypertrophy · 62 lb × 8 · tempo 2.6·0.4·0.95·0.28',
-  meta: 'SET 3 · REP 8 / 8',
+  subtitle: `Push A · Hypertrophy · 62 lb × ${MOCK_PLANNED_REPS} · tempo 2.6·0.4·0.95·0.28`,
+  meta: `SET 3 · REP ${MOCK_PLANNED_REPS} / ${MOCK_PLANNED_REPS}`,
 }


### PR DESCRIPTION
The live panel puts the ROM chart and the velocity strip side by side, and each draws its own upcoming-rep remainder from a **separate prop** — `plannedReps` on the fatigue model, `targetReps` on the velocity. The stories hardcoded `targetReps: 8` and never set `plannedReps` at all, so the velocity half showed 8 reps of intent while the ROM half showed only what had been performed. The two halves of one panel disagreed about how long the set was.

This is a state-shape problem rather than a design one, so the fix is a single source rather than matching literals.

## Changes

- `MOCK_PLANNED_REPS`, derived from the rep data (`SPECS.length`) rather than written as a literal.
- `buildMockPanelState(current)` assembles **model + velocity + header** from one truncation point. Stories ask for a rep index and get a consistent panel.
- `buildMockModel` now attaches `plannedReps` by default, with an explicit `undefined` for the no-plan case.
- `WithPlannedReps` dropped its hand-written `10` against an 8-rep set.
- `WithoutPlannedReps` strips the plan **explicitly** — the mock supplies one by default, so "no plan attached" has to be stated to stay true.
- `MOCK_HEADER` counts out of the same total instead of a baked-in `8`.

## Verification

- typecheck ✅ · lint 0 errors ✅ · prettier ✅ · 2799 tests pass
- 7 new tests in `fatigue-mock.test.ts` lock the invariant: ROM and velocity get the same planned count, both truncate at the same point, and the plan is never smaller than the performed count.
- **Mutation-checked** — reintroducing the exact drift this fixes (planned count of 10 against a hardcoded `targetReps: 8`) fails two of the new tests and nothing else.

Visual result: the four `LiveStates` panels now read 2+6, 3+5, 6+2, 8+0 across both charts, with the header counting out of the same total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)