### PR TITLE
Lock Storybook to one port and make conflicts loud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,28 @@ Port 6006 is **locked**. `pnpm storybook` runs a launcher that owns the policy:
 | ------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `pnpm storybook`          | Locked port. Reuses ours; **kills a foreign server squatting 6006**; refuses if a non-Storybook holds it. |
 | `pnpm storybook:isolated` | A private port from 6100–6199. Use when you _expect_ to run beside another instance.                      |
-| `pnpm storybook:ports`    | Inventory only — what is listening, whose it is, what is orphaned.                                        |
-| `pnpm storybook:reap`     | Kill **orphaned** servers (worktree deleted, process still running), then re-list.                        |
-| `--reap-all`              | Also kill live foreign/duplicate servers. Not the default: it can kill a parallel agent's instance.       |
+| `pnpm storybook:ports`    | Inventory only — every server, categorised, with the flag that would clear it.                            |
+| `pnpm storybook:reap`     | Kill **orphans** (the default scope), then re-list.                                                       |
+| `pnpm storybook:reap:all` | Kill orphans + foreign + dupes.                                                                           |
 | `--restart`               | Replace our own server on the locked port.                                                                |
+
+`pnpm storybook:ports` categorises every server, and the categories **are** the reap
+scopes — so the inventory doubles as a menu of what each option would kill:
+
+| category  | meaning                               | cleared by         |
+| --------- | ------------------------------------- | ------------------ |
+| `locked`  | ours, on 6006                         | `--restart`        |
+| `orphan`  | its worktree no longer exists on disk | `--reap` (default) |
+| `foreign` | a live server rooted in another tree  | `--reap=foreign`   |
+| `dupe`    | ours, off the locked port             | `--reap=dupes`     |
+| `other`   | not identifiable as Storybook         | never touched      |
+
+Scopes combine: `--reap=foreign,dupes`. `--reap=all` is everything reapable.
+
+**Orphans are the default because they are the only category that is unambiguously
+dead** — nobody can be using a server whose tree has been deleted. A live `foreign`
+server may belong to a parallel agent, and a `dupe` may be a deliberate `--isolated`
+instance, so both are opt-in.
 
 Every launch passes `--exact-port`, so a port conflict is a **loud failure** instead of a
 silent move. Proof: on a busy port, `--exact-port` refuses to start; without it, Storybook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,34 @@ Cross-platform React + React Native design system built on Gluestack UI, NativeW
 - **Node**: Use `pnpm` (v9.15.0) for all package management
 - **Build**: `pnpm build` (tsup, outputs ESM + CJS + DTS to `dist/`)
 - **Test**: `pnpm test` (Vitest + Testing Library + jest-axe)
-- **Storybook**: `pnpm storybook` (Storybook 10 on port 6006)
+- **Storybook**: `pnpm storybook` (Storybook 10, locked to port 6006 — see below)
 - **Lint**: `pnpm lint` (ESLint 9)
+
+### Storybook ports — read this before screenshotting anything
+
+`storybook dev` **auto-increments off a busy port**. A launch on a port you believed was
+free silently lands on a _different worktree's_ server, and every screenshot taken
+afterwards is plausible and wrong. This has already invalidated a VW-85 evidence set, and
+verifying `index.json` does not catch it — `importPath` is relative and identical across
+worktrees.
+
+Port 6006 is **locked**. `pnpm storybook` runs a launcher that owns the policy:
+
+| command                   | behaviour                                                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `pnpm storybook`          | Locked port. Reuses ours; **kills a foreign server squatting 6006**; refuses if a non-Storybook holds it. |
+| `pnpm storybook:isolated` | A private port from 6100–6199. Use when you _expect_ to run beside another instance.                      |
+| `pnpm storybook:ports`    | Inventory only — what is listening, whose it is, what is orphaned.                                        |
+| `pnpm storybook:reap`     | Kill **orphaned** servers (worktree deleted, process still running), then re-list.                        |
+| `--reap-all`              | Also kill live foreign/duplicate servers. Not the default: it can kill a parallel agent's instance.       |
+| `--restart`               | Replace our own server on the locked port.                                                                |
+
+Every launch passes `--exact-port`, so a port conflict is a **loud failure** instead of a
+silent move. Proof: on a busy port, `--exact-port` refuses to start; without it, Storybook
+quietly comes up one port over.
+
+**Verify provenance by something unique to the tree you meant to shoot** — a story that
+only exists there, or a rendered detail only that commit produces. Never by story IDs alone.
 
 ## Architecture
 
@@ -18,13 +44,13 @@ Cross-platform React + React Native design system built on Gluestack UI, NativeW
 
 All components use React Native primitives - never HTML elements directly:
 
-| Use | Not |
-|-----|-----|
-| `View` | `div` |
-| `Text` | `span`, `p` |
-| `Pressable` | `button` |
-| `TextInput` | `input` |
-| `Image` | `img` |
+| Use          | Not              |
+| ------------ | ---------------- |
+| `View`       | `div`            |
+| `Text`       | `span`, `p`      |
+| `Pressable`  | `button`         |
+| `TextInput`  | `input`          |
+| `Image`      | `img`            |
 | `ScrollView` | scrollable `div` |
 
 ### Styling: NativeWind v4 + Tailwind CSS
@@ -69,16 +95,16 @@ Custom components go in `src/components/custom/` with PascalCase directories.
 
 ### Props Conventions
 
-| Prop | Type | Notes |
-|------|------|-------|
-| `variant` | `'solid' \| 'outline' \| 'ghost' \| 'link'` | Visual style |
-| `size` | `'sm' \| 'md' \| 'lg'` | Size variant |
-| `color` | `'primary' \| 'secondary' \| 'success' \| 'error' \| 'warning' \| 'info'` | Color scheme |
-| `isDisabled` | `boolean` | Not `disabled` |
-| `isLoading` | `boolean` | Not `loading` |
-| `isSelected` | `boolean` | Not `selected` |
-| `onPress` | `() => void` | Not `onClick` (React Native convention) |
-| `className` | `string` | Tailwind overrides via cn() |
+| Prop         | Type                                                                      | Notes                                   |
+| ------------ | ------------------------------------------------------------------------- | --------------------------------------- |
+| `variant`    | `'solid' \| 'outline' \| 'ghost' \| 'link'`                               | Visual style                            |
+| `size`       | `'sm' \| 'md' \| 'lg'`                                                    | Size variant                            |
+| `color`      | `'primary' \| 'secondary' \| 'success' \| 'error' \| 'warning' \| 'info'` | Color scheme                            |
+| `isDisabled` | `boolean`                                                                 | Not `disabled`                          |
+| `isLoading`  | `boolean`                                                                 | Not `loading`                           |
+| `isSelected` | `boolean`                                                                 | Not `selected`                          |
+| `onPress`    | `() => void`                                                              | Not `onClick` (React Native convention) |
+| `className`  | `string`                                                                  | Tailwind overrides via cn()             |
 
 ### Accessibility Requirements
 
@@ -90,33 +116,37 @@ Custom components go in `src/components/custom/` with PascalCase directories.
 ### Testing Pattern
 
 ```tsx
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
 
-expect.extend(toHaveNoViolations)
+expect.extend(toHaveNoViolations);
 
-describe('ComponentName', () => {
-  it('renders correctly', () => { /* ... */ })
-  it('has no accessibility violations', async () => {
-    const { container } = render(<Component />)
-    expect(await axe(container)).toHaveNoViolations()
-  })
-})
+describe("ComponentName", () => {
+  it("renders correctly", () => {
+    /* ... */
+  });
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Component />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
 ```
 
 ### Storybook Pattern
 
 ```tsx
-import type { Meta, StoryObj } from '@storybook/react-vite'  // NOT @storybook/react
+import type { Meta, StoryObj } from "@storybook/react-vite"; // NOT @storybook/react
 
 const meta: Meta<typeof Component> = {
-  title: 'Components/ComponentName',  // or 'Custom/Name', 'Design Tokens/Name'
+  title: "Components/ComponentName", // or 'Custom/Name', 'Design Tokens/Name'
   component: Component,
-  tags: ['autodocs'],
-  argTypes: { /* controls */ },
-}
-export default meta
-type Story = StoryObj<typeof Component>
+  tags: ["autodocs"],
+  argTypes: {
+    /* controls */
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Component>;
 ```
 
 **Critical**: Storybook uses `@storybook/react-native-web-vite` with `jsxImportSource: 'nativewind'`. Without this NativeWind classes won't work.
@@ -130,21 +160,22 @@ type Story = StoryObj<typeof Component>
 
 ### Token Categories
 
-| Category | Pattern | Example Classes |
-|----------|---------|----------------|
-| Brand | `brand-{role}` | `bg-brand-primary`, `text-brand-secondary` |
-| Status | `status-{type}` | `bg-status-success`, `text-status-error` |
-| Text | `text-{role}` | `text-text-primary`, `text-text-secondary` |
-| Surface | `surface-{level}` | `bg-surface-base`, `bg-surface-elevated` |
-| Background | `background-{role}` | `bg-background-base`, `bg-background-default` |
-| Border | `border-{strength}` | `border-border-default`, `border-border-subtle` |
+| Category    | Pattern               | Example Classes                                              |
+| ----------- | --------------------- | ------------------------------------------------------------ |
+| Brand       | `brand-{role}`        | `bg-brand-primary`, `text-brand-secondary`                   |
+| Status      | `status-{type}`       | `bg-status-success`, `text-status-error`                     |
+| Text        | `text-{role}`         | `text-text-primary`, `text-text-secondary`                   |
+| Surface     | `surface-{level}`     | `bg-surface-base`, `bg-surface-elevated`                     |
+| Background  | `background-{role}`   | `bg-background-base`, `bg-background-default`                |
+| Border      | `border-{strength}`   | `border-border-default`, `border-border-subtle`              |
 | Interactive | `interactive-{state}` | `hover:bg-interactive-hover`, `focus:ring-interactive-focus` |
-| Result | `result-{outcome}` | `text-result-improve`, `text-result-degrade` |
-| Data | `data-{n}` | `bg-data-1` through `bg-data-10` |
+| Result      | `result-{outcome}`    | `text-result-improve`, `text-result-degrade`                 |
+| Data        | `data-{n}`            | `bg-data-1` through `bg-data-10`                             |
 
 ### Adding New Tokens
 
 Four files must be updated in order:
+
 1. `primitives.ts` - Add raw value (if new)
 2. `semantic.ts` - Add semantic mapping (both dark and light)
 3. `global.css` - Add CSS custom property (both `:root` and `.light`)
@@ -153,6 +184,7 @@ Four files must be updated in order:
 ### Elevation System
 
 Levels -2 to +5 with calculated surface colors and shadows:
+
 - **-2, -1**: Inset (inputs, pressed states)
 - **0**: Base level
 - **1-3**: Cards, panels
@@ -160,31 +192,37 @@ Levels -2 to +5 with calculated surface colors and shadows:
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `packages/ui/src/index.ts` | Main barrel export |
-| `packages/ui/src/theme/global.css` | CSS custom properties + Tailwind imports |
-| `packages/ui/src/theme/tokens/primitives.ts` | Raw color/spacing values |
-| `packages/ui/src/theme/tokens/semantic.ts` | Semantic token definitions |
-| `packages/ui/src/theme/elevation.ts` | Elevation system with shadow math |
-| `packages/ui/src/utils/cn.ts` | Tailwind class merge utility |
-| `packages/ui/tailwind.config.js` | Tailwind + NativeWind configuration |
-| `packages/ui/tsup.config.ts` | Build configuration |
-| `packages/ui/vitest.config.ts` | Test configuration |
-| `packages/ui/.storybook/main.ts` | Storybook config (jsxImportSource critical) |
+| File                                         | Purpose                                     |
+| -------------------------------------------- | ------------------------------------------- |
+| `packages/ui/src/index.ts`                   | Main barrel export                          |
+| `packages/ui/src/theme/global.css`           | CSS custom properties + Tailwind imports    |
+| `packages/ui/src/theme/tokens/primitives.ts` | Raw color/spacing values                    |
+| `packages/ui/src/theme/tokens/semantic.ts`   | Semantic token definitions                  |
+| `packages/ui/src/theme/elevation.ts`         | Elevation system with shadow math           |
+| `packages/ui/src/utils/cn.ts`                | Tailwind class merge utility                |
+| `packages/ui/tailwind.config.js`             | Tailwind + NativeWind configuration         |
+| `packages/ui/tsup.config.ts`                 | Build configuration                         |
+| `packages/ui/vitest.config.ts`               | Test configuration                          |
+| `packages/ui/.storybook/main.ts`             | Storybook config (jsxImportSource critical) |
 
 ## Exports
 
 ```tsx
 // Components + theme + utils
-import { Button, ButtonText, Card, Typography, cn } from '@titan-design/react-ui'
+import {
+  Button,
+  ButtonText,
+  Card,
+  Typography,
+  cn,
+} from "@titan-design/react-ui";
 
 // Theme only (subpath export)
-import { semanticColorsDark, elevation } from '@titan-design/react-ui/theme'
+import { semanticColorsDark, elevation } from "@titan-design/react-ui/theme";
 
 // CSS (required by consumers)
-import '@titan-design/react-ui/theme/global.css'
+import "@titan-design/react-ui/theme/global.css";
 
 // Tailwind config (for extending in consuming apps)
-const tailwindConfig = require('@titan-design/react-ui/tailwind.config.js')
+const tailwindConfig = require("@titan-design/react-ui/tailwind.config.js");
 ```

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -77,7 +77,7 @@
     "storybook:isolated": "node scripts/storybook-launch.mjs --isolated",
     "storybook:ports": "node scripts/storybook-launch.mjs --list",
     "storybook:reap": "node scripts/storybook-launch.mjs --reap --list",
-    "storybook:raw": "storybook dev -p 6006 --exact-port"
+    "storybook:reap:all": "node scripts/storybook-launch.mjs --reap=all --list"
   },
   "peerDependencies": {
     "nativewind": "^4.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,7 +58,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "node scripts/storybook-launch.mjs",
     "build-storybook": "storybook build",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
@@ -73,7 +73,11 @@
     "test:visual:stories": "playwright test stories.spec.ts",
     "test:visual:stories:update": "playwright test stories.spec.ts --update-snapshots",
     "prepublishOnly": "tsup && vitest --run",
-    "lint:colors:baseline": "node scripts/update-raw-color-baseline.mjs"
+    "lint:colors:baseline": "node scripts/update-raw-color-baseline.mjs",
+    "storybook:isolated": "node scripts/storybook-launch.mjs --isolated",
+    "storybook:ports": "node scripts/storybook-launch.mjs --list",
+    "storybook:reap": "node scripts/storybook-launch.mjs --reap --list",
+    "storybook:raw": "storybook dev -p 6006 --exact-port"
   },
   "peerDependencies": {
     "nativewind": "^4.2.1",

--- a/packages/ui/scripts/storybook-launch.mjs
+++ b/packages/ui/scripts/storybook-launch.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Storybook launcher — one locked port, no silent drift.
+ *
+ * Storybook's `dev` auto-increments off a busy port. That is actively dangerous here:
+ * a launch on a "free" port silently lands on ANOTHER worktree's server, and every
+ * screenshot taken afterwards is plausible and wrong. It cost a VW-85 evidence set.
+ * `--exact-port` turns that into a loud failure, and this script owns the port policy
+ * around it.
+ *
+ *   node scripts/storybook-launch.mjs              # the locked port, reclaiming it
+ *   node scripts/storybook-launch.mjs --isolated   # a private port, for parallel work
+ *   node scripts/storybook-launch.mjs --list       # inventory only, launch nothing
+ *   node scripts/storybook-launch.mjs --restart    # replace our own server on the port
+ *   node scripts/storybook-launch.mjs --reap       # kill ORPHANED servers, then launch
+ *   node scripts/storybook-launch.mjs --reap-all   # also kill live foreign / duplicate ours
+ *
+ * Anything not understood is forwarded to `storybook dev`.
+ */
+import { execFileSync, spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** THE port. Everything non-isolated uses it, so a stale server is a bug, not a fork. */
+const LOCKED_PORT = 6006
+/** Isolated launches allocate here — deliberately clear of the locked port. */
+const ISOLATED_RANGE = [6100, 6199]
+/** Scanned for the inventory. Wide enough to catch Storybook's own auto-increment drift. */
+const SCAN_RANGE = [6000, 6250]
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const argv = process.argv.slice(2)
+const has = (f) => argv.includes(f)
+const FLAGS = ['--isolated', '--list', '--restart', '--reap', '--reap-all']
+const passthrough = argv.filter((a) => !FLAGS.includes(a))
+
+const sh = (cmd, args) => {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch {
+    return ''
+  }
+}
+
+/** Every listening TCP socket, as `{ port, pid }`. One lsof call, not one per port. */
+function listeners() {
+  const out = sh('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-Fpn'])
+  const found = []
+  let pid = null
+  for (const line of out.split('\n')) {
+    if (line.startsWith('p')) pid = Number(line.slice(1))
+    else if (line.startsWith('n')) {
+      const m = line.match(/:(\d+)$/)
+      if (m && pid) found.push({ port: Number(m[1]), pid })
+    }
+  }
+  return found
+}
+
+/** A process's working directory — the only reliable way to tell WHICH worktree it serves. */
+function cwdOf(pid) {
+  const out = sh('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'])
+  const line = out.split('\n').find((l) => l.startsWith('n'))
+  return line ? line.slice(1) : null
+}
+
+const commandOf = (pid) => sh('ps', ['-o', 'command=', '-p', String(pid)]).trim()
+const isStorybook = (cmd) => /storybook|\bsb\b/i.test(cmd)
+
+/** What is listening in the scan range, and whose it is. */
+function inventory() {
+  const [lo, hi] = SCAN_RANGE
+  const seen = new Map()
+  for (const { port, pid } of listeners()) {
+    if (port < lo || port > hi) continue
+    if (seen.has(port)) continue
+    const command = commandOf(pid)
+    seen.set(port, {
+      port,
+      pid,
+      command,
+      cwd: cwdOf(pid),
+      storybook: isStorybook(command),
+    })
+  }
+  return [...seen.values()].sort((a, b) => a.port - b.port)
+}
+
+const isOurs = (entry) => entry.cwd != null && entry.cwd.startsWith(PKG_ROOT)
+
+/**
+ * The server is still running but the tree it serves is GONE — a worktree was deleted
+ * out from under it. Unambiguously dead, and the safe default for reaping: nobody can
+ * be using it, and it is exactly what squats ports and poisons screenshots.
+ */
+const isOrphan = (entry) => entry.storybook && entry.cwd != null && !existsSync(entry.cwd)
+
+function printInventory(entries) {
+  if (entries.length === 0) {
+    console.log(`\n  Nothing listening in ${SCAN_RANGE[0]}-${SCAN_RANGE[1]}.\n`)
+    return
+  }
+  console.log(`\n  Listening in ${SCAN_RANGE[0]}-${SCAN_RANGE[1]}:\n`)
+  console.log('  PORT   PID     KIND        STATE     ROOT')
+  for (const e of entries) {
+    const kind = e.storybook ? (isOurs(e) ? 'storybook*' : 'storybook') : 'other'
+    const state = isOrphan(e) ? 'ORPHAN' : e.port === LOCKED_PORT ? 'locked' : 'live'
+    const root = e.cwd ?? '(unknown)'
+    console.log(
+      `  ${String(e.port).padEnd(6)} ${String(e.pid).padEnd(7)} ${kind.padEnd(11)} ${state.padEnd(9)} ${root}`
+    )
+  }
+  const orphans = entries.filter(isOrphan).length
+  console.log('\n  * = this package.  ORPHAN = its worktree no longer exists on disk.')
+  if (orphans) console.log(`  ${orphans} orphaned server(s) — clear with --reap.`)
+  console.log('')
+}
+
+/** Kill the dead (and, with --reap-all, the merely redundant). Returns ports freed. */
+function reap(entries, all) {
+  const targets = entries.filter((e) => {
+    if (!e.storybook) return false // never touch what we cannot identify
+    if (isOrphan(e)) return true
+    if (!all) return false
+    return e.port !== LOCKED_PORT // --reap-all: every duplicate except the locked port
+  })
+  if (targets.length === 0) {
+    console.log('  Nothing to reap.\n')
+    return []
+  }
+  for (const e of targets) {
+    killPid(e.pid, isOrphan(e) ? `orphaned — ${e.cwd} is gone` : `duplicate on ${e.port}`)
+  }
+  console.log('')
+  return targets.map((e) => e.port)
+}
+
+function killPid(pid, why) {
+  console.log(`  Reclaiming: killing pid ${pid} — ${why}`)
+  sh('kill', [String(pid)])
+  // Give it a moment to release the socket before we bind.
+  const deadline = Date.now() + 5000
+  while (Date.now() < deadline) {
+    if (!listeners().some((l) => l.pid === pid)) return true
+    execFileSync('sleep', ['0.2'])
+  }
+  console.log(`  pid ${pid} did not exit; sending SIGKILL`)
+  sh('kill', ['-9', String(pid)])
+  return true
+}
+
+function pickIsolatedPort(entries) {
+  const busy = new Set(entries.map((e) => e.port))
+  for (let p = ISOLATED_RANGE[0]; p <= ISOLATED_RANGE[1]; p++) if (!busy.has(p)) return p
+  console.error(`\n  No free port in ${ISOLATED_RANGE.join('-')}. Clean some up.\n`)
+  process.exit(1)
+}
+
+/**
+ * The local binary, not bare `storybook` — a bare name only resolves when a package
+ * runner has put `node_modules/.bin` on PATH, and this script is meant to be runnable
+ * directly (`node scripts/storybook-launch.mjs`) too.
+ */
+function storybookBin() {
+  const local = resolve(PKG_ROOT, 'node_modules/.bin/storybook')
+  if (existsSync(local)) return local
+  const hoisted = resolve(PKG_ROOT, '../../node_modules/.bin/storybook')
+  return existsSync(hoisted) ? hoisted : 'storybook'
+}
+
+function launch(port) {
+  console.log(`  Starting Storybook on ${port} (--exact-port: it fails rather than drifts)\n`)
+  const args = ['dev', '-p', String(port), '--exact-port', ...passthrough]
+  const child = spawn(storybookBin(), args, { stdio: 'inherit', cwd: PKG_ROOT })
+  child.on('error', (err) => {
+    console.error(`\n  Could not start Storybook: ${err.message}\n`)
+    process.exit(1)
+  })
+  child.on('exit', (code) => process.exit(code ?? 0))
+}
+
+// --- main --------------------------------------------------------------------
+
+let entries = inventory()
+printInventory(entries)
+
+// Reap BEFORE the --list exit, so `--reap --list` reaps and then shows the result.
+if (has('--reap') || has('--reap-all')) {
+  const freed = reap(entries, has('--reap-all'))
+  if (freed.length > 0) {
+    entries = inventory() // re-read: ports we just freed are now available
+    console.log('  After reaping:')
+    printInventory(entries)
+  }
+}
+
+if (has('--list')) process.exit(0)
+
+if (has('--isolated')) {
+  const port = pickIsolatedPort(entries)
+  console.log(`  ISOLATED launch — this port is yours alone.`)
+  console.log(`  http://127.0.0.1:${port}\n`)
+  launch(port)
+} else {
+  const holder = entries.find((e) => e.port === LOCKED_PORT)
+
+  if (!holder) {
+    launch(LOCKED_PORT)
+  } else if (!holder.storybook) {
+    // Never kill something we cannot identify.
+    console.error(`  Port ${LOCKED_PORT} is held by a NON-Storybook process (pid ${holder.pid}):`)
+    console.error(`    ${holder.command}`)
+    console.error(`\n  Refusing to kill it. Free the port, or use --isolated.\n`)
+    process.exit(1)
+  } else if (isOurs(holder) && !has('--restart')) {
+    console.log(`  Storybook for THIS package is already on ${LOCKED_PORT} (pid ${holder.pid}).`)
+    console.log(`  http://127.0.0.1:${LOCKED_PORT}`)
+    console.log(`\n  Use --restart to replace it, or --isolated for a second instance.\n`)
+    process.exit(0)
+  } else {
+    const why = isOurs(holder)
+      ? 'ours, --restart requested'
+      : `STALE — serving ${holder.cwd ?? 'an unknown root'}, not this package`
+    if (!isOurs(holder)) {
+      console.log(`  ⚠ The locked port is held by a DIFFERENT tree. This is the failure mode`)
+      console.log(`    that produces plausible screenshots of the wrong code.`)
+    }
+    killPid(holder.pid, why)
+    launch(LOCKED_PORT)
+  }
+}

--- a/packages/ui/scripts/storybook-launch.mjs
+++ b/packages/ui/scripts/storybook-launch.mjs
@@ -36,6 +36,11 @@ const has = (f) => argv.includes(f)
 const FLAGS = ['--isolated', '--list', '--restart', '--reap', '--reap-all']
 const passthrough = argv.filter((a) => !FLAGS.includes(a))
 
+/**
+ * Best-effort shell out. Swallowing the error is deliberate: on a runner without `lsof`
+ * the inventory simply comes back empty and we fall through to launching normally, which
+ * is the safe degradation. A port policy must not be able to block CI.
+ */
 const sh = (cmd, args) => {
   try {
     return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
@@ -215,6 +220,11 @@ if (has('--isolated')) {
     console.error(`\n  Refusing to kill it. Free the port, or use --isolated.\n`)
     process.exit(1)
   } else if (isOurs(holder) && !has('--restart')) {
+    // Exits 0 WITHOUT holding the foreground. Safe for `playwright.config.ts`, whose
+    // webServer sets `reuseExistingServer: true` and therefore never runs this command
+    // when 6006 is already serving. If that ever flips to false, this branch has to
+    // become a restart instead, or Playwright will wait forever for a server we did
+    // not start.
     console.log(`  Storybook for THIS package is already on ${LOCKED_PORT} (pid ${holder.pid}).`)
     console.log(`  http://127.0.0.1:${LOCKED_PORT}`)
     console.log(`\n  Use --restart to replace it, or --isolated for a second instance.\n`)

--- a/packages/ui/scripts/storybook-launch.mjs
+++ b/packages/ui/scripts/storybook-launch.mjs
@@ -12,8 +12,18 @@
  *   node scripts/storybook-launch.mjs --isolated   # a private port, for parallel work
  *   node scripts/storybook-launch.mjs --list       # inventory only, launch nothing
  *   node scripts/storybook-launch.mjs --restart    # replace our own server on the port
- *   node scripts/storybook-launch.mjs --reap       # kill ORPHANED servers, then launch
- *   node scripts/storybook-launch.mjs --reap-all   # also kill live foreign / duplicate ours
+ *
+ * Reaping is scoped, and the default is the only category that is unambiguously dead:
+ *
+ *   --reap                 orphans (default) — worktree deleted, process still running
+ *   --reap=orphans         the same, said explicitly
+ *   --reap=foreign         live servers rooted in ANOTHER tree — may be a parallel agent's
+ *   --reap=dupes           our own extra servers, off the locked port
+ *   --reap=all             orphans + foreign + dupes
+ *   --reap=foreign,dupes   any combination
+ *
+ * The locked port is never reaped (use `--restart`), and anything not identifiable as
+ * Storybook is never touched.
  *
  * Anything not understood is forwarded to `storybook dev`.
  */
@@ -34,7 +44,33 @@ const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const argv = process.argv.slice(2)
 const has = (f) => argv.includes(f)
 const FLAGS = ['--isolated', '--list', '--restart', '--reap', '--reap-all']
-const passthrough = argv.filter((a) => !FLAGS.includes(a))
+const isReapFlag = (a) => a === '--reap' || a === '--reap-all' || a.startsWith('--reap=')
+const passthrough = argv.filter((a) => !FLAGS.includes(a) && !isReapFlag(a))
+
+/** Reap categories requested, or `null` when reaping was not asked for at all. */
+function requestedScopes() {
+  const flag = argv.find(isReapFlag)
+  if (!flag) return null
+  if (flag === '--reap-all') return ['orphan', 'foreign', 'dupe']
+  if (flag === '--reap') return ['orphan'] // the default scope
+  const asked = flag.slice('--reap='.length).split(',').filter(Boolean)
+  if (asked.includes('all')) return ['orphan', 'foreign', 'dupe']
+  const map = {
+    orphans: 'orphan',
+    orphan: 'orphan',
+    foreign: 'foreign',
+    dupes: 'dupe',
+    dupe: 'dupe',
+  }
+  const scopes = asked.map((a) => map[a]).filter(Boolean)
+  const unknown = asked.filter((a) => !map[a] && a !== 'all')
+  if (unknown.length) {
+    console.error(`\n  Unknown reap scope: ${unknown.join(', ')}`)
+    console.error(`  Valid: orphans (default), foreign, dupes, all\n`)
+    process.exit(1)
+  }
+  return scopes.length ? scopes : ['orphan']
+}
 
 /**
  * Best-effort shell out. Swallowing the error is deliberate: on a runner without `lsof`
@@ -96,11 +132,24 @@ function inventory() {
 const isOurs = (entry) => entry.cwd != null && entry.cwd.startsWith(PKG_ROOT)
 
 /**
- * The server is still running but the tree it serves is GONE — a worktree was deleted
- * out from under it. Unambiguously dead, and the safe default for reaping: nobody can
- * be using it, and it is exactly what squats ports and poisons screenshots.
+ * Which reap scope an entry belongs to. These names are exactly the `--reap=` values, so
+ * the inventory reads as a map of what each option would kill.
+ *
+ *   other   not identifiable as Storybook — never touched
+ *   locked  ours, on the locked port — never reaped; use --restart
+ *   orphan  the tree it serves is GONE. Unambiguously dead: nobody can be using it, and
+ *           it is exactly what squats ports and poisons screenshots. The DEFAULT scope.
+ *   foreign live, rooted in another tree — may be a parallel agent's, so opt-in only
+ *   dupe    ours, off the locked port — probably a leftover --isolated, so opt-in only
  */
-const isOrphan = (entry) => entry.storybook && entry.cwd != null && !existsSync(entry.cwd)
+function category(entry) {
+  if (!entry.storybook) return 'other'
+  if (entry.cwd != null && !existsSync(entry.cwd)) return 'orphan'
+  if (isOurs(entry)) return entry.port === LOCKED_PORT ? 'locked' : 'dupe'
+  return 'foreign'
+}
+
+const isOrphan = (entry) => category(entry) === 'orphan'
 
 function printInventory(entries) {
   if (entries.length === 0) {
@@ -108,35 +157,41 @@ function printInventory(entries) {
     return
   }
   console.log(`\n  Listening in ${SCAN_RANGE[0]}-${SCAN_RANGE[1]}:\n`)
-  console.log('  PORT   PID     KIND        STATE     ROOT')
+  console.log('  PORT   PID     CATEGORY   ROOT')
   for (const e of entries) {
-    const kind = e.storybook ? (isOurs(e) ? 'storybook*' : 'storybook') : 'other'
-    const state = isOrphan(e) ? 'ORPHAN' : e.port === LOCKED_PORT ? 'locked' : 'live'
-    const root = e.cwd ?? '(unknown)'
     console.log(
-      `  ${String(e.port).padEnd(6)} ${String(e.pid).padEnd(7)} ${kind.padEnd(11)} ${state.padEnd(9)} ${root}`
+      `  ${String(e.port).padEnd(6)} ${String(e.pid).padEnd(7)} ${category(e).padEnd(10)} ${e.cwd ?? '(unknown)'}`
     )
   }
-  const orphans = entries.filter(isOrphan).length
-  console.log('\n  * = this package.  ORPHAN = its worktree no longer exists on disk.')
-  if (orphans) console.log(`  ${orphans} orphaned server(s) — clear with --reap.`)
+
+  const counts = entries.reduce((acc, e) => {
+    acc[category(e)] = (acc[category(e)] ?? 0) + 1
+    return acc
+  }, {})
+  console.log('\n  locked  = ours on the locked port     → --restart to replace')
+  console.log('  orphan  = its worktree is GONE        → --reap            (default)')
+  console.log('  foreign = another live tree           → --reap=foreign')
+  console.log('  dupe    = ours, off the locked port   → --reap=dupes')
+  console.log('  other   = not Storybook               → never touched')
+  const summary = ['orphan', 'foreign', 'dupe']
+    .filter((c) => counts[c])
+    .map((c) => `${counts[c]} ${c}`)
+    .join(', ')
+  if (summary) console.log(`\n  Reapable: ${summary}.  --reap=all clears every one of them.`)
   console.log('')
 }
 
-/** Kill the dead (and, with --reap-all, the merely redundant). Returns ports freed. */
-function reap(entries, all) {
-  const targets = entries.filter((e) => {
-    if (!e.storybook) return false // never touch what we cannot identify
-    if (isOrphan(e)) return true
-    if (!all) return false
-    return e.port !== LOCKED_PORT // --reap-all: every duplicate except the locked port
-  })
+/** Kill everything in the requested scopes. Returns the ports freed. */
+function reap(entries, scopes) {
+  const targets = entries.filter((e) => scopes.includes(category(e)))
   if (targets.length === 0) {
-    console.log('  Nothing to reap.\n')
+    console.log(`  Nothing to reap in scope: ${scopes.join(', ')}.\n`)
     return []
   }
+  console.log(`  Reaping scope: ${scopes.join(', ')}`)
   for (const e of targets) {
-    killPid(e.pid, isOrphan(e) ? `orphaned — ${e.cwd} is gone` : `duplicate on ${e.port}`)
+    const c = category(e)
+    killPid(e.pid, c === 'orphan' ? `orphan — ${e.cwd} is gone` : `${c} on ${e.port}`)
   }
   console.log('')
   return targets.map((e) => e.port)
@@ -192,8 +247,9 @@ let entries = inventory()
 printInventory(entries)
 
 // Reap BEFORE the --list exit, so `--reap --list` reaps and then shows the result.
-if (has('--reap') || has('--reap-all')) {
-  const freed = reap(entries, has('--reap-all'))
+const scopes = requestedScopes()
+if (scopes) {
+  const freed = reap(entries, scopes)
   if (freed.length > 0) {
     entries = inventory() // re-read: ports we just freed are now available
     console.log('  After reaping:')


### PR DESCRIPTION
## The bug this closes

`storybook dev` **auto-increments off a busy port**. A launch on a port believed free silently lands on *another worktree's* server, and every screenshot taken afterwards is plausible and wrong.

This invalidated a VW-85 evidence set today. The launcher landed on a Storybook rooted in `/private/tmp/harden-fatigue-wt` — a **deleted** worktree — and it was only caught because that server happened to return `Unable to index files: ENOENT` instead of JSON. Had it been merely outdated rather than broken, a full set of wrong gate screenshots would have gone out as evidence for a release tag.

**Verifying `index.json` does not catch this.** The runbook's check compares story IDs and `importPath`, but `importPath` is relative (`./src/components/...`) and identical across worktrees.

For scale: this machine had **13 Storybook servers** running, **7 of them orphaned** across deleted worktrees.

## The fix

`packages/ui/scripts/storybook-launch.mjs` owns port policy. Port 6006 is locked.

| command | behaviour |
|---|---|
| `pnpm storybook` | Locked port. Reuses ours; **kills a foreign squatter**; refuses if a non-Storybook holds it. |
| `pnpm storybook:isolated` | Private port from 6100–6199 — the explicit path for expected parallel work. |
| `pnpm storybook:ports` | Inventory: what is listening, whose it is, what is orphaned. |
| `pnpm storybook:reap` | Kill orphaned servers, then re-list. |
| `--reap-all` | Also kill live foreign/duplicate servers. |
| `--restart` | Replace our own server on the locked port. |

Every launch passes **`--exact-port`**, so a conflict is a loud failure rather than a silent move.

## Verification

Tested both directions on a genuinely busy port (6024):

- **with** `--exact-port` → refuses to start, no server
- **without** → quietly comes up on **6025**

Inventory, orphan detection, reap, isolated allocation and the already-running path were each exercised against the real 13-server mess; the 7 orphans were reaped successfully.

## Safety

- Reaping defaults to **orphans only** — a server whose worktree no longer exists on disk. Unambiguously dead. A *live* foreign server may be a parallel agent's and needs explicit `--reap-all`.
- Processes that cannot be identified as Storybook are **never** killed — the script refuses the locked port and exits non-zero instead.
- Ownership is determined by the process's actual `cwd` (via `lsof -d cwd`), not by guessing from the command line.

## Also

`CLAUDE.md` gains a "Storybook ports" section stating the hazard, the commands, and the rule that provenance must be verified by something unique to the tree you meant to shoot — never by story IDs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)