### PR TITLE
Pace each phase against its prescribed duration

### DIFF
--- a/packages/ui/REJECTED.md
+++ b/packages/ui/REJECTED.md
@@ -120,3 +120,28 @@ reads more like a hold: a held position is an absence of movement, not an event.
 
 **What survives both:** the `hold` SamplePhase split itself, which is still
 load-bearing — it is what lets a hold carry a label, a target and a fill at all.
+
+### Raised paper fill on the band (2026-07-27)
+
+**What it was:** the pacing fill carrying the system's paper material — matte
+`feTurbulence` grain, a top rim-light, and a contact shadow cast past its leading
+edge into the well — so the fill read as a physical block that had travelled.
+
+**Why it lost — the payoff is scale-dependent and the two lockups disagreed.**
+Rendered in the real `LiveFatigueCard`, at `BAND_H` 16 px in a ~280 px band, it was
+indistinguishable from flat: the well's falloff and the rim-light each had about two
+pixels to work in, on a strip at the bottom of a tall card. In the mirrored dual, at
+720 px wide, it read clearly — but that is exactly where the band sits BETWEEN the
+two wings, so making it tactile set it competing with the traces it exists to
+support. A treatment that is invisible where it is cheap and risky where it is
+visible is not worth the code.
+
+**Chosen instead:** the inset WELL alone, unconditionally. It costs one gradient,
+survives at 16 px, and delivers the part that actually mattered — the unearned
+remainder reading as empty channel rather than a darker shade of the phase. No prop:
+where nothing is prescribed the fill covers the run and the recess is hidden anyway.
+
+**Worth keeping in mind:** `barPaper` (`theme/bar-paper.ts`) is CSS
+`boxShadow`/`backgroundImage` for RN Views and does NOT apply to the band, which is
+pure SVG. Any future material work there has to be re-expressed as SVG defs — that
+translation cost is real and was part of why this did not pay for itself.

--- a/packages/ui/REJECTED.md
+++ b/packages/ui/REJECTED.md
@@ -77,3 +77,46 @@ dark at the rep's start → full tone at the leading edge. Contiguity survives
 because there are no interior gradient restarts, and it still reads as "this rep
 has been building". Holds became their own `hold` phase in amber, which is what
 actually made a hold legible — not the fill.
+
+---
+
+## The whole-band progress ramp, and amber holds (2026-07-27, superseded same day)
+
+Both of these shipped in `fc46330` and were replaced hours later by phase pacing.
+Recording them because the _reasons_ they lost are the useful part.
+
+### The gradient ramp
+
+**What it was:** one dark→full gradient across the whole band, so the rep's start
+sat back and the leading edge read at full tone.
+
+**Why it lost:** it encoded progress as _shading over the extent already drawn_,
+which is a second encoding of something the band's WIDTH already says. It also
+could not answer "how am I doing against the prescription", because it had no
+notion of a target — it only ever showed how far the rep had got, not whether
+that was fast or slow.
+
+**Chosen instead:** per-phase pacing. Each run paints a muted base with a fill
+earned against its own prescribed duration (`elapsed / target`, capped), and the
+label takes the pacing tone. Same "fills left to right" instinct, but measured
+against something.
+
+### Amber holds
+
+**What it was:** `hold` as its own phase hue, amber, to separate a deliberate hold
+from idle dead time.
+
+**Why it lost — a genuine conflict, not a taste call.** The pacing tone uses
+warning-**amber** for "ahead of target". A phase painted amber therefore collides
+with the semantic signal drawn on top of it. `TempoDisplay` had already written the
+governing rule down: phase hues are "deliberately NON-semantic ... so the phase hue
+never collides with the semantic pacing tones". Amber holds violated it; we just
+hadn't added the pacing tones yet, so nothing collided until they arrived.
+
+**Chosen instead:** hold returns to the grey family, separated from idle by VALUE
+(unfilled `charcoal[300]` < idle `charcoal[200]` < filled `charcoal[100]`), by the
+`HOLD` label, and by the fact that a hold PACES while idle never fills. Grey also
+reads more like a hold: a held position is an absence of movement, not an event.
+
+**What survives both:** the `hold` SamplePhase split itself, which is still
+load-bearing — it is what lets a hold carry a label, a target and a fill at all.

--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.tsx
@@ -24,6 +24,7 @@ import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { alpha } from '../../../utils/colors'
 import { FONT_UI, ghostLineColor, clamp01 } from './fatigue-tokens'
 import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
+import type { TempoTuple } from './tempo-pacing'
 import { GhostBloom, type Pt } from './GhostBloom'
 import type { PhaseSegment, RepVelocityCurve } from './fatigue-model'
 
@@ -43,6 +44,8 @@ export interface DualGhostSparkProps {
   rightLabel?: string
   /** Reveal the device captions. Default `true`. */
   showDeviceLabels?: boolean
+  /** Prescribed tempo — turns on the shared band's phase pacing. */
+  targetTempoSeconds?: TempoTuple | null
 }
 
 /** The phase covering `ms`, or `null` where the side has no coverage. */
@@ -95,6 +98,7 @@ export function DualGhostSpark({
   leftLabel = 'LEFT',
   rightLabel = 'RIGHT',
   showDeviceLabels = true,
+  targetTempoSeconds = null,
 }: DualGhostSparkProps) {
   const w = width
   const h = height
@@ -170,6 +174,7 @@ export function DualGhostSpark({
           top={bandTop}
           showLabels
           labelColor={alpha(t['text-primary'], 0.92)}
+          targetTempoSeconds={targetTempoSeconds}
         />
         {showDeviceLabels && (
           <>

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -194,4 +194,27 @@ describe('GhostBand', () => {
     const c = band(onPace, { showLabels: true })
     expect(labelsOf(c).every((l) => l.fill === t['text-primary'])).toBe(true)
   })
+
+  // --- the well ---------------------------------------------------------------
+
+  it('recesses every run, so an unearned remainder reads as empty channel', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO })
+    expect(c.querySelectorAll('[data-testid="ghost-band-well"]')).toHaveLength(onPace.length)
+  })
+
+  it('sits the well UNDER the fill — a filled run hides its own recess', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO })
+    const order = Array.from(c.querySelectorAll('g[clip-path] > g > rect')).map((r) =>
+      r.getAttribute('data-testid')
+    )
+    expect(order.slice(0, 3)).toEqual(['ghost-band-base', 'ghost-band-well', 'ghost-band-fill'])
+  })
+
+  it('spans the well across the whole run, not just the unfilled part', () => {
+    // Recessing only the exposed remainder would step in tone at the fill's edge.
+    const fast: PhaseSegment[] = [{ phase: 'eccentric', startMs: 0, endMs: 1300 }]
+    const c = band(fast, { targetTempoSeconds: TEMPO })
+    const well = geom(c.querySelector('[data-testid="ghost-band-well"]')!)
+    expect(well.width).toBeCloseTo(basesOf(c)[0].width, 5)
+  })
 })

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
 import { GhostBand, BAND_H, type GhostBandProps } from './GhostBand'
-import { PHASE_AXIS_COLOR, PHASE_AXIS_BASE_COLOR } from './fatigue-tokens'
+import { PHASE_AXIS_COLOR, PHASE_AXIS_BASE_COLOR, PACING_TONE } from './fatigue-tokens'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import type { PhaseSegment } from './fatigue-model'
 
@@ -184,9 +184,9 @@ describe('GhostBand', () => {
     ]
     const c = band(mixed, { targetTempoSeconds: TEMPO, showLabels: true })
     expect(labelsOf(c)).toEqual([
-      { text: 'ECC', fill: t['status-warning'] },
-      { text: 'CON', fill: t['status-success'] },
-      { text: 'HOLD', fill: t['status-error'] },
+      { text: 'ECC', fill: PACING_TONE.ahead },
+      { text: 'CON', fill: PACING_TONE.onPace },
+      { text: 'HOLD', fill: PACING_TONE.over },
     ])
   })
 

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
 import { GhostBand, BAND_H, type GhostBandProps } from './GhostBand'
-import { PHASE_AXIS_COLOR } from './fatigue-tokens'
+import { PHASE_AXIS_COLOR, PHASE_AXIS_BASE_COLOR } from './fatigue-tokens'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
 import type { PhaseSegment } from './fatigue-model'
+
+const t = getSemanticColors('dark')
 
 /** Phase runs with SEAMS between them — the shape the sample-derived model actually produces. */
 const segments: PhaseSegment[] = [
@@ -28,13 +31,29 @@ const geom = (r: Element) => ({
 
 /** The strip floor — the one rect sitting directly in the clipped group. */
 const floorOf = (c: HTMLElement) => geom(c.querySelector('g[clip-path] > rect')!)
-/** The phase runs — one rect per run, each in its own group. */
-const runsOf = (c: HTMLElement) =>
-  Array.from(c.querySelectorAll('g[clip-path] > g > rect')).map(geom)
+/** Per-run BASE rects — these carry the run's true geometry (full width). */
+const basesOf = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('[data-testid="ghost-band-base"]')).map(geom)
+/** Per-run FILL rects — width is the share of the run earned against target. */
+const fillsOf = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('[data-testid="ghost-band-fill"]')).map(geom)
+const labelsOf = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll('text')).map((n) => ({
+    text: n.textContent,
+    fill: n.getAttribute('fill'),
+  }))
+
+/** A rep whose phases each run EXACTLY their prescribed duration. */
+const onPace: PhaseSegment[] = [
+  { phase: 'eccentric', startMs: 0, endMs: 2600 },
+  { phase: 'hold', startMs: 2600, endMs: 3000 },
+  { phase: 'concentric', startMs: 3000, endMs: 3950 },
+]
+const TEMPO: [number, number, number, number] = [2.6, 0.4, 0.95, 0.28]
 
 describe('GhostBand', () => {
   it('draws a contiguous strip — each run butts against the next with no gap', () => {
-    const runs = runsOf(band())
+    const runs = basesOf(band())
     runs.forEach((r, i) => {
       const next = runs[i + 1]
       if (next) expect(r.x + r.width).toBeCloseTo(next.x, 5)
@@ -49,8 +68,7 @@ describe('GhostBand', () => {
   })
 
   it('paints the pause run in the idle tone', () => {
-    const runs = runsOf(band())
-    expect(runs.map((r) => r.fill)).toEqual([
+    expect(fillsOf(band()).map((r) => r.fill)).toEqual([
       PHASE_AXIS_COLOR.eccentric,
       PHASE_AXIS_COLOR.idle,
       PHASE_AXIS_COLOR.concentric,
@@ -62,8 +80,8 @@ describe('GhostBand', () => {
     expect(c.querySelectorAll('rect')).toHaveLength(0)
   })
 
-  it('paints a hold in the amber hold tone — a deliberate hold is not idle dead time', () => {
-    const runs = runsOf(
+  it('separates a hold from idle by VALUE, so a narrow hold still reads as a hold', () => {
+    const runs = fillsOf(
       band([
         { phase: 'eccentric', startMs: 0, endMs: 1000 },
         { phase: 'hold', startMs: 1000, endMs: 1500 },
@@ -72,6 +90,9 @@ describe('GhostBand', () => {
     )
     expect(runs[1].fill).toBe(PHASE_AXIS_COLOR.hold)
     expect(runs[1].fill).not.toBe(PHASE_AXIS_COLOR.idle)
+    // A filled hold sits BRIGHTER than idle, an unfilled one darker — never the same.
+    expect(PHASE_AXIS_COLOR.hold).not.toBe(PHASE_AXIS_BASE_COLOR.hold)
+    expect(PHASE_AXIS_BASE_COLOR.hold).not.toBe(PHASE_AXIS_COLOR.idle)
   })
 
   it('labels a hold run wide enough to hold the word', () => {
@@ -83,11 +104,7 @@ describe('GhostBand', () => {
       ],
       { showLabels: true }
     )
-    expect(Array.from(c.querySelectorAll('text')).map((t) => t.textContent)).toEqual([
-      'ECC',
-      'HOLD',
-      'CON',
-    ])
+    expect(labelsOf(c).map((l) => l.text)).toEqual(['ECC', 'HOLD', 'CON'])
   })
 
   it('DROPS a label that will not fit rather than clipping it', () => {
@@ -101,29 +118,16 @@ describe('GhostBand', () => {
       ],
       { showLabels: true }
     )
-    const labels = Array.from(c.querySelectorAll('text')).map((t) => t.textContent)
+    const labels = labelsOf(c).map((l) => l.text)
     expect(labels).not.toContain('HOLD')
     expect(labels).toEqual(['ECC', 'CON'])
   })
 
   it('never labels idle — dead time has no name', () => {
-    const c = band(segments, { showLabels: true })
-    expect(Array.from(c.querySelectorAll('text')).map((t) => t.textContent)).toEqual(['ECC', 'CON'])
-  })
-
-  it('draws NO progress ramp by default', () => {
-    expect(band().querySelector('[data-testid="ghost-band-ramp"]')).toBeNull()
-  })
-
-  it('ramps ONCE across the whole band — a per-run ramp would step dark at every seam', () => {
-    const c = band(segments, { progressRamp: true })
-    const ramps = c.querySelectorAll('[data-testid="ghost-band-ramp"]')
-    expect(ramps).toHaveLength(1)
-    // Spans the full strip, so no interior boundary can restart the gradient.
-    const floor = floorOf(c)
-    expect(geom(ramps[0]).x).toBeCloseTo(floor.x, 5)
-    expect(geom(ramps[0]).width).toBeCloseTo(floor.width, 5)
-    expect(c.querySelectorAll('linearGradient')).toHaveLength(1)
+    expect(labelsOf(band(segments, { showLabels: true })).map((l) => l.text)).toEqual([
+      'ECC',
+      'CON',
+    ])
   })
 
   it('rounds the band once, as a clip — never per run', () => {
@@ -131,5 +135,63 @@ describe('GhostBand', () => {
     expect(c.querySelector('clipPath rect')?.getAttribute('rx')).toBe('2')
     const runRects = Array.from(c.querySelectorAll('g[clip-path] > g > rect'))
     expect(runRects.every((r) => r.getAttribute('rx') == null)).toBe(true)
+  })
+
+  // --- pacing -----------------------------------------------------------------
+
+  it('fills every run completely when no tempo is prescribed', () => {
+    const bases = basesOf(band())
+    fillsOf(band()).forEach((f, i) => expect(f.width).toBeCloseTo(bases[i].width, 5))
+  })
+
+  it('leaves the geometry alone when pacing turns on — only the FILL changes', () => {
+    const flat = basesOf(band(onPace))
+    const paced = basesOf(band(onPace, { targetTempoSeconds: TEMPO }))
+    expect(paced).toEqual(flat)
+  })
+
+  it('fills a run that hit its target to the brim', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO })
+    const bases = basesOf(c)
+    fillsOf(c).forEach((f, i) => expect(f.width).toBeCloseTo(bases[i].width, 5))
+  })
+
+  it('leaves a FAST phase partly unfilled — the base shows through', () => {
+    // A 1.3 s eccentric against a 2.6 s target is exactly half paced.
+    const fast: PhaseSegment[] = [{ phase: 'eccentric', startMs: 0, endMs: 1300 }]
+    const c = band(fast, { targetTempoSeconds: TEMPO })
+    expect(fillsOf(c)[0].width).toBeCloseTo(basesOf(c)[0].width * 0.5, 5)
+  })
+
+  it('CAPS a slow phase at its own run width rather than overflowing', () => {
+    const slow: PhaseSegment[] = [{ phase: 'eccentric', startMs: 0, endMs: 9000 }]
+    const c = band(slow, { targetTempoSeconds: TEMPO })
+    expect(fillsOf(c)[0].width).toBeCloseTo(basesOf(c)[0].width, 5)
+  })
+
+  it('paints the muted base UNDER the fill so an unfilled remainder is still band', () => {
+    const fast: PhaseSegment[] = [{ phase: 'eccentric', startMs: 0, endMs: 1300 }]
+    const c = band(fast, { targetTempoSeconds: TEMPO })
+    expect(basesOf(c)[0].fill).toBe(PHASE_AXIS_BASE_COLOR.eccentric)
+    expect(fillsOf(c)[0].fill).toBe(PHASE_AXIS_COLOR.eccentric)
+  })
+
+  it('tones each label by its own pacing — ahead warns, on-pace succeeds, over errors', () => {
+    const mixed: PhaseSegment[] = [
+      { phase: 'eccentric', startMs: 0, endMs: 1000 }, // 1.0s vs 2.6s → ahead
+      { phase: 'concentric', startMs: 1000, endMs: 1950 }, // 0.95s vs 0.95s → on pace
+      { phase: 'hold', startMs: 1950, endMs: 3950 }, // 2.0s vs 0.28s → over
+    ]
+    const c = band(mixed, { targetTempoSeconds: TEMPO, showLabels: true })
+    expect(labelsOf(c)).toEqual([
+      { text: 'ECC', fill: t['status-warning'] },
+      { text: 'CON', fill: t['status-success'] },
+      { text: 'HOLD', fill: t['status-error'] },
+    ])
+  })
+
+  it('keeps labels plain when nothing is prescribed to pace against', () => {
+    const c = band(onPace, { showLabels: true })
+    expect(labelsOf(c).every((l) => l.fill === t['text-primary'])).toBe(true)
   })
 })

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -95,39 +95,33 @@ describe('GhostBand', () => {
     expect(PHASE_AXIS_BASE_COLOR.hold).not.toBe(PHASE_AXIS_COLOR.idle)
   })
 
-  it('labels a hold run wide enough to hold the word', () => {
+  it('labels ONLY the movement phases — hold and idle stay unnamed', () => {
+    // The pacing-tone contrast floor is measured against ECC/CON backgrounds only, so this
+    // exclusion is what keeps that narrower set honest. Widening it here needs the tones
+    // re-measured against whatever new background can sit behind a label.
     const c = band(
       [
         { phase: 'eccentric', startMs: 0, endMs: 1000 },
         { phase: 'hold', startMs: 1000, endMs: 1500 },
         { phase: 'concentric', startMs: 1500, endMs: 3000 },
+        { phase: 'idle', startMs: 3000, endMs: 4000 },
       ],
       { showLabels: true }
     )
-    expect(labelsOf(c).map((l) => l.text)).toEqual(['ECC', 'HOLD', 'CON'])
+    expect(labelsOf(c).map((l) => l.text)).toEqual(['ECC', 'CON'])
   })
 
   it('DROPS a label that will not fit rather than clipping it', () => {
-    // A 300 ms hold is ~22 px here — over the old flat 20 px floor, which rendered a
-    // 'HOLD' that ran past its own run and clipped to 'HOL'.
+    // A 300 ms concentric is ~22 px here — over the old flat 20 px floor, which rendered a
+    // word that ran past its own run and clipped.
     const c = band(
       [
         { phase: 'eccentric', startMs: 0, endMs: 1000 },
-        { phase: 'hold', startMs: 1000, endMs: 1300 },
-        { phase: 'concentric', startMs: 1300, endMs: 3000 },
+        { phase: 'concentric', startMs: 1000, endMs: 1300 },
       ],
       { showLabels: true }
     )
-    const labels = labelsOf(c).map((l) => l.text)
-    expect(labels).not.toContain('HOLD')
-    expect(labels).toEqual(['ECC', 'CON'])
-  })
-
-  it('never labels idle — dead time has no name', () => {
-    expect(labelsOf(band(segments, { showLabels: true })).map((l) => l.text)).toEqual([
-      'ECC',
-      'CON',
-    ])
+    expect(labelsOf(c).map((l) => l.text)).toEqual(['ECC'])
   })
 
   it('rounds the band once, as a clip — never per run', () => {
@@ -176,18 +170,21 @@ describe('GhostBand', () => {
     expect(fillsOf(c)[0].fill).toBe(PHASE_AXIS_COLOR.eccentric)
   })
 
-  it('tones each label by its own pacing — ahead warns, on-pace succeeds, over errors', () => {
+  it('tones each label by its OWN pacing, independently', () => {
     const mixed: PhaseSegment[] = [
       { phase: 'eccentric', startMs: 0, endMs: 1000 }, // 1.0s vs 2.6s → ahead
-      { phase: 'concentric', startMs: 1000, endMs: 1950 }, // 0.95s vs 0.95s → on pace
-      { phase: 'hold', startMs: 1950, endMs: 3950 }, // 2.0s vs 0.28s → over
+      { phase: 'concentric', startMs: 1000, endMs: 4000 }, // 3.0s vs 0.95s → over
     ]
     const c = band(mixed, { targetTempoSeconds: TEMPO, showLabels: true })
     expect(labelsOf(c)).toEqual([
       { text: 'ECC', fill: PACING_TONE.ahead },
-      { text: 'CON', fill: PACING_TONE.onPace },
-      { text: 'HOLD', fill: PACING_TONE.over },
+      { text: 'CON', fill: PACING_TONE.over },
     ])
+  })
+
+  it('tones a label ON PACE when the phase hits its target', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO, showLabels: true })
+    expect(labelsOf(c).map((l) => l.fill)).toEqual([PACING_TONE.onPace, PACING_TONE.onPace])
   })
 
   it('keeps labels plain when nothing is prescribed to pace against', () => {

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -19,9 +19,14 @@
  *
  * The two encodings read together: a slow phase is a WIDE run filled to the brim with an
  * error-toned label; a fast phase is a NARROW run only partly filled, warning-toned.
+ *
+ * Every run is recessed into a WELL, so the part not yet earned reads as empty channel
+ * rather than as a darker shade of the phase. The well needs no flag: where nothing is
+ * prescribed the fill covers the whole run and the recess is hidden behind it.
  */
 import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { primitiveColors } from '../../../theme/tokens/primitives'
 import { FONT_UI, PHASE_AXIS_COLOR, PHASE_AXIS_BASE_COLOR } from './fatigue-tokens'
 import { phaseFillFraction, pacingTone, phaseTargetsMs, type TempoTuple } from './tempo-pacing'
 import type { PhaseSegment } from './fatigue-model'
@@ -43,6 +48,11 @@ const PHASE_LABEL: Partial<Record<PhaseSegment['phase'], string>> = {
 /** Label glyph advance at fontSize 8 + letterSpacing 1, plus a little side padding. */
 const LABEL_CH_PX = 7
 const LABEL_PAD_PX = 6
+
+/** The well shades toward black so it recesses every phase tone identically. */
+const WELL_SHADE = primitiveColors.black
+/** The faint light line on the well's floor — the far lip catching light. */
+const WELL_FLOOR_LIGHT = primitiveColors.white
 
 /**
  * Does `label` fit inside a run `segW` px wide? Sized per WORD, not a flat floor — a flat
@@ -97,7 +107,9 @@ export function GhostBand({
   targetTempoSeconds = null,
 }: GhostBandProps) {
   const rawId = useId()
-  const clipId = `ghost-band-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
+  const safeId = rawId.replace(/[^a-zA-Z0-9]/g, '')
+  const clipId = `ghost-band-${safeId}`
+  const wellId = `ghost-band-well-${safeId}`
 
   const drawn = segments.filter((seg) => x(seg.endMs) - x(seg.startMs) > 0)
   if (drawn.length === 0) return null
@@ -139,6 +151,14 @@ export function GhostBand({
         <clipPath id={clipId}>
           <rect x={bandLeft} y={top} width={bandW} height={height} rx={2} />
         </clipPath>
+        {/* The WELL — dark under the top lip, falling off fast, with a faint light line on
+            the floor. SVG has no `inset` box-shadow, so a recess is a gradient. */}
+        <linearGradient id={wellId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={WELL_SHADE} stopOpacity={0.6} />
+          <stop offset="42%" stopColor={WELL_SHADE} stopOpacity={0.12} />
+          <stop offset="88%" stopColor={WELL_SHADE} stopOpacity={0.02} />
+          <stop offset="100%" stopColor={WELL_FLOOR_LIGHT} stopOpacity={0.07} />
+        </linearGradient>
       </defs>
       <g clipPath={`url(#${clipId})`}>
         {/* the strip floor — the idle tone spans the rep so a pause is band, not a hole. */}
@@ -162,6 +182,14 @@ export function GhostBand({
               height={height}
               fill={PHASE_AXIS_BASE_COLOR[run.phase]}
               data-testid="ghost-band-base"
+            />
+            <rect
+              x={run.left}
+              y={top}
+              width={run.width}
+              height={height}
+              fill={`url(#${wellId})`}
+              data-testid="ghost-band-well"
             />
             <rect
               x={run.left}

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -1,17 +1,29 @@
 // Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
 /**
  * GhostBand — the wide phase-coloured AXIS BAND that carries movement phase for the
- * ghost family (eccentric magenta / concentric cyan / hold amber / idle grey), with the
+ * ghost family (eccentric magenta / concentric cyan / hold and idle grey), with the
  * ECC / HOLD / CON labels rendered INSIDE it. Extracted from GhostSpark so the single
  * sparkline and a future top/bottom dual compose the SAME band instead of re-rolling it.
  *
  * It is a pure SVG group: the caller owns the x-scale (`x`) and the band's vertical
  * placement (`top`), so the same band serves a bottom-pinned single or a centred dual.
+ *
+ * ## Pacing
+ *
+ * Given a target tempo, each run paints a MUTED base with a brighter fill growing
+ * left-to-right across `elapsed / target` of its own width (capped at full), and its label
+ * takes the pacing tone — ahead / on pace / over. The band's GEOMETRY is untouched by this:
+ * runs keep their actual-time positions and widths so the internal boundaries still land
+ * under the sparkline's phase transitions. Pacing is a fill INSIDE the existing bars, never
+ * a re-layout of them.
+ *
+ * The two encodings read together: a slow phase is a WIDE run filled to the brim with an
+ * error-toned label; a fast phase is a NARROW run only partly filled, warning-toned.
  */
 import { useId } from 'react'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { primitiveColors } from '../../../theme/tokens/primitives'
-import { FONT_UI, PHASE_AXIS_COLOR } from './fatigue-tokens'
+import { FONT_UI, PHASE_AXIS_COLOR, PHASE_AXIS_BASE_COLOR } from './fatigue-tokens'
+import { phaseFillFraction, pacingTone, phaseTargetsMs, type TempoTuple } from './tempo-pacing'
 import type { PhaseSegment } from './fatigue-model'
 
 const t = getSemanticColors('dark')
@@ -32,11 +44,6 @@ const PHASE_LABEL: Partial<Record<PhaseSegment['phase'], string>> = {
 const LABEL_CH_PX = 7
 const LABEL_PAD_PX = 6
 
-/** How far back the {@link GhostBandProps.progressRamp} pulls the strip's start. */
-const RAMP_START_OPACITY = 0.62
-/** The ramp shades toward black so it darkens every phase tone identically. */
-const RAMP_SHADE = primitiveColors.black
-
 /**
  * Does `label` fit inside a run `segW` px wide? Sized per WORD, not a flat floor — a flat
  * 20 px clipped 'HOLD' to 'HOL' on exactly the short top-hold runs the label exists for.
@@ -56,18 +63,19 @@ export interface GhostBandProps {
   height?: number
   /** Reveal the ECC / HOLD / CON labels inside the band. */
   showLabels?: boolean
-  /** Label colour. Default the primary text token. */
+  /**
+   * Label colour when there is no pacing tone to apply. Default the primary text token.
+   * Ignored for a run that paces — that label takes {@link pacingTone}.
+   */
   labelColor?: string
   /**
-   * Shade the strip with ONE dark→full ramp across its whole extent, so the rep's start sits
-   * back and the leading edge reads at full tone — the band doubling as a progress bar.
+   * Prescribed tempo `[ecc, pauseBottom, con, pauseTop]` in seconds. Supplying it turns on
+   * PACING: runs paint muted-base + fill, and labels take the ahead/on-pace/over tone.
    *
-   * Deliberately one ramp over the WHOLE band, never a ramp per phase: a per-phase ramp
-   * restarts dark at every boundary, which butts a dark leading edge against the previous
-   * run's bright tail and reads as a SEAM — reopening the very gap this band is built to
-   * close. Off by default; the band is otherwise flat-toned.
+   * Omit it and the band paints flat at full tone with plain labels — the pre-pacing look,
+   * which is also the honest one when nothing was prescribed to pace against.
    */
-  progressRamp?: boolean
+  targetTempoSeconds?: TempoTuple | null
 }
 
 /**
@@ -86,12 +94,10 @@ export function GhostBand({
   height = BAND_H,
   showLabels = false,
   labelColor = t['text-primary'],
-  progressRamp = false,
+  targetTempoSeconds = null,
 }: GhostBandProps) {
   const rawId = useId()
-  const safeId = rawId.replace(/[^a-zA-Z0-9]/g, '')
-  const clipId = `ghost-band-${safeId}`
-  const rampId = `ghost-band-ramp-${safeId}`
+  const clipId = `ghost-band-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`
 
   const drawn = segments.filter((seg) => x(seg.endMs) - x(seg.startMs) > 0)
   if (drawn.length === 0) return null
@@ -101,12 +107,30 @@ export function GhostBand({
   const bandW = bandRight - bandLeft
   if (bandW <= 0) return null
 
+  const pacing = targetTempoSeconds != null
+  // Each run's elapsed time IS its own duration — the in-flight run's `endMs` is already
+  // "now" — so pacing needs no clock of its own.
+  const targetsMs = phaseTargetsMs(
+    drawn.map((seg) => seg.phase),
+    targetTempoSeconds
+  )
+
   // Butt each run against the NEXT run's start (not its own end) so rounding between the
   // two can never open a seam; the last run runs to the band edge.
   const runs = drawn.map((seg, i) => {
     const left = x(seg.startMs)
     const right = i === drawn.length - 1 ? bandRight : x(drawn[i + 1].startMs)
-    return { phase: seg.phase, left, width: Math.max(0, right - left) }
+    const width = Math.max(0, right - left)
+    const targetMs = targetsMs[i]
+    const elapsedMs = seg.endMs - seg.startMs
+    return {
+      phase: seg.phase,
+      left,
+      width,
+      // No target (or no prescription at all) → the run reads complete rather than empty.
+      fillWidth: pacing ? width * phaseFillFraction(elapsedMs, targetMs) : width,
+      labelTone: pacing ? pacingTone(elapsedMs, targetMs) : labelColor,
+    }
   })
 
   return (
@@ -115,12 +139,6 @@ export function GhostBand({
         <clipPath id={clipId}>
           <rect x={bandLeft} y={top} width={bandW} height={height} rx={2} />
         </clipPath>
-        {progressRamp && (
-          <linearGradient id={rampId} x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0%" stopColor={RAMP_SHADE} stopOpacity={RAMP_START_OPACITY} />
-            <stop offset="100%" stopColor={RAMP_SHADE} stopOpacity={0} />
-          </linearGradient>
-        )}
       </defs>
       <g clipPath={`url(#${clipId})`}>
         {/* the strip floor — the idle tone spans the rep so a pause is band, not a hole. */}
@@ -132,6 +150,9 @@ export function GhostBand({
           fill={PHASE_AXIS_COLOR.idle}
           data-testid="ghost-band-floor"
         />
+        {/* Each run: the muted base at FULL run width, then the pacing fill over the part
+            of it that has been earned. Both square inside the one clip — the fill is a
+            fill, never an inset, so no boundary can open a seam. */}
         {runs.map((run, i) => (
           <g key={i}>
             <rect
@@ -139,22 +160,20 @@ export function GhostBand({
               y={top}
               width={run.width}
               height={height}
+              fill={PHASE_AXIS_BASE_COLOR[run.phase]}
+              data-testid="ghost-band-base"
+            />
+            <rect
+              x={run.left}
+              y={top}
+              width={run.fillWidth}
+              height={height}
               fill={PHASE_AXIS_COLOR[run.phase]}
+              data-testid="ghost-band-fill"
             />
           </g>
         ))}
-        {/* ONE ramp over the finished strip — never per run, or every boundary steps dark. */}
-        {progressRamp && (
-          <rect
-            x={bandLeft}
-            y={top}
-            width={bandW}
-            height={height}
-            fill={`url(#${rampId})`}
-            data-testid="ghost-band-ramp"
-          />
-        )}
-        {/* Labels last so the ramp shades the BAND, never the words. */}
+        {/* Labels last so a fill sweeping past never paints over the word. */}
         {showLabels &&
           runs.map((run, i) => {
             const label = PHASE_LABEL[run.phase]
@@ -166,7 +185,7 @@ export function GhostBand({
                 y={top + height / 2}
                 textAnchor="middle"
                 dominantBaseline="central"
-                fill={labelColor}
+                fill={run.labelTone}
                 fontSize={8}
                 fontWeight={800}
                 letterSpacing={1}

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -38,11 +38,18 @@ export const BAND_H = 16
 /** Gap between the band's near edge and a bloom's baseline. */
 export const BAND_GAP = 4
 
-/** Phase → the word rendered inside its run. `idle` stays unnamed: dead time has no name. */
+/**
+ * Phase → the word rendered inside its run.
+ *
+ * Only the two MOVEMENT phases are named. `idle` never was — dead time has no name — and
+ * `hold` is deliberately unlabelled too: holds are the narrowest runs on the band, so the
+ * word was dropping out at exactly the sizes it mattered, and the runs it did fit were
+ * spending their whole width on it. A hold is legible without the word, from its tone,
+ * its position between the movement phases, and the fact that it fills.
+ */
 const PHASE_LABEL: Partial<Record<PhaseSegment['phase'], string>> = {
   eccentric: 'ECC',
   concentric: 'CON',
-  hold: 'HOLD',
 }
 
 /** Label glyph advance at fontSize 8 + letterSpacing 1, plus a little side padding. */

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -159,9 +159,9 @@ export const LineTreatmentSoft: Story = {
  * the shape the model actually produces — to prove the band closes them: one contiguous
  * strip, boundaries on the phase transitions, the hold reading as band material.
  *
- * The two prescribed pauses are `hold` (deliberate, under load) and take the amber tone;
- * the trailing run is `idle` — undirected dead time after the rep — and stays grey. That
- * contrast is the point of the story: amber vs grey is hold vs nothing.
+ * The two prescribed pauses are `hold` (deliberate, under load); the trailing run is
+ * `idle` — undirected dead time after the rep. Both sit in the grey family, separated by
+ * VALUE and by the fact that a hold paces and idle never does.
  */
 const PAUSED_SEGMENTS: PhaseSegment[] = [
   { phase: 'eccentric', startMs: 0, endMs: 2100 },
@@ -171,26 +171,32 @@ const PAUSED_SEGMENTS: PhaseSegment[] = [
   { phase: 'idle', startMs: 4690, endMs: 5200 },
 ]
 
+/** Prescribed tempo for the paced variants — [ecc, pauseBottom, con, pauseTop] seconds. */
+const PAUSED_TARGET: [number, number, number, number] = [2.1, 0.7, 1.05, 0.45]
+
 export const PausedRepBand: Story = {
   render: () => {
     const w = 360
     const h = 60
     const bandTop = 22
     const x = (ms: number) => 12 + (ms / 5400) * (w - 20)
+    const Band = (props: { targetTempoSeconds?: [number, number, number, number] }) => (
+      <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
+        <svg width={w} height={h}>
+          <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels {...props} />
+        </svg>
+      </View>
+    )
     return (
       <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 16, alignItems: 'flex-start' }}>
-        {label('PHASE BAND · HOLDS (amber) VS TRAILING IDLE (grey) · FLAT')}
-        <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
-          <svg width={w} height={h}>
-            <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels />
-          </svg>
-        </View>
-        {label('SAME BAND · PROGRESS RAMP (one ramp, no interior steps)')}
-        <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
-          <svg width={w} height={h}>
-            <GhostBand segments={PAUSED_SEGMENTS} x={x} top={bandTop} showLabels progressRamp />
-          </svg>
-        </View>
+        {label('FLAT · no tempo prescribed — nothing to pace against')}
+        <Band />
+        {label('PACED · every phase ON TARGET — fills to the brim, labels green')}
+        <Band targetTempoSeconds={PAUSED_TARGET} />
+        {label('PACED · target DOUBLED — every phase now reads early, half-filled, amber')}
+        <Band targetTempoSeconds={[4.2, 1.4, 2.1, 0.9]} />
+        {label('PACED · target HALVED — every phase overruns, capped full, labels red')}
+        <Band targetTempoSeconds={[1.05, 0.35, 0.52, 0.22]} />
       </View>
     )
   },

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
@@ -4,8 +4,10 @@
  * the mirrored dual: single = one bloom + band; dual = two blooms sharing one band).
  *
  * A WIDE phase-coloured AXIS BAND ({@link GhostBand}) sits at the BOTTOM, filled per the
- * current rep's phase runs (eccentric magenta / concentric cyan / hold amber / idle grey),
- * each sized to its time extent, with the ECC / HOLD / CON labels shown INSIDE it. Velocity is
+ * current rep's phase runs (eccentric magenta / concentric cyan / hold and idle grey),
+ * each sized to its ACTUAL time extent, with the ECC / HOLD / CON labels shown INSIDE it.
+ * Given `targetTempoSeconds` the runs also PACE — muted base, fill earned against the
+ * prescribed phase duration, label toned ahead/on-pace/over. Velocity is
  * drawn as MAGNITUDE blooming UP from just above the band ({@link GhostBloom}) — the current
  * rep SOLID over faded grey GHOSTS of the prior reps. Phase is carried by the band colour
  * beneath the line (no ecc-below / con-above split), so single and dual read the same.
@@ -19,6 +21,7 @@ import { View } from 'react-native'
 import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
 import { GhostBloom, type Pt } from './GhostBloom'
+import type { TempoTuple } from './tempo-pacing'
 import type { RepVelocityCurve } from './fatigue-model'
 
 export interface GhostSparkProps {
@@ -28,13 +31,19 @@ export interface GhostSparkProps {
   /** Plot height in px. Default 172. */
   height?: number
   /**
-   * Shade the phase band with one dark→full ramp so it doubles as a progress bar for the
-   * rep in flight. Default on — see {@link GhostBand.progressRamp}.
+   * Prescribed tempo `[ecc, pauseBottom, con, pauseTop]` seconds — turns on the band's
+   * phase PACING (muted base + earned fill, pacing-toned labels). Omit when nothing was
+   * prescribed: the band then paints flat, which is the honest read.
    */
-  progressRamp?: boolean
+  targetTempoSeconds?: TempoTuple | null
 }
 
-export function GhostSpark({ curves, width, height = 172, progressRamp = true }: GhostSparkProps) {
+export function GhostSpark({
+  curves,
+  width,
+  height = 172,
+  targetTempoSeconds = null,
+}: GhostSparkProps) {
   const w = width
   const h = height
   const padL = 12
@@ -86,7 +95,7 @@ export function GhostSpark({ curves, width, height = 172, progressRamp = true }:
           x={x}
           top={bandTop}
           showLabels
-          progressRamp={progressRamp}
+          targetTempoSeconds={targetTempoSeconds}
         />
       </svg>
     </View>

--- a/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
+++ b/packages/ui/src/components/custom/Fatigue/LiveFatigueCard.tsx
@@ -75,7 +75,12 @@ export function LiveFatigueCard({ model, width = 318, height }: LiveFatigueCardP
 
       <View style={{ flex: 1, minHeight: 16 }} />
 
-      <GhostSpark curves={model.velocityCurves} width={chartW} height={chartH} />
+      <GhostSpark
+        curves={model.velocityCurves}
+        width={chartW}
+        height={chartH}
+        targetTempoSeconds={model.targetTempoSeconds}
+      />
     </Surface>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -31,7 +31,7 @@ export const STATE_LABEL: Record<FatigueVerdictState, string> = {
 
 /**
  * The phase-identity colours for the ghost-spark phase BAND — the TempoDisplay
- * language: eccentric magenta, concentric cyan, hold amber, idle a muted grey.
+ * language: eccentric magenta, concentric cyan, hold and idle in the grey family.
  *
  * The idle grey has to read as BAND MATERIAL (a pause the lifter held), not as a
  * hole in the strip: at charcoal[300] it sat inside the surface-ramp's own value
@@ -39,17 +39,40 @@ export const STATE_LABEL: Record<FatigueVerdictState, string> = {
  * gap. charcoal[200] clears every content plane while staying quieter than the two
  * saturated phase tones, so the band reads contiguous and the phases still lead.
  *
- * `hold` takes amber at ramp step 700 — one step LIGHTER than the two phase tones at
- * 800. The asymmetry is deliberate: holds are the NARROWEST runs on the band (a
- * prescribed top hold is ~280 ms against a ~4.2 s rep, ~18 px at card width), so they
- * drop under the label floor first and the TONE has to carry the read alone. At
- * amber[800] the hold sank toward the idle grey and read as dead time again — the
- * exact confusion this phase was split out to end.
+ * `hold` stays GREY rather than taking a hue of its own. It was briefly amber, which
+ * was wrong for a reason worth recording: the phase-pacing tone (`pacingTone`) uses
+ * warning-amber for "ahead of target", so an amber phase hue collides with the semantic
+ * signal painted on top of it. Phase hues are deliberately non-semantic precisely so
+ * pacing can own success/warning/error. Grey also reads more like a hold — a held
+ * position is an absence of movement, not an event.
+ *
+ * Hold and idle are separated by VALUE rather than hue, plus the `HOLD` label and the
+ * fact that a hold PACES (it has a prescribed duration) while idle never fills:
+ *   unfilled hold  charcoal[300]  — darker than idle
+ *   idle           charcoal[200]
+ *   filled hold    charcoal[100]  — brighter than idle
+ * so a hold reads apart from dead time at any fill level, including the narrow runs
+ * where the label drops out.
  */
 export const PHASE_AXIS_COLOR: Record<SamplePhase, string> = {
   eccentric: primitiveRamps.magenta[800],
   concentric: primitiveRamps.cyan[800],
-  hold: primitiveRamps.amber[700],
+  hold: primitiveColors.charcoal[100],
+  idle: primitiveColors.charcoal[200],
+}
+
+/**
+ * The UNFILLED base a phase sits at before its pacing fill covers it — the same hue,
+ * pulled back. {@link PHASE_AXIS_COLOR} is the FILL, so a phase that runs its full
+ * prescribed duration ends up looking exactly as the band did before pacing existed;
+ * muting is only ever visible where the lifter is UNDER target.
+ *
+ * `idle` has no prescribed duration, never fills, and so its base is its colour.
+ */
+export const PHASE_AXIS_BASE_COLOR: Record<SamplePhase, string> = {
+  eccentric: primitiveRamps.magenta[950],
+  concentric: primitiveRamps.cyan[950],
+  hold: primitiveColors.charcoal[300],
   idle: primitiveColors.charcoal[200],
 }
 

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -76,6 +76,32 @@ export const PHASE_AXIS_BASE_COLOR: Record<SamplePhase, string> = {
   idle: primitiveColors.charcoal[200],
 }
 
+/**
+ * Pacing tones for a label sitting INSIDE the band — ahead / on pace / over.
+ *
+ * These deliberately do NOT use the `status-*` semantic tokens. Those are tuned for text
+ * on a neutral surface; here the text sits on a saturated phase fill, and `status-error`
+ * (red[600]) measures **1.88:1** on the hold fill — below even the large-text floor. The
+ * whole family therefore drops to ramp step **200**, the lightest step at which all three
+ * clear 4.5:1 against every background the band can put behind them:
+ *
+ *   worst-case contrast, over {ecc, con, hold, idle} × {fill, base}
+ *     red[200]    5.63     (was red[600]   1.88 — failed everywhere)
+ *     amber[200]  6.01     (was amber[300] 4.73 — passed)
+ *     green[200]  6.17     (was green[300] 4.45 — marginally failed)
+ *
+ * One step across all three keeps them reading as one family. `PACING_TONE_MIN_CONTRAST`
+ * is asserted in `tempo-pacing.test.ts`, so a future ramp edit cannot quietly regress this.
+ */
+export const PACING_TONE = {
+  ahead: primitiveRamps.amber[200],
+  onPace: primitiveRamps.green[200],
+  over: primitiveRamps.red[200],
+} as const
+
+/** The floor every {@link PACING_TONE} must clear against any band background. */
+export const PACING_TONE_MIN_CONTRAST = 4.5
+
 // --- shared silver/red scheme (ROM chart + ghost-spark line) --------------------
 // One source of truth for the two quality readouts: SILVER when the rep is right,
 // SHADES OF RED when there's an issue. No greens, no ambers — those languages belong

--- a/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
+++ b/packages/ui/src/components/custom/Fatigue/fatigue-tokens.ts
@@ -79,24 +79,31 @@ export const PHASE_AXIS_BASE_COLOR: Record<SamplePhase, string> = {
 /**
  * Pacing tones for a label sitting INSIDE the band — ahead / on pace / over.
  *
- * These deliberately do NOT use the `status-*` semantic tokens. Those are tuned for text
- * on a neutral surface; here the text sits on a saturated phase fill, and `status-error`
- * (red[600]) measures **1.88:1** on the hold fill — below even the large-text floor. The
- * whole family therefore drops to ramp step **200**, the lightest step at which all three
- * clear 4.5:1 against every background the band can put behind them:
+ * Only ECC and CON carry labels, so the backgrounds these must survive are the eccentric
+ * and concentric fills and their muted bases. The binding one is the CONCENTRIC FILL
+ * (cyan[800]) — a mid-dark blue, so a legible tone on it has to stay fairly light.
  *
- *   worst-case contrast, over {ecc, con, hold, idle} × {fill, base}
- *     red[200]    5.63     (was red[600]   1.88 — failed everywhere)
- *     amber[200]  6.01     (was amber[300] 4.73 — passed)
- *     green[200]  6.17     (was green[300] 4.45 — marginally failed)
+ * Ramp step **300** is the DEEPEST step at which all three clear 4.5:1:
  *
- * One step across all three keeps them reading as one family. `PACING_TONE_MIN_CONTRAST`
- * is asserted in `tempo-pacing.test.ts`, so a future ramp edit cannot quietly regress this.
+ *   worst-case contrast over {ecc, con} × {fill, base}   (worst is always conFill)
+ *     red[300]    4.91      red[400] = 3.59 — fails
+ *     amber[300]  5.48      amber[400] = 3.76 — fails
+ *     green[300]  5.16      green[400] = 4.15 — fails
+ *
+ * `over` cannot go deeper than this without losing legibility, which is a property of
+ * small light-on-dark text rather than a choice: the 3:1 large-text allowance needs ~18.7px
+ * bold and these labels are 8px. `status-error` (red[600]) measures 2.18:1 here.
+ *
+ * `ahead` and `onPace` land back on exactly the `status-warning` / `status-success` values;
+ * only `over` has to deviate from the semantic token.
+ *
+ * `PACING_TONE_MIN_CONTRAST` is asserted in `tempo-pacing.test.ts`, so a future ramp edit
+ * cannot quietly regress this.
  */
 export const PACING_TONE = {
-  ahead: primitiveRamps.amber[200],
-  onPace: primitiveRamps.green[200],
-  over: primitiveRamps.red[200],
+  ahead: primitiveRamps.amber[300],
+  onPace: primitiveRamps.green[300],
+  over: primitiveRamps.red[300],
 } as const
 
 /** The floor every {@link PACING_TONE} must clear against any band background. */

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
@@ -7,6 +7,7 @@ import {
   PHASE_AXIS_BASE_COLOR,
 } from './fatigue-tokens'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { primitiveRamps } from '../../../theme/tokens/primitives'
 import type { SamplePhase } from './fatigue-model'
 
 const t = getSemanticColors('dark')
@@ -62,13 +63,17 @@ describe('pacingTone', () => {
 })
 
 describe('pacing tone legibility', () => {
-  // The label sits INSIDE the band, so every phase fill AND every muted base is a possible
-  // backdrop. `status-error` (red[600]) measured 1.88:1 on the hold fill — this is the guard
-  // that stopped that shipping, and that stops a ramp edit reintroducing it.
-  const backgrounds = Object.entries({ ...PHASE_AXIS_COLOR, ...PHASE_AXIS_BASE_COLOR })
+  // Only ECC and CON are labelled, so only those runs can put a colour behind a pacing
+  // tone — each over its fill and its muted base. `GhostBand.test.tsx` pins the fact that
+  // hold and idle stay unlabelled, which is what keeps this narrower set honest.
+  const LABELLED: SamplePhase[] = ['eccentric', 'concentric']
+  const backgrounds = LABELLED.flatMap((p) => [
+    [`${p} fill`, PHASE_AXIS_COLOR[p]] as const,
+    [`${p} base`, PHASE_AXIS_BASE_COLOR[p]] as const,
+  ])
 
   for (const [toneName, tone] of Object.entries(PACING_TONE)) {
-    it(`keeps '${toneName}' legible on every band background`, () => {
+    it(`keeps '${toneName}' legible on every background a label can sit on`, () => {
       for (const [bgName, bg] of backgrounds) {
         const ratio = contrastRatio(tone, bg)
         expect(
@@ -80,10 +85,34 @@ describe('pacing tone legibility', () => {
   }
 
   it('rejects the status-error token the band used to borrow', () => {
-    // Proves the guard above has teeth rather than passing by luck.
-    expect(contrastRatio(t['status-error'], PHASE_AXIS_COLOR.hold)).toBeLessThan(
+    // Proves the guard has teeth rather than passing by luck: red[600] on the concentric
+    // fill is 2.18:1, which is what made the label unreadable in the first place.
+    expect(contrastRatio(t['status-error'], PHASE_AXIS_COLOR.concentric)).toBeLessThan(
       PACING_TONE_MIN_CONTRAST
     )
+  })
+
+  it('sits at the DEEPEST ramp step that still clears the floor', () => {
+    // Guards the other direction — the tones should be as saturated as legibility allows,
+    // so a "make it lighter" edit has to justify itself. Derived from the ramp rather than
+    // hardcoded, so it catches a change in EITHER direction.
+    const STEPS = [100, 200, 300, 400, 500, 600, 700, 800, 900] as const
+    const worstOf = (c: string): number =>
+      Math.min(...backgrounds.map(([, bg]) => contrastRatio(c, bg)))
+
+    const cases = [
+      ['ahead', PACING_TONE.ahead, primitiveRamps.amber],
+      ['onPace', PACING_TONE.onPace, primitiveRamps.green],
+      ['over', PACING_TONE.over, primitiveRamps.red],
+    ] as const
+
+    for (const [name, configured, ramp] of cases) {
+      const deepestPassing = STEPS.filter((s) => worstOf(ramp[s]) >= PACING_TONE_MIN_CONTRAST).pop()
+      expect(
+        configured,
+        `${name}: deepest step clearing ${PACING_TONE_MIN_CONTRAST}:1 is ${deepestPassing}`
+      ).toBe(ramp[deepestPassing!])
+    }
   })
 })
 

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { phaseFillFraction, pacingTone, phaseTargetsMs, ON_TARGET_MS } from './tempo-pacing'
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import type { SamplePhase } from './fatigue-model'
+
+const t = getSemanticColors('dark')
+const TEMPO: [number, number, number, number] = [2.6, 0.4, 0.95, 0.28]
+
+describe('phaseFillFraction', () => {
+  it('is the elapsed share of the target', () => {
+    expect(phaseFillFraction(500, 1000)).toBeCloseTo(0.5, 5)
+  })
+
+  it('CAPS at full so an over-long phase does not overflow its run', () => {
+    expect(phaseFillFraction(4000, 1000)).toBe(1)
+  })
+
+  it('reads complete when there is no target to pace against', () => {
+    expect(phaseFillFraction(500, null)).toBe(1)
+    expect(phaseFillFraction(500, 0)).toBe(1)
+  })
+})
+
+describe('pacingTone', () => {
+  it('warns while still short of target', () => {
+    expect(pacingTone(500, 2000)).toBe(t['status-warning'])
+  })
+
+  it('succeeds within the on-target window either side', () => {
+    expect(pacingTone(2000, 2000)).toBe(t['status-success'])
+    expect(pacingTone(2000 - ON_TARGET_MS, 2000)).toBe(t['status-success'])
+    expect(pacingTone(2000 + ON_TARGET_MS, 2000)).toBe(t['status-success'])
+  })
+
+  it('errors once past the window', () => {
+    expect(pacingTone(2000 + ON_TARGET_MS + 1, 2000)).toBe(t['status-error'])
+  })
+
+  it('stays neutral with no target', () => {
+    expect(pacingTone(500, null)).toBe(t['text-primary'])
+  })
+})
+
+describe('phaseTargetsMs', () => {
+  it('maps a hold to BOTTOM before the concentric and TOP after it', () => {
+    const phases: SamplePhase[] = ['eccentric', 'hold', 'concentric', 'hold']
+    expect(phaseTargetsMs(phases, TEMPO)).toEqual([2600, 400, 950, 280])
+  })
+
+  it('gives idle no target — dead time never paces', () => {
+    const phases: SamplePhase[] = ['eccentric', 'idle', 'concentric']
+    expect(phaseTargetsMs(phases, TEMPO)[1]).toBeNull()
+  })
+
+  it('targets nothing at all when no tempo is prescribed', () => {
+    const phases: SamplePhase[] = ['eccentric', 'hold', 'concentric']
+    expect(phaseTargetsMs(phases, null)).toEqual([null, null, null])
+  })
+
+  it('treats a rep that opens on the concentric as having a TOP hold after it', () => {
+    const phases: SamplePhase[] = ['concentric', 'hold']
+    expect(phaseTargetsMs(phases, TEMPO)).toEqual([950, 280])
+  })
+})

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
@@ -1,10 +1,30 @@
 import { describe, it, expect } from 'vitest'
 import { phaseFillFraction, pacingTone, phaseTargetsMs, ON_TARGET_MS } from './tempo-pacing'
+import {
+  PACING_TONE,
+  PACING_TONE_MIN_CONTRAST,
+  PHASE_AXIS_COLOR,
+  PHASE_AXIS_BASE_COLOR,
+} from './fatigue-tokens'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import type { SamplePhase } from './fatigue-model'
 
 const t = getSemanticColors('dark')
 const TEMPO: [number, number, number, number] = [2.6, 0.4, 0.95, 0.28]
+
+/** WCAG 2.1 relative luminance / contrast ratio. */
+function contrastRatio(a: string, b: string): number {
+  const lum = (hex: string): number => {
+    const h = hex.replace('#', '')
+    const chan = [0, 2, 4].map((i) => {
+      const c = parseInt(h.slice(i, i + 2), 16) / 255
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+    })
+    return 0.2126 * chan[0] + 0.7152 * chan[1] + 0.0722 * chan[2]
+  }
+  const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
 
 describe('phaseFillFraction', () => {
   it('is the elapsed share of the target', () => {
@@ -22,22 +42,48 @@ describe('phaseFillFraction', () => {
 })
 
 describe('pacingTone', () => {
-  it('warns while still short of target', () => {
-    expect(pacingTone(500, 2000)).toBe(t['status-warning'])
+  it('reads AHEAD while still short of target', () => {
+    expect(pacingTone(500, 2000)).toBe(PACING_TONE.ahead)
   })
 
-  it('succeeds within the on-target window either side', () => {
-    expect(pacingTone(2000, 2000)).toBe(t['status-success'])
-    expect(pacingTone(2000 - ON_TARGET_MS, 2000)).toBe(t['status-success'])
-    expect(pacingTone(2000 + ON_TARGET_MS, 2000)).toBe(t['status-success'])
+  it('reads ON PACE within the on-target window either side', () => {
+    expect(pacingTone(2000, 2000)).toBe(PACING_TONE.onPace)
+    expect(pacingTone(2000 - ON_TARGET_MS, 2000)).toBe(PACING_TONE.onPace)
+    expect(pacingTone(2000 + ON_TARGET_MS, 2000)).toBe(PACING_TONE.onPace)
   })
 
-  it('errors once past the window', () => {
-    expect(pacingTone(2000 + ON_TARGET_MS + 1, 2000)).toBe(t['status-error'])
+  it('reads OVER once past the window', () => {
+    expect(pacingTone(2000 + ON_TARGET_MS + 1, 2000)).toBe(PACING_TONE.over)
   })
 
   it('stays neutral with no target', () => {
     expect(pacingTone(500, null)).toBe(t['text-primary'])
+  })
+})
+
+describe('pacing tone legibility', () => {
+  // The label sits INSIDE the band, so every phase fill AND every muted base is a possible
+  // backdrop. `status-error` (red[600]) measured 1.88:1 on the hold fill — this is the guard
+  // that stopped that shipping, and that stops a ramp edit reintroducing it.
+  const backgrounds = Object.entries({ ...PHASE_AXIS_COLOR, ...PHASE_AXIS_BASE_COLOR })
+
+  for (const [toneName, tone] of Object.entries(PACING_TONE)) {
+    it(`keeps '${toneName}' legible on every band background`, () => {
+      for (const [bgName, bg] of backgrounds) {
+        const ratio = contrastRatio(tone, bg)
+        expect(
+          ratio,
+          `${toneName} (${tone}) on ${bgName} (${bg}) = ${ratio.toFixed(2)}:1`
+        ).toBeGreaterThanOrEqual(PACING_TONE_MIN_CONTRAST)
+      }
+    })
+  }
+
+  it('rejects the status-error token the band used to borrow', () => {
+    // Proves the guard above has teeth rather than passing by luck.
+    expect(contrastRatio(t['status-error'], PHASE_AXIS_COLOR.hold)).toBeLessThan(
+      PACING_TONE_MIN_CONTRAST
+    )
   })
 })
 

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
@@ -1,0 +1,80 @@
+// Font mapping: font-heading=Space Grotesk, font-body=Nunito Sans (UI), font-sans=Inter (body)
+/**
+ * Tempo PACING — how far through its prescribed duration a phase has run, and the
+ * semantic tone that says whether the lifter is ahead, on pace, or over.
+ *
+ * The rule this encodes (borrowed from `TempoDisplay`, which established it): the phase
+ * HUE carries phase identity and is deliberately non-semantic, so the pacing tone is free
+ * to use success/warning/error without the two colliding. Anything that paints a phase
+ * should take its identity colour from `PHASE_AXIS_COLOR` and its pacing colour from here.
+ *
+ * ⚠️ `TempoDisplay` currently carries its own private copy of this logic
+ * (`getTempoFillPct` / `activeNumberTone`). The two agree today and this module is the
+ * canonical one; migrating TempoDisplay onto it is deliberately left out of the change
+ * that introduced this file, so its rendering is untouched.
+ */
+import { getSemanticColors } from '../../../theme/tokens/semantic'
+import type { SamplePhase } from './fatigue-model'
+
+const t = getSemanticColors('dark')
+
+/** ± this window (ms) around the target still counts as on pace. Matches TempoDisplay. */
+export const ON_TARGET_MS = 100
+
+/** The canonical tempo tuple order: `[ecc, pauseBottom, con, pauseTop]`, seconds. */
+export type TempoTuple = [number, number, number, number]
+
+/**
+ * How far a phase has run toward its prescribed duration, 0..1, CAPPED at 1.
+ *
+ * The cap is what makes an over-long phase read correctly: the fill stops at full and the
+ * TONE takes over to say "you are past target". Without a target there is nothing to pace
+ * against, so the phase reads complete rather than perpetually empty.
+ */
+export function phaseFillFraction(elapsedMs: number, targetMs: number | null): number {
+  if (targetMs == null || targetMs <= 0) return 1
+  return Math.min(1, Math.max(0, elapsedMs / targetMs))
+}
+
+/**
+ * Pacing tone for a phase's LABEL: still short of target → warning; within ±100 ms →
+ * success; past target → error. Keyed on time REMAINING, so it reads the same whether the
+ * phase is in flight or finished.
+ */
+export function pacingTone(elapsedMs: number, targetMs: number | null): string {
+  if (targetMs == null || targetMs <= 0) return t['text-primary']
+  const remainingMs = targetMs - elapsedMs
+  if (remainingMs > ON_TARGET_MS) return t['status-warning']
+  if (remainingMs >= -ON_TARGET_MS) return t['status-success']
+  return t['status-error']
+}
+
+/**
+ * Target duration (ms) for each phase run of a rep, in stream order.
+ *
+ * A `hold` maps to `pauseBottom` or `pauseTop` by POSITION, not by name: the tuple
+ * distinguishes the two but the sample phase does not, so the first hold of a rep is the
+ * bottom and a hold after the concentric is the top. Phases with no prescribed duration
+ * (`idle` — undirected dead time) get `null` and never pace.
+ */
+export function phaseTargetsMs(
+  phases: readonly SamplePhase[],
+  tempo: TempoTuple | null
+): Array<number | null> {
+  if (tempo == null) return phases.map(() => null)
+  const [eccS, pauseBottomS, conS, pauseTopS] = tempo
+  let seenConcentric = false
+  return phases.map((phase) => {
+    switch (phase) {
+      case 'eccentric':
+        return eccS * 1000
+      case 'concentric':
+        seenConcentric = true
+        return conS * 1000
+      case 'hold':
+        return (seenConcentric ? pauseTopS : pauseBottomS) * 1000
+      default:
+        return null
+    }
+  })
+}

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
@@ -14,6 +14,7 @@
  * that introduced this file, so its rendering is untouched.
  */
 import { getSemanticColors } from '../../../theme/tokens/semantic'
+import { PACING_TONE } from './fatigue-tokens'
 import type { SamplePhase } from './fatigue-model'
 
 const t = getSemanticColors('dark')
@@ -37,16 +38,19 @@ export function phaseFillFraction(elapsedMs: number, targetMs: number | null): n
 }
 
 /**
- * Pacing tone for a phase's LABEL: still short of target → warning; within ±100 ms →
- * success; past target → error. Keyed on time REMAINING, so it reads the same whether the
- * phase is in flight or finished.
+ * Pacing tone for a phase's LABEL: still short of target → ahead; within ±100 ms → on pace;
+ * past target → over. Keyed on time REMAINING, so it reads the same whether the phase is in
+ * flight or finished.
+ *
+ * Takes {@link PACING_TONE} rather than the `status-*` semantic tokens — the label sits on a
+ * saturated phase fill, where `status-error` measures 1.88:1. See the token's note.
  */
 export function pacingTone(elapsedMs: number, targetMs: number | null): string {
   if (targetMs == null || targetMs <= 0) return t['text-primary']
   const remainingMs = targetMs - elapsedMs
-  if (remainingMs > ON_TARGET_MS) return t['status-warning']
-  if (remainingMs >= -ON_TARGET_MS) return t['status-success']
-  return t['status-error']
+  if (remainingMs > ON_TARGET_MS) return PACING_TONE.ahead
+  if (remainingMs >= -ON_TARGET_MS) return PACING_TONE.onPace
+  return PACING_TONE.over
 }
 
 /**


### PR DESCRIPTION
The band said what phase you were in and how long it took, but never whether that was the time asked for.

Given a target tempo, each run now paints a **muted base** with a brighter **fill** grown across `elapsed / target` of its own width (capped at full), and its **label takes the pacing tone** — ahead warns, on pace succeeds, over errors.

## The geometry does not change

Runs keep their actual-time positions and widths. The internal boundaries still land under the sparkline's phase transitions, so **VW-85 row 5 still holds**. Pacing is a fill *inside* the existing bars, never a re-layout of them — a test asserts exactly this (`leaves the geometry alone when pacing turns on`).

## How it reads

The two encodings work together:

| | run width | fill | label |
|---|---|---|---|
| slow phase | wide | to the brim (capped) | red |
| on pace | as prescribed | to the brim | green |
| fast phase | narrow | partly filled | amber |

A phase that ran exactly its prescribed time looks **precisely as the band did before pacing existed** — `PHASE_AXIS_COLOR` became the FILL and a new `PHASE_AXIS_BASE_COLOR` is the muted base, so muting is only ever visible where the lifter is under target. No regression to the merged look.

Pacing needs **no clock**: a run's `endMs - startMs` IS its elapsed time, and the in-flight run's `endMs` is already "now". Pure render from data `GhostBand` already receives.

## Two reversals, both recorded in REJECTED.md

- **The whole-band gradient ramp is replaced.** It encoded progress as shading over the extent already drawn — a second encoding of what the run's WIDTH already says, and one with no notion of a target, so it could never say fast or slow.
- **`hold` returns to the grey family.** Amber was a genuine conflict, not a taste call: the pacing tone uses warning-**amber** for "ahead of target", so an amber phase hue collides with the semantic signal drawn on top of it. `TempoDisplay` had already written the governing rule down — phase hues are "deliberately NON-semantic ... so the phase hue never collides with the semantic pacing tones." Hold and idle now separate by VALUE (unfilled `charcoal[300]` < idle `charcoal[200]` < filled `charcoal[100]`), by the `HOLD` label, and by the fact that a hold paces while idle never fills.

The `hold` SamplePhase split itself survives and is load-bearing — it's what lets a hold carry a label, a target and a fill at all.

## Scope

`TempoDisplay` is **untouched** by request. `tempo-pacing.ts` is the canonical home for this logic and notes TempoDisplay's private copy (`getTempoFillPct` / `activeNumberTone`) as the migration to make later — the two agree today.

## Verification

- typecheck ✅ · lint 0 errors ✅ · prettier ✅ · **2809 tests pass**
- 4 mutations checked, each failing only its intended test: removing the fill cap, mapping every hold to `pauseBottom`, ignoring pacing in the fill width, and flattening the label tone.

## Ordering

Stacks conceptually on #144 (panel state consistency) but branches from `main` and touches different files — either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)