### PR TITLE
Storybook review nits across the fatigue family

### DIFF
--- a/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/DualGhostSpark.stories.tsx
@@ -3,7 +3,7 @@ import { View, Text } from 'react-native'
 import { DualGhostSpark } from './DualGhostSpark'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { buildMockModel } from './fatigue-mock'
+import { buildMockModel, TARGET_TEMPO_SECONDS } from './fatigue-mock'
 import { GRIND_THRESHOLD } from './fatigue-tokens'
 import type { RepVelocityCurve } from './fatigue-model'
 
@@ -133,7 +133,13 @@ export const Symmetric: Story = {
     page(
       panel(
         'SYMMETRIC · MATCHED DEVICES · BOTH SILVER',
-        <DualGhostSpark left={HEALTHY} right={HEALTHY} width={360} height={232} />
+        <DualGhostSpark
+          left={HEALTHY}
+          right={HEALTHY}
+          width={360}
+          height={232}
+          targetTempoSeconds={TARGET_TEMPO_SECONDS}
+        />
       )
     ),
 }
@@ -147,6 +153,7 @@ export const AsymmetricLeftRight: Story = {
       panel(
         'ASYMMETRIC · LEFT SILVER · RIGHT GRINDING RED',
         <DualGhostSpark
+          targetTempoSeconds={TARGET_TEMPO_SECONDS}
           left={HEALTHY}
           right={grinding(HEALTHY, 0.85)}
           width={360}
@@ -168,6 +175,7 @@ export const AsymmetricControlled: Story = {
       panel(
         'ASYMMETRIC · RIGHT AT ~55% VELOCITY · BOTH STILL SILVER',
         <DualGhostSpark
+          targetTempoSeconds={TARGET_TEMPO_SECONDS}
           left={HEALTHY}
           right={weaken(HEALTHY, 0.55)}
           width={360}
@@ -187,7 +195,13 @@ export const OneSideLagging: Story = {
     page(
       panel(
         'LAGGING · RIGHT STILL MID-REP · BOTH CONTROLLED',
-        <DualGhostSpark left={HEALTHY} right={lagging(HEALTHY, 0.6)} width={360} height={232} />
+        <DualGhostSpark
+          left={HEALTHY}
+          right={lagging(HEALTHY, 0.6)}
+          width={360}
+          height={232}
+          targetTempoSeconds={TARGET_TEMPO_SECONDS}
+        />
       )
     ),
 }
@@ -205,6 +219,7 @@ export const TintRange: Story = {
             {panel(
               `RIGHT GRIND ${grind.toFixed(2)} · ${grind < GRIND_THRESHOLD ? 'CONTROLLED · SILVER' : 'GRINDING · RED'}`,
               <DualGhostSpark
+                targetTempoSeconds={TARGET_TEMPO_SECONDS}
                 left={HEALTHY}
                 right={grinding(HEALTHY, grind)}
                 width={360}
@@ -230,7 +245,13 @@ export const Empty: Story = {
         )}
         {panel(
           'SINGLE-SIDED · ONLY THE LEFT DEVICE BOUND',
-          <DualGhostSpark left={HEALTHY} right={[]} width={360} height={232} />
+          <DualGhostSpark
+            left={HEALTHY}
+            right={[]}
+            width={360}
+            height={232}
+            targetTempoSeconds={TARGET_TEMPO_SECONDS}
+          />
         )}
       </>
     ),

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.test.tsx
@@ -192,6 +192,24 @@ describe('GhostBand', () => {
     expect(labelsOf(c).every((l) => l.fill === t['text-primary'])).toBe(true)
   })
 
+  // --- prescribed (nothing performed yet) --------------------------------------
+
+  it('paints a PRESCRIBED rep entirely unfilled — nothing has been performed', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO, prescribed: true })
+    fillsOf(c).forEach((f) => expect(f.width).toBe(0))
+  })
+
+  it('still draws the prescribed runs at full width, so the shape reads', () => {
+    const plain = basesOf(band(onPace, { targetTempoSeconds: TEMPO }))
+    const pre = basesOf(band(onPace, { targetTempoSeconds: TEMPO, prescribed: true }))
+    expect(pre).toEqual(plain)
+  })
+
+  it('keeps prescribed labels PLAIN — an unstarted rep is neither ahead nor behind', () => {
+    const c = band(onPace, { targetTempoSeconds: TEMPO, prescribed: true, showLabels: true })
+    expect(labelsOf(c).every((l) => l.fill === t['text-primary'])).toBe(true)
+  })
+
   // --- the well ---------------------------------------------------------------
 
   it('recesses every run, so an unearned remainder reads as empty channel', () => {

--- a/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBand.tsx
@@ -93,6 +93,14 @@ export interface GhostBandProps {
    * which is also the honest one when nothing was prescribed to pace against.
    */
   targetTempoSeconds?: TempoTuple | null
+  /**
+   * These runs are PRESCRIBED, not performed — the set has not started. Every run paints
+   * unfilled at its base tone with a plain label, because nothing has been paced yet.
+   *
+   * Used by the empty state, where the band shows the SHAPE of the rep that was asked for
+   * (from the target tempo) rather than an axis with nothing on it.
+   */
+  prescribed?: boolean
 }
 
 /**
@@ -112,6 +120,7 @@ export function GhostBand({
   showLabels = false,
   labelColor = t['text-primary'],
   targetTempoSeconds = null,
+  prescribed = false,
 }: GhostBandProps) {
   const rawId = useId()
   const safeId = rawId.replace(/[^a-zA-Z0-9]/g, '')
@@ -126,7 +135,7 @@ export function GhostBand({
   const bandW = bandRight - bandLeft
   if (bandW <= 0) return null
 
-  const pacing = targetTempoSeconds != null
+  const pacing = targetTempoSeconds != null && !prescribed
   // Each run's elapsed time IS its own duration — the in-flight run's `endMs` is already
   // "now" — so pacing needs no clock of its own.
   const targetsMs = phaseTargetsMs(
@@ -146,8 +155,9 @@ export function GhostBand({
       phase: seg.phase,
       left,
       width,
-      // No target (or no prescription at all) → the run reads complete rather than empty.
-      fillWidth: pacing ? width * phaseFillFraction(elapsedMs, targetMs) : width,
+      // Prescribed → nothing performed, so nothing filled. No target at all → the run reads
+      // complete rather than perpetually empty.
+      fillWidth: prescribed ? 0 : pacing ? width * phaseFillFraction(elapsedMs, targetMs) : width,
       labelTone: pacing ? pacingTone(elapsedMs, targetMs) : labelColor,
     }
   })

--- a/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostBloom.tsx
@@ -41,14 +41,16 @@ export function smoothPath(pts: Pt[]): string {
 }
 
 /**
- * The line's ground treatment. Adapts the bar "paper" language (grain + rim-light + soft
- * contact shadow) to a chart LINE — no hard black outline:
- * - `soft` — a soft, blurred, low-opacity dark shadow with no hard edge (the quiet default).
- * - `glow` — a soft blurred halo in the line's OWN tint (no black at all).
- * - `rimlight` — a thin lighter rim on the upper edge + a soft blurred contact shadow below
- *   (paper's inset highlight + drop shadow).
+ * The line's ground treatment: a soft, blurred, low-opacity dark shadow with no hard edge —
+ * the bar "paper" language adapted to a chart LINE, never a hard black outline.
+ *
+ * `glow` (a halo in the line's own tint) and `rimlight` (a lighter upper edge plus a dropped
+ * contact shadow) were explored alongside it and NOT chosen. They were removed rather than
+ * left as unreachable options: no component ever exposed the choice, so the only thing that
+ * could select them was the exploration story, and dead branches in a render path read as
+ * intent that no longer exists.
  */
-export type BloomTreatment = 'soft' | 'glow' | 'rimlight'
+const BLUR_STD_DEV = 2.6
 
 export interface GhostBloomProps {
   /** The current rep as `[x_px, magnitude_px]` points (magnitude ≥ 0 off the baseline). */
@@ -61,8 +63,6 @@ export interface GhostBloomProps {
   baseline: number
   /** Grow UP from the baseline (default) or DOWN — the mirrored-dual flip. */
   orientation?: 'up' | 'down'
-  /** The paper-inspired line ground treatment. Default `soft`. */
-  treatment?: BloomTreatment
   /** Per-ghost stroke colour by index; default fades the primary text token. */
   ghostStroke?: (index: number) => string
   /** Current-line stroke width, px. Default 3.5. */
@@ -76,7 +76,6 @@ export function GhostBloom({
   tint,
   baseline,
   orientation = 'up',
-  treatment = 'soft',
   ghostStroke = (i) => alpha(PARCH, 0.1 + i * 0.015),
   lineWidth = 3.5,
 }: GhostBloomProps) {
@@ -87,15 +86,12 @@ export function GhostBloom({
   const curD = smoothPath(toAbs(current))
   const ghostDs = ghosts.map((g) => smoothPath(toAbs(g)))
   // Rim-light sits on the side the line grows toward (its "top"); shadow falls the other way.
-  const rimDy = orientation === 'down' ? 1 : -1
-  const shadowDy = orientation === 'down' ? -2.2 : 2.2
-  const blurStdDev = treatment === 'glow' ? 3.4 : treatment === 'rimlight' ? 1.8 : 2.6
 
   return (
     <>
       <defs>
         <filter id={blurId} x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation={blurStdDev} />
+          <feGaussianBlur stdDeviation={BLUR_STD_DEV} />
         </filter>
       </defs>
 
@@ -112,41 +108,15 @@ export function GhostBloom({
       ))}
 
       {/* ground treatment — a paper-inspired line contact, never a hard black outline. */}
-      {treatment === 'glow' && (
-        <path
-          d={curD}
-          fill="none"
-          stroke={tint}
-          strokeWidth={lineWidth + 4}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          opacity={0.55}
-          filter={`url(#${blurId})`}
-        />
-      )}
-      {treatment === 'soft' && (
-        <path
-          d={curD}
-          fill="none"
-          stroke={alpha(primitiveColors.black, 0.3)}
-          strokeWidth={lineWidth + 3}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          filter={`url(#${blurId})`}
-        />
-      )}
-      {treatment === 'rimlight' && (
-        <path
-          d={curD}
-          fill="none"
-          stroke={alpha(primitiveColors.black, 0.33)}
-          strokeWidth={lineWidth + 0.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          filter={`url(#${blurId})`}
-          transform={`translate(0,${shadowDy})`}
-        />
-      )}
+      <path
+        d={curD}
+        fill="none"
+        stroke={alpha(primitiveColors.black, 0.3)}
+        strokeWidth={lineWidth + 3}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        filter={`url(#${blurId})`}
+      />
 
       {/* the crisp tinted line. */}
       <path
@@ -157,19 +127,6 @@ export function GhostBloom({
         strokeLinejoin="round"
         strokeLinecap="round"
       />
-
-      {/* rim-light: a thin lighter edge on the line's upper side (paper inset highlight). */}
-      {treatment === 'rimlight' && (
-        <path
-          d={curD}
-          fill="none"
-          stroke={alpha(primitiveColors.white, 0.28)}
-          strokeWidth={1.1}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-          transform={`translate(0,${rimDy})`}
-        />
-      )}
     </>
   )
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.stories.tsx
@@ -1,12 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { View, Text } from 'react-native'
 import { GhostSpark } from './GhostSpark'
-import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
-import { GhostBloom, type Pt, type BloomTreatment } from './GhostBloom'
-import { ghostLineColor, clamp01 } from './fatigue-tokens'
+import { GhostBand } from './GhostBand'
 import { primitiveColors } from '../../../theme/tokens/primitives'
 import { getSemanticColors } from '../../../theme/tokens/semantic'
-import { FATIGUE_STATES } from './fatigue-mock'
+import { FATIGUE_STATES, TARGET_TEMPO_SECONDS } from './fatigue-mock'
 import type { PhaseSegment } from './fatigue-model'
 
 const PANEL_BG = primitiveColors.charcoal[800]
@@ -25,7 +23,10 @@ const meta: Meta<typeof GhostSpark> = {
           'phase-coloured band at the bottom (ecc magenta / con cyan, ECC/CON labelled inside, always ' +
           'shown) with the velocity blooming UP from it — current rep solid over faded ghosts, a control-' +
           'aware silver/red line tint (silver when controlled, dimming with tempo drift; shades of red on ' +
-          'collapse), over a soft paper-inspired ground (no hard outline).',
+          'collapse), over a soft paper-inspired ground (no hard outline). Given `targetTempoSeconds` ' +
+          'the band also PACES: each run fills across `elapsed / target` of its own width and its label ' +
+          'takes the ahead / on-pace / over tone. Every story here passes the prescription the mock reps ' +
+          'were generated against, so the fill you see is the real relationship, not a decoration.',
       },
     },
   },
@@ -52,8 +53,15 @@ const label = (s: string) => (
 export const Default: Story = {
   render: () => (
     <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
-      {label('GHOST SPARK')}
-      {box(<GhostSpark curves={cur.velocityCurves} width={360} height={190} />)}
+      {label('GHOST SPARK · paced against the prescribed tempo')}
+      {box(
+        <GhostSpark
+          curves={cur.velocityCurves}
+          width={360}
+          height={190}
+          targetTempoSeconds={TARGET_TEMPO_SECONDS}
+        />
+      )}
     </View>
   ),
 }
@@ -73,82 +81,16 @@ export const ControlAwareTint: Story = {
       {FATIGUE_STATES.map((s) => (
         <View key={s.name} style={{ gap: 8 }}>
           {label(s.name)}
-          {box(<GhostSpark curves={s.model.velocityCurves} width={360} height={170} />)}
+          {box(
+            <GhostSpark
+              curves={s.model.velocityCurves}
+              width={360}
+              height={170}
+              targetTempoSeconds={s.model.targetTempoSeconds}
+            />
+          )}
         </View>
       ))}
-    </View>
-  ),
-}
-
-// --- Line ground treatment comparison ------------------------------------------------
-// The paper-inspired line treatments, fed the same current rep, for the operator to pick.
-// Each renders GhostBloom directly (same geometry GhostSpark uses) at one treatment.
-function TreatmentDemo({ treatment }: { treatment: BloomTreatment }) {
-  const w = 360
-  const h = 190
-  const padL = 12
-  const padR = 8
-  const padTop = 10
-  const padBot = 6
-  const curves = cur.velocityCurves
-  const c = curves[curves.length - 1]
-  const allSamples = curves.flatMap((cc) => cc.samples)
-  const vmax = Math.max(0.01, ...allSamples.map((s) => s.velocityMps)) * 1.06
-  const axisMaxT =
-    Math.max(1, ...curves.map((cc) => cc.samples[cc.samples.length - 1]?.tMs ?? 0)) * 1.04
-  const bandTop = h - padBot - BAND_H
-  const baseline = bandTop - BAND_GAP
-  const plotH = Math.max(1, baseline - padTop)
-  const x = (ms: number) => padL + (ms / axisMaxT) * (w - padL - padR)
-  const magOf = (v: number) => clamp01(v / vmax) * plotH
-  const curPts: Pt[] = c.samples.map((s) => [x(s.tMs), magOf(s.velocityMps)])
-  const ghostPts: Pt[][] = curves
-    .slice(0, -1)
-    .map((cc) => cc.samples.map((s): Pt => [x(s.tMs), magOf(s.velocityMps)]))
-  const tint = ghostLineColor(c.tempoDeviation, c.grindSignature)
-  return (
-    <View style={{ width: w, backgroundColor: PANEL_BG, borderRadius: 12, padding: 16 }}>
-      <svg width={w} height={h}>
-        <GhostBloom
-          current={curPts}
-          ghosts={ghostPts}
-          tint={tint}
-          baseline={baseline}
-          orientation="up"
-          treatment={treatment}
-        />
-        <GhostBand segments={c.phaseSegments} x={x} top={bandTop} showLabels />
-      </svg>
-    </View>
-  )
-}
-
-/** (a) Soft blurred GLOW in the line's own tint — a colored halo, no black. */
-export const LineTreatmentGlow: Story = {
-  render: () => (
-    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
-      {label('A · GLOW (colored halo, no black)')}
-      <TreatmentDemo treatment="glow" />
-    </View>
-  ),
-}
-
-/** (b) Rim-light: a thin lighter edge on the upper side + a soft contact shadow below. */
-export const LineTreatmentRimlight: Story = {
-  render: () => (
-    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
-      {label('B · RIM-LIGHT (upper rim + soft contact shadow)')}
-      <TreatmentDemo treatment="rimlight" />
-    </View>
-  ),
-}
-
-/** (c) Soft: a much softer/blurrier low-opacity shadow with no hard edge (the default). */
-export const LineTreatmentSoft: Story = {
-  render: () => (
-    <View style={{ backgroundColor: PAGE_BG, padding: 28, gap: 8, alignItems: 'flex-start' }}>
-      {label('C · SOFT (blurred low-opacity shadow, no hard edge)')}
-      <TreatmentDemo treatment="soft" />
     </View>
   ),
 }
@@ -200,4 +142,34 @@ export const PausedRepBand: Story = {
       </View>
     )
   },
+}
+
+/**
+ * BEFORE the first rep. With a prescription there is still something true to draw: the shape
+ * of the rep being asked for — its phases at their target durations, unfilled — so the axis
+ * previews the work rather than reading as "no data".
+ *
+ * The right-hand case is the honest fallback: no tempo prescribed, nothing to preview.
+ */
+export const EmptyBeforeFirstRep: Story = {
+  render: () => (
+    <View
+      style={{
+        backgroundColor: PAGE_BG,
+        padding: 28,
+        flexDirection: 'row',
+        gap: 24,
+        alignItems: 'flex-start',
+      }}
+    >
+      <View style={{ gap: 8 }}>
+        {label('EMPTY · tempo prescribed — the rep to come')}
+        {box(<GhostSpark curves={[]} width={360} height={190} targetTempoSeconds={[3, 1, 2, 1]} />)}
+      </View>
+      <View style={{ gap: 8 }}>
+        {label('EMPTY · no prescription — nothing to preview')}
+        {box(<GhostSpark curves={[]} width={360} height={190} />)}
+      </View>
+    </View>
+  ),
 }

--- a/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
+++ b/packages/ui/src/components/custom/Fatigue/GhostSpark.tsx
@@ -21,7 +21,7 @@ import { View } from 'react-native'
 import { ghostLineColor, clamp01 } from './fatigue-tokens'
 import { GhostBand, BAND_H, BAND_GAP } from './GhostBand'
 import { GhostBloom, type Pt } from './GhostBloom'
-import type { TempoTuple } from './tempo-pacing'
+import { prescribedSegments, type TempoTuple } from './tempo-pacing'
 import type { RepVelocityCurve } from './fatigue-model'
 
 export interface GhostSparkProps {
@@ -51,8 +51,31 @@ export function GhostSpark({
   const padTop = 10
   const padBot = 6
 
+  // Nothing performed yet. With a prescription there is still something true to draw: the
+  // SHAPE of the rep being asked for, laid out at its target durations and unfilled. An
+  // empty axis says "no data"; this says "here is the rep you are about to do".
   if (curves.length === 0) {
-    return <View testID="ghost-spark" style={{ width: w, height: h }} />
+    const prescribed = prescribedSegments(targetTempoSeconds)
+    if (prescribed.length === 0) {
+      return <View testID="ghost-spark" style={{ width: w, height: h }} />
+    }
+    const totalMs = prescribed[prescribed.length - 1].endMs
+    const bandTopEmpty = h - padBot - BAND_H
+    const xEmpty = (ms: number): number => padL + (ms / (totalMs * 1.04)) * (w - padL - padR)
+    return (
+      <View testID="ghost-spark" style={{ paddingHorizontal: 4 }}>
+        <svg width={w} height={h}>
+          <GhostBand
+            segments={prescribed}
+            x={xEmpty}
+            top={bandTopEmpty}
+            showLabels
+            targetTempoSeconds={targetTempoSeconds}
+            prescribed
+          />
+        </svg>
+      </View>
+    )
   }
 
   const cur = curves[curves.length - 1]

--- a/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/SilverRedPalette.stories.tsx
@@ -28,7 +28,7 @@ const PANEL_BG = primitiveColors.charcoal[800]
 const t = getSemanticColors('dark')
 
 const meta: Meta = {
-  title: 'Workout/Fatigue/Silver-Red Palette',
+  title: 'Foundations/Color/Silver-Red Scheme',
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/packages/ui/src/components/custom/Fatigue/VelocityHero.stories.tsx
+++ b/packages/ui/src/components/custom/Fatigue/VelocityHero.stories.tsx
@@ -10,7 +10,7 @@ const PANEL_BG = primitiveColors.charcoal[800]
 const t = getSemanticColors('dark')
 
 const meta: Meta<typeof VelocityHero> = {
-  title: 'Workout/Fatigue/Velocity Hero',
+  title: 'Workout/DataViz/VelocityHero',
   component: VelocityHero,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ui/src/components/custom/Fatigue/index.ts
+++ b/packages/ui/src/components/custom/Fatigue/index.ts
@@ -13,13 +13,7 @@ export { RomProgressionChart, type RomProgressionChartProps } from './RomProgres
 export { GhostSpark, type GhostSparkProps } from './GhostSpark'
 export { DualGhostSpark, type DualGhostSparkProps, mergePhaseSegments } from './DualGhostSpark'
 export { GhostBand, type GhostBandProps, BAND_H, BAND_GAP } from './GhostBand'
-export {
-  GhostBloom,
-  type GhostBloomProps,
-  type Pt,
-  type BloomTreatment,
-  smoothPath,
-} from './GhostBloom'
+export { GhostBloom, type GhostBloomProps, type Pt, smoothPath } from './GhostBloom'
 export { VelocityHero, type VelocityHeroProps } from './VelocityHero'
 export {
   ghostLineColor,

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { phaseFillFraction, pacingTone, phaseTargetsMs, ON_TARGET_MS } from './tempo-pacing'
+import {
+  phaseFillFraction,
+  pacingTone,
+  phaseTargetsMs,
+  prescribedSegments,
+  ON_TARGET_MS,
+} from './tempo-pacing'
 import {
   PACING_TONE,
   PACING_TONE_MIN_CONTRAST,
@@ -113,6 +119,37 @@ describe('pacing tone legibility', () => {
         `${name}: deepest step clearing ${PACING_TONE_MIN_CONTRAST}:1 is ${deepestPassing}`
       ).toBe(ramp[deepestPassing!])
     }
+  })
+})
+
+describe('prescribedSegments', () => {
+  it('lays the prescribed rep out end to end at its target durations', () => {
+    expect(prescribedSegments(TEMPO)).toEqual([
+      { phase: 'eccentric', startMs: 0, endMs: 2600 },
+      { phase: 'hold', startMs: 2600, endMs: 3000 },
+      { phase: 'concentric', startMs: 3000, endMs: 3950 },
+      { phase: 'hold', startMs: 3950, endMs: 4230 },
+    ])
+  })
+
+  it('drops zero-length phases rather than drawing slivers', () => {
+    const noHolds = prescribedSegments([3, 0, 2, 0])
+    expect(noHolds.map((s) => s.phase)).toEqual(['eccentric', 'concentric'])
+    // The concentric still starts where the eccentric ended — no gap from the dropped hold.
+    expect(noHolds[1].startMs).toBe(noHolds[0].endMs)
+  })
+
+  it('has nothing to describe without a prescription', () => {
+    expect(prescribedSegments(null)).toEqual([])
+  })
+
+  it('round-trips against phaseTargetsMs — every run matches its own target', () => {
+    const segs = prescribedSegments(TEMPO)
+    const targets = phaseTargetsMs(
+      segs.map((s) => s.phase),
+      TEMPO
+    )
+    segs.forEach((s, i) => expect(s.endMs - s.startMs).toBe(targets[i]))
   })
 })
 

--- a/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
+++ b/packages/ui/src/components/custom/Fatigue/tempo-pacing.ts
@@ -15,7 +15,7 @@
  */
 import { getSemanticColors } from '../../../theme/tokens/semantic'
 import { PACING_TONE } from './fatigue-tokens'
-import type { SamplePhase } from './fatigue-model'
+import type { SamplePhase, PhaseSegment } from './fatigue-model'
 
 const t = getSemanticColors('dark')
 
@@ -51,6 +51,34 @@ export function pacingTone(elapsedMs: number, targetMs: number | null): string {
   if (remainingMs > ON_TARGET_MS) return PACING_TONE.ahead
   if (remainingMs >= -ON_TARGET_MS) return PACING_TONE.onPace
   return PACING_TONE.over
+}
+
+/**
+ * The rep the prescription DESCRIBES, as phase runs — ecc, bottom hold, con, top hold, laid
+ * end to end at their target durations from t=0.
+ *
+ * This is the only place a band's geometry may come from the prescription rather than from
+ * actual samples, and it exists for exactly one case: nothing has been performed yet, so
+ * there is no actual time to lay out. Zero-length phases (a tempo with no holds) are
+ * dropped rather than drawn as slivers.
+ */
+export function prescribedSegments(tempo: TempoTuple | null): PhaseSegment[] {
+  if (tempo == null) return []
+  const [ecc, pauseBottom, con, pauseTop] = tempo
+  const order: Array<[SamplePhase, number]> = [
+    ['eccentric', ecc],
+    ['hold', pauseBottom],
+    ['concentric', con],
+    ['hold', pauseTop],
+  ]
+  const out: PhaseSegment[] = []
+  let t = 0
+  for (const [phase, seconds] of order) {
+    const ms = seconds * 1000
+    if (ms > 0) out.push({ phase, startMs: t, endMs: t + ms })
+    t += ms
+  }
+  return out
 }
 
 /**


### PR DESCRIPTION
Five fixes from a Storybook pass. The third was the substantive one.

## 1. Pacing was invisible in the spark stories — and that mattered

`GhostSpark` and `DualGhostSpark` both accept `targetTempoSeconds`, and `LiveFatigueCard` wires it through. But **their own stories never passed it**, so the axis showed no fill — which reasonably reads as "either these aren't wired together or the stories are fake".

They *are* wired. The stories were incomplete. Every spark story now passes the prescription its mock reps were generated against, so the fill on screen is the real phase-timing ↔ axis relationship rather than a decoration. Verified visually: ECC renders partly filled with an amber (ahead) label, CON filled to the brim with an over-tone label, and the run boundary still lands under the trace's phase transition.

## 2. Empty state previews the prescribed rep

With no curves and a target tempo, the band now draws the rep being **asked for** — phases at their target durations, unfilled, via a new `GhostBand prescribed` mode. An empty axis says "no data"; this says "here is the rep you're about to do". With no prescription it still renders nothing, which stays the honest fallback.

`prescribedSegments()` is the **only** place band geometry may come from the prescription rather than from actual samples, and its docblock says so — everywhere else the actual-time alignment under the sparkline is load-bearing.

## 3. Line-treatment explorations removed

`glow` and `rimlight` lost to `soft` and were reachable only from the exploration stories. Deleting just the stories would have left two unreachable branches in a render path, so the `treatment` prop and the `BloomTreatment` type go with them.

⚠️ **BREAKING**: `BloomTreatment` was exported from the package root (`src/index.ts` → components → custom → Fatigue). Dead API, but public. Appropriate for the 0.11.0 cut.

## 4 & 5. Two stories were filed in the wrong section

- **Silver-Red Palette** → `Foundations/Color/Silver-Red Scheme`, beside the other colour stories instead of under a workout feature.
- **Velocity Hero** → `Workout/DataViz/VelocityHero`. It's a thin alias over `VelocityStrip`, so it belongs next to it (`Workout/DataViz/VelocityStrip/*`), not in Fatigue.

## Verification

- typecheck ✅ · lint 0 errors ✅ · prettier ✅ · **2829 tests pass** (+7)
- New tests cover `prescribedSegments` (including zero-length holds dropped, and a round-trip against `phaseTargetsMs`) and the `prescribed` render mode.
- Mutation-checked: making `prescribed` fill normally fails exactly its test and nothing else.

## Worth knowing, not fixed here

**`**/*.stories.tsx` is excluded from `tsconfig.json`.** Stories are not typechecked, which is why they can reference removed API while `type-check` stays green — and part of why they drift from their components. The `stories-smoke` suite catches runtime breakage but not type breakage. Left alone deliberately: turning it on will surface unrelated errors and deserves its own change.

Separately, an agent is investigating `LiveFatiguePanel` responsiveness; that proposal lands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)