### PR TITLE
Release @titan-design/react-ui 0.11.0

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-design/react-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Cross-platform design system built on Gluestack UI",
   "author": "Henry Jewkes",
   "license": "MIT",


### PR DESCRIPTION
Version bump only — `0.10.0` → `0.11.0`. The tag goes on the merge commit; publish CI validates that the tag matches `packages/ui/package.json` and refuses otherwise.

First cut since `v0.10.0`, **22 commits back**. The dashboard SPA pins `^0.9.3`, which npm's 0.x caret rule resolves `<0.10.0`, so nothing merged in that window has reached it. That range gets widened separately once this is on npm.

## Why minor, not patch

Real consumer-visible breaking changes — under 0.x this is the conventional slot:

- **`SamplePhase` gains `'hold'`** — an exhaustive switch over it no longer compiles.
- **`PHASE_AXIS_COLOR.hold`** is new; the map is no longer three entries.
- **`BloomTreatment` removed**, with `GhostBloom`'s `treatment` prop. `glow`/`rimlight` lost to `soft` and were unreachable from any component.
- **ROM to-do treatment** changed from dashed stubs to solid sections.

## What ships

Phase pacing on the ghost band (muted base + fill earned against the prescribed duration, labels toned ahead/on-pace/over) with **geometry unchanged** — runs keep actual-time positions, so they stay aligned under the sparkline. Plus the inset well, holds as a first-class phase, the prescribed-rep empty state, panel rep-count consistency, and the `tempo-pacing` module.

## Pre-flight

Ran the publish workflow's own gates locally against this branch:

- `pnpm lint` → 0
- `pnpm type-check` → 0
- `pnpm build` → 0
- 2829 tests pass

Publish payload checked with `npm pack --dry-run`: 568 files, no `tmp-` artifacts, `!src/lab` correctly excludes the explorations.

## Gate

**VW-85 approved** against main — this tag releases that hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)