### PR TITLE
Retune the hairlines and drop the tonal fill (VW-99 wall results)

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -37,8 +37,12 @@ const HTML_CSS = `
     --text-primary: #F9F6F3;
     --text-secondary: #A29F9D;
     --text-tertiary: #888684;
-    --border-default: rgba(255, 255, 255, 0.09);
-    --border-strong: rgba(255, 255, 255, 0.14);
+    /* Mirrors hairline-default / hairline-strong in tokens/semantic.ts. Retuned
+       on the wall in VW-99 (.09/.14 -> .14/.21). This copy is hand-maintained,
+       so it drifts silently unless the parity layer catches it — which is
+       exactly what happened here. */
+    --border-default: rgba(255, 255, 255, 0.14);
+    --border-strong: rgba(255, 255, 255, 0.21);
     /* A dim FILL for 'no data' dots. Used to borrow --border-strong; borders are
        alpha now, so a fill needs its own solid ramp step. */
     --dot-inactive: #2C2A28;

--- a/packages/ui/src/components/ui/surface/surface.contract.test.ts
+++ b/packages/ui/src/components/ui/surface/surface.contract.test.ts
@@ -181,10 +181,17 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
     // the S-3 ramp (default dropped 8->7 — the `overlay` plane now measures
     // ~7.97, just under the old floor); a wall-display calibration pass (S-6)
     // may retune the alpha values themselves.
+    //
+    // S-6 DID (VW-99). The alphas went up ×1.5 to .09/.135/.21: on the wall at
+    // ~3 m `subtle` rendered but was indiscernible, and `default` — which has had
+    // no solid-border fallback since TD-07.14 — went weak on the lightest plane.
+    // Floors below re-measured against the new alphas. Note new `subtle` now
+    // measures exactly where old `default` did (min 7.97), and the new `default`
+    // where old `strong` did (min 12.26) — each tier onto a measured-good rung.
     const HAIRLINES = {
-      subtle: { token: 'hairline-subtle', floor: 5 },
-      default: { token: 'hairline-default', floor: 7 },
-      strong: { token: 'hairline-strong', floor: 12 },
+      subtle: { token: 'hairline-subtle', floor: 7 },
+      default: { token: 'hairline-default', floor: 12 },
+      strong: { token: 'hairline-strong', floor: 18 },
     } as const
 
     for (const [name, { token, floor }] of Object.entries(HAIRLINES)) {
@@ -199,19 +206,30 @@ describe('surface ramp contract (dark) — token-value guardrails', () => {
       })
     }
 
-    it('is near-constant (self-normalizing) across all planes: spread < 4 L* per tier', () => {
-      // Measured spread (frame..overlay): subtle ~1.6, default ~2.2, strong ~3.2 —
-      // still far tighter than a solid border token (which swings ~5.6 -> 0
-      // across this same ramp, see R4). "Near-constant" is relative to that,
-      // not perfectly flat — alpha-over-white is sublinear in L* as the base
-      // lightens, which is exactly the R3 floor-vs-doc discrepancy noted above.
+    it('is near-constant (self-normalizing) across all planes: spread stays proportional', () => {
+      // Measured RELATIVE spread ((max-min)/min): subtle 0.27, default 0.29,
+      // strong 0.29 — and, importantly, those are the same figures the OLD
+      // .06/.09/.14 family produced (0.28 / 0.27 / 0.28). Self-normalization
+      // survived the S-6 retune untouched.
+      //
+      // This assertion used to be an ABSOLUTE `spread < 4 L*`, which was the
+      // wrong metric: absolute spread scales with the alpha, so ANY strengthening
+      // fails it no matter how well the property holds. The S-6 ×1.5 retune
+      // tripped it (strong 3.46 -> 5.29) purely arithmetically. A ratio is
+      // scale-invariant, which is what "self-normalizing" actually claims.
+      //
+      // Contrast a solid border token, which swings ~5.6 -> 0 across this same
+      // ramp (see R4): the point is not a tight absolute band, it is that no
+      // plane ever loses the cue. Alpha-over-white is sublinear in L* as the
+      // base lightens, which is the R3 floor-vs-doc discrepancy noted above.
       for (const { token } of Object.values(HAIRLINES)) {
         const hairlineColor = dark[token as keyof typeof dark]
         const deltas = PLANE_ORDER.map((plane) => {
           const planeHex = RAMP_HEX[plane]
           return lstar(compositeOver(planeHex, hairlineColor)) - lstar(planeHex)
         })
-        expect(Math.max(...deltas) - Math.min(...deltas)).toBeLessThan(4)
+        const min = Math.min(...deltas)
+        expect((Math.max(...deltas) - min) / min, `${token} relative spread`).toBeLessThan(0.35)
       }
     })
   })

--- a/packages/ui/src/theme/DepthCalibration.stories.tsx
+++ b/packages/ui/src/theme/DepthCalibration.stories.tsx
@@ -4,7 +4,7 @@ import { View, Text, Pressable } from 'react-native'
 import { greyRamp } from './tokens/primitives'
 import { getSemanticColors } from './tokens/semantic'
 import { getBaseSurfaceColor, getElevationSurface, type ElevationLevel } from './elevation'
-import { tonalFill, grainForTone, ditherTile, paperSheet } from './materials'
+import { grainForTone, paperSheet } from './materials'
 
 /**
  * Foundations/Depth Calibration — the S-6 wall gate (VW-99).
@@ -331,51 +331,67 @@ export const ToneSteps: StoryObj = {
   ),
 }
 
-// ── C3 · tonal fill ─────────────────────────────────────────────────────────
+// ── C3 · paper material ─────────────────────────────────────────────────────
 
 const PAPER_TONE = greyRamp[875]
 
-export const TonalFill: StoryObj = {
-  name: 'C3 · Tonal fill — ΔL* 3, just under seen-as-a-gradient',
+/**
+ * REWRITTEN FOR RUN 2. Run 1 asked "is the tonal fill visible?" and the answer
+ * was no, so the fill was deleted — which left this panel with nothing to
+ * compare. The question that survives the deletion is broader and more useful:
+ * with the fill gone, does what REMAINS of the paper material read at all?
+ *
+ * `paperSheet` is now grain + dither + a top rim-light + a contact shadow. If
+ * that stack cannot be told from a flat `backgroundColor` at 3 m, it is three
+ * paint layers buying nothing and it should follow the fill out.
+ *
+ * The forced choice is odd-one-out with a genuine identical pair, rather than
+ * "can you see it" — the operator has to say WHICH and HOW, and "they are all
+ * the same" is an available, unembarrassing answer. That matters here more than
+ * on C1: grain lifts apparent lightness, so a two-way comparison can be won on
+ * a brightness cue without the material ever reading as a material.
+ */
+const PAPER_SHEETS = ['flat', 'paper', 'flat'] as const
+
+export const PaperMaterial: StoryObj = {
+  name: 'C3 · Paper material — what is left after the fill',
   render: () => (
     <Panel
-      title="C3 · Tonal fill"
+      title="C3 · Paper material"
       task={
-        'TOP: two sheets on the same tone — one carries the fill, one is flat. Which is which, or ' +
-        'are they identical? BOTTOM: the full shipped material. Does it read as a sheet with light ' +
-        'falling on it, or as a decorative gradient? Invisible and obvious are both failures.'
+        'TOP: three sheets on the same tone. Two are identical. Which one differs, and in what way ' +
+        '— lighter, textured, edged? "All three the same" is a real answer. BOTTOM: the same ' +
+        'material at hero size. Does it read as a sheet with light on it, as visible noise, or as ' +
+        'nothing at all?'
       }
     >
       {(revealed) => (
         <View>
-          {/*
-           * The forced choice is fill-vs-flat ONLY, and both sheets are tone-matched.
-           * An earlier version put paperSheet() in the same row — but grain raises
-           * apparent lightness, so the full recipe was picked out instantly on a cue
-           * that had nothing to do with the fill, and the question the panel exists
-           * to ask never got asked. The recipe is now judged separately, on its own
-           * question.
-           */}
           <View style={{ flexDirection: 'row', gap: 22 }}>
-            <Card
-              label="1"
-              revealed={revealed}
-              answer="tonalFill — the shipped ΔL* 3 gradient, no grain, no dither"
-              style={{ backgroundColor: PAPER_TONE, backgroundImage: tonalFill(PAPER_TONE) }}
-            />
-            <Card
-              label="2"
-              revealed={revealed}
-              answer="FLAT — backgroundColor alone"
-              style={{ backgroundColor: PAPER_TONE }}
-            />
+            {PAPER_SHEETS.map((kind, i) => (
+              <Card
+                key={i}
+                label={String(i + 1)}
+                revealed={revealed}
+                answer={
+                  kind === 'paper'
+                    ? 'paperSheet() — grain + dither + rim-light + contact shadow'
+                    : 'FLAT (decoy) — backgroundColor alone'
+                }
+                style={
+                  kind === 'paper'
+                    ? { ...(paperSheet(PAPER_TONE) as Record<string, unknown>) }
+                    : { backgroundColor: PAPER_TONE }
+                }
+              />
+            ))}
           </View>
 
           <Text
             className="text-text-secondary"
             style={{ fontSize: 15, marginTop: 26, marginBottom: 10 }}
           >
-            The full material, at hero size — paper, or decorative gradient?
+            The same material, at hero size — lit sheet, visible noise, or nothing?
           </Text>
           <View
             style={{
@@ -385,22 +401,26 @@ export const TonalFill: StoryObj = {
             }}
           />
           <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 8 }}>
-            {revealed
-              ? 'paperSheet() — fill + grain + dither + top rim-light + contact shadow'
-              : 'reads as: ______'}
+            {revealed ? 'paperSheet() at hero width' : 'reads as: ______'}
           </Text>
 
           {revealed ? (
             <View style={{ marginTop: 14, maxWidth: 1000 }}>
               <KeyLine>
-                {'PASS: sheet 1 correctly called as the one with light on it, AND the hero sheet ' +
-                  'not described as a gradient. If 1 and 2 are indistinguishable, ΔL* 3 is below ' +
-                  'this panel and the fill is costing a paint for nothing.'}
+                {'Sheet 2 is the material; 1 and 3 are the identical decoy pair. PASS: 2 picked out, ' +
+                  'AND the hero sheet described as a surface rather than as noise. Invisible and ' +
+                  'obvious are both failures — the same two-sided bar the fill was held to.'}
               </KeyLine>
               <KeyLine>
-                {'Retune lever: the ±1.5 L* shift in `tonalFill` (materials.ts). The exploration ' +
-                  'rejected anything past ~4 total span as decorative, so ±2.0 is the ceiling — ' +
-                  'past that, drop the fill rather than push it.'}
+                {'Levers. Reads as NOTHING: the honest move is to drop grain and the dither from ' +
+                  'paperSheet and keep only the rim-light and contact shadow, which are edge cues ' +
+                  'and sit at a spatial frequency the wall demonstrably resolves — that is the ' +
+                  'lesson C2 taught and the fill failed. Reads as NOISE: lower the grain opacity in ' +
+                  'grainForTone (materials.ts) before touching its frequency.'}
+              </KeyLine>
+              <KeyLine>
+                {'If 1 and 3 were reported as different from each other, the run is invalid at this ' +
+                  'distance — they are byte-identical. Step back to 3 m and go again.'}
               </KeyLine>
             </View>
           ) : null}
@@ -436,68 +456,102 @@ function Card({
 
 const BAND_TONE = greyRamp[900]
 
+/**
+ * REWRITTEN FOR RUN 2, and this panel is why the rewrite could not be skipped.
+ *
+ * Run 1 compared dither-on against dither-off over the tonal fill. Neither field
+ * banded — but the fill was already established as invisible, so there was no
+ * gradient to band and the panel could not have failed. That is a VOID result,
+ * not a pass, and it is the exact failure mode a calibration rig exists to catch
+ * in itself.
+ *
+ * Two changes:
+ *
+ * 1. Both material fields are now the SHIPPED stack ± dither, derived from
+ *    `paperSheet` rather than reassembled by hand, so they cannot drift from
+ *    what actually ships.
+ * 2. A POSITIVE CONTROL is seeded: a bare low-contrast vertical gradient with no
+ *    dither and no grain, which on an 8-bit panel must band. If it does not, the
+ *    panel cannot detect banding under these viewing conditions and the row is
+ *    VOID AGAIN — now with evidence, instead of being mistaken for a pass.
+ *
+ * The control cannot be disguised as one of the material fields, and does not
+ * need to be: it is not part of a forced choice. Which field it is stays hidden
+ * with the rest of the key, so the operator still reports what they see rather
+ * than what they expect.
+ */
+const SHIPPED_PAPER = paperSheet(BAND_TONE) as Record<string, unknown>
+
+const BAND_FIELDS: { key: string; answer: string; style: Record<string, unknown> }[] = [
+  {
+    key: '1',
+    answer: 'the SHIPPED stack — dither over grain',
+    style: SHIPPED_PAPER,
+  },
+  {
+    key: '2',
+    answer: 'CONTROL (decoy) — a bare grey-900 → grey-875 gradient, no dither, no grain',
+    style: {
+      backgroundColor: BAND_TONE,
+      backgroundImage: `linear-gradient(180deg, ${greyRamp[900]} 0%, ${greyRamp[875]} 100%)`,
+    },
+  },
+  {
+    key: '3',
+    answer: 'the shipped stack MINUS the dither — grain alone',
+    style: { ...SHIPPED_PAPER, backgroundImage: grainForTone(BAND_TONE) },
+  },
+]
+
 export const Banding: StoryObj = {
   name: 'C4 · Banding — does the dither earn its place',
   render: () => (
     <Panel
       title="C4 · Banding"
       task={
-        'Two wide fields carrying the same gradient. Look for horizontal STEPS — flat stripes with ' +
-        'a visible edge between them, rather than a smooth fall. Which field bands, if either? ' +
-        'This is the one check that cannot be done anywhere but on the panel: banding is an 8-bit ' +
-        'artefact of this display.'
+        'Three wide fields. Look for horizontal STEPS — flat stripes with a visible edge between ' +
+        'them, rather than a smooth fall. Say BANDS or SMOOTH for each. This is the one check that ' +
+        'cannot be done anywhere but on the panel: banding is an 8-bit artefact of this display.'
       }
     >
       {(revealed) => (
         <View>
-          {/*
-           * BOTH fields carry grain; the ONLY difference is the dither layer.
-           * Grain also breaks up banding, so a grain-vs-no-grain comparison would
-           * confound which layer is doing the work — and grain is visible, which
-           * would give the answer away on a cue that is not the one under test.
-           */}
-          <View
-            style={
-              {
-                height: 260,
-                borderRadius: 8,
-                backgroundColor: BAND_TONE,
-                backgroundImage: `${grainForTone(BAND_TONE)}, ${tonalFill(BAND_TONE)}`,
-              } as Record<string, unknown>
-            }
-          />
-          <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 6 }}>
-            {revealed ? 'Field 1 · NO dither — grain over the fill' : 'Field 1 · steps? ______'}
-          </Text>
-
-          <View
-            style={
-              {
-                height: 260,
-                borderRadius: 8,
-                marginTop: 20,
-                backgroundColor: BAND_TONE,
-                backgroundImage: `${ditherTile()}, ${grainForTone(BAND_TONE)}, ${tonalFill(BAND_TONE)}`,
-              } as Record<string, unknown>
-            }
-          />
-          <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 6 }}>
-            {revealed
-              ? 'Field 2 · dither ADDED over the same grain + fill — the shipped stack'
-              : 'Field 2 · steps? ______'}
-          </Text>
+          {BAND_FIELDS.map((field) => (
+            <View key={field.key}>
+              <View
+                style={
+                  {
+                    height: 240,
+                    borderRadius: 8,
+                    marginTop: field.key === '1' ? 0 : 20,
+                    ...field.style,
+                  } as Record<string, unknown>
+                }
+              />
+              <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 6 }}>
+                {`Field ${field.key}`}
+                {revealed ? `  ·  ${field.answer}` : '  ·  bands? ______'}
+              </Text>
+            </View>
+          ))}
 
           {revealed ? (
             <View style={{ marginTop: 14, maxWidth: 1000 }}>
               <KeyLine>
-                {'PASS: field 2 does not band. Field 1 banding is FINE — it is the reason dither ' +
-                  'exists, and it is the evidence the dither is doing work.'}
+                {'READ FIELD 2 FIRST. It is the control and it must BAND. If it reads smooth, this ' +
+                  'panel is blind under these conditions and rows about fields 1 and 3 mean nothing ' +
+                  '— record VOID, do not record PASS. That is precisely how run 1 went wrong.'}
               </KeyLine>
               <KeyLine>
-                {'If NEITHER bands, the dither is unearned on this panel and `ditherTile` can come ' +
-                  'out of paperSheet — that is a real result, not a null one. If BOTH band, raise ' +
-                  'the 0.02α in `ditherTile` (materials.ts) until it stops; past ~0.03 it stops ' +
-                  'being invisible and becomes texture, at which point it is grain, not dither.'}
+                {'Given a banding control: if field 3 bands and field 1 does not, the dither is ' +
+                  'earning its place — keep it. If NEITHER bands, there is no gradient left in the ' +
+                  'shipped material to protect and ditherTile comes out of paperSheet. That is a ' +
+                  'real result, not a null one, and it is the expected one now the fill is gone.'}
+              </KeyLine>
+              <KeyLine>
+                {'If field 1 bands too, raise the 0.02α in ditherTile (materials.ts) until it stops; ' +
+                  'past ~0.03 it stops being invisible and becomes texture, at which point it is ' +
+                  'grain, not dither.'}
               </KeyLine>
             </View>
           ) : null}

--- a/packages/ui/src/theme/depth-calibration.test.tsx
+++ b/packages/ui/src/theme/depth-calibration.test.tsx
@@ -12,8 +12,8 @@ import * as stories from './DepthCalibration.stories'
  * The theme stories are outside `stories-smoke.test.tsx`'s
  * `../components/**` glob, so this file also carries the render smoke for them.
  */
-const { Hairlines, ToneSteps, TonalFill, Banding } = composeStories(stories)
-const ALL = { Hairlines, ToneSteps, TonalFill, Banding }
+const { Hairlines, ToneSteps, PaperMaterial, Banding } = composeStories(stories)
+const ALL = { Hairlines, ToneSteps, PaperMaterial, Banding }
 
 describe('depth calibration rig', () => {
   for (const [name, Story] of Object.entries(ALL)) {
@@ -47,6 +47,34 @@ describe('depth calibration rig', () => {
 
     const rows = decoys.map((n) => n.textContent?.match(/^[A-D](\d)/)?.[1])
     expect(new Set(rows).size).toBe(4)
+  })
+
+  it('seeds an identical pair among the paper sheets', () => {
+    render(<PaperMaterial />)
+    expect(screen.queryByText(/FLAT \(decoy\)/)).toBeNull()
+
+    // Two byte-identical flats, so "all three look the same" stays an available
+    // answer rather than an admission — the material has to be picked OUT.
+    fireEvent.click(screen.getByText('Reveal key'))
+    expect(screen.getAllByText(/FLAT \(decoy\)/)).toHaveLength(2)
+  })
+
+  it('keeps a real gradient in the banding panel for the control to work', () => {
+    // Run 1 was VOID because nothing on the panel could band once the tonal fill
+    // turned out to be invisible. The control is the fix, and this is the
+    // property that makes it one: exactly one field carries a gradient, and it
+    // is not any of the shipped-material fields.
+    const { container } = render(<Banding />)
+    const gradients = container.querySelectorAll('[style*="linear-gradient"]')
+    expect(gradients).toHaveLength(1)
+  })
+
+  it('seeds a positive control among the banding fields', () => {
+    render(<Banding />)
+    expect(screen.queryByText(/CONTROL \(decoy\)/)).toBeNull()
+
+    fireEvent.click(screen.getByText('Reveal key'))
+    expect(screen.getAllByText(/CONTROL \(decoy\)/)).toHaveLength(1)
   })
 
   it('seeds an identical pair among the tone-step pairs', () => {

--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -119,10 +119,13 @@
     --color-border-input-focus: #828DF8;
     --color-border-input-error: #E05254;
 
-    /* Alpha hairline separators — self-normalizing on any plane (§4/S-2) */
-    --color-hairline-subtle: rgba(255, 255, 255, 0.06);
-    --color-hairline-default: rgba(255, 255, 255, 0.09);
-    --color-hairline-strong: rgba(255, 255, 255, 0.14);
+    /* Alpha hairline separators — self-normalizing on any plane (§4/S-2).
+       Retuned on the wall (VW-99): each tier steps onto the previous tier's
+       measured-good value. Two decimals only — RNW quantises alpha to 8 bits.
+       Dark only; the light family below is unverified. */
+    --color-hairline-subtle: rgba(255, 255, 255, 0.09);
+    --color-hairline-default: rgba(255, 255, 255, 0.14);
+    --color-hairline-strong: rgba(255, 255, 255, 0.21);
 
     --color-interactive-hover: rgba(255, 255, 255, 0.04);
     --color-interactive-focus: rgba(255, 255, 255, 0.12);

--- a/packages/ui/src/theme/materials.test.ts
+++ b/packages/ui/src/theme/materials.test.ts
@@ -1,62 +1,27 @@
 /**
  * Surface materials — the properties that make paper read as ONE material.
  *
- * These treatments are mostly invisible by design (a ΔL* 3 gradient, a 0.02α
- * dither), which makes them exactly the kind of thing that can be broken without
- * anyone noticing until it looks subtly wrong on the wall. So the numbers that
- * define them are asserted rather than left as comments.
+ * These treatments are mostly invisible by design (a 0.02α dither, grain that is
+ * a whisper at dark tones), which makes them exactly the kind of thing that can be
+ * broken without anyone noticing until it looks subtly wrong on the wall. So the
+ * numbers that define them are asserted rather than left as comments.
+ *
+ * The `tonal fill` block that used to lead this file went with `tonalFill` in
+ * VW-99 — the wall run found the ΔL* 3 gradient indiscernible. See the
+ * materials.ts module header.
  */
 import { describe, it, expect } from 'vitest'
 import {
   grainOpacityForTone,
   grainForTone,
   ditherTile,
-  tonalFill,
   paperSheet,
   insetWell,
   barPaper,
 } from './materials'
 import { greyRamp } from './tokens/primitives'
 
-const hex2rgb = (h: string): [number, number, number] => {
-  const n = parseInt(h.slice(1), 16)
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
-}
-const srgb2lin = (c: number) => {
-  const s = c / 255
-  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
-}
-const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116)
-const Lstar = (hex: string) => {
-  const [r, g, b] = hex2rgb(hex).map(srgb2lin)
-  return 116 * f(r * 0.2126729 + g * 0.7151522 + b * 0.072175) - 16
-}
-
-const PLANES = [850, 875, 900, 925, 950, 975] as const
 const styleOf = (s: Record<string, unknown>) => s as { backgroundImage?: string; boxShadow?: string; backgroundColor?: string }
-
-describe('tonal fill', () => {
-  /**
-   * The whole point of the gradient is to sit just under "seen as a gradient".
-   * Past roughly ΔL* 4 it stops reading as light falling on a sheet and starts
-   * reading as decoration — the thing the surface exploration rejected.
-   */
-  it.each(PLANES)('spans no more than ΔL* 3 on grey-%s', (step) => {
-    const stops = tonalFill(greyRamp[step]).match(/#[0-9A-F]{6}/g)
-    expect(stops, 'gradient should declare two hex stops').toHaveLength(2)
-    const span = Math.abs(Lstar(stops![0]) - Lstar(stops![1]))
-    expect(span, `grey-${step} spans ΔL* ${span.toFixed(2)}`).toBeLessThanOrEqual(3.1)
-    // …and it must actually be there. A zero-span "gradient" is a flat fill
-    // wearing a costume, which is the failure mode a ceiling-only check misses.
-    expect(span, `grey-${step} has no perceptible span`).toBeGreaterThan(2)
-  })
-
-  it('runs lighter at the top, darker at the bottom', () => {
-    const stops = tonalFill(greyRamp[900]).match(/#[0-9A-F]{6}/g)!
-    expect(Lstar(stops[0])).toBeGreaterThan(Lstar(stops[1]))
-    expect(tonalFill(greyRamp[900])).toContain('180deg')
-  })
-})
 
 describe('grain', () => {
   it('scales opacity with the tone it sits on', () => {
@@ -105,16 +70,16 @@ describe('dither', () => {
 })
 
 describe('paperSheet', () => {
-  it('layers dither over grain over the tonal fill', () => {
+  it('layers dither over grain, and carries no gradient', () => {
     const bg = styleOf(paperSheet(greyRamp[875])).backgroundImage!
-    const gradientAt = bg.indexOf('linear-gradient')
-    expect(gradientAt, 'tonal fill missing').toBeGreaterThan(-1)
-    // Later entries in backgroundImage paint BEHIND earlier ones, so the fill
-    // must come last or it covers the texture it is supposed to sit under.
-    expect(bg.indexOf('url('), 'texture should precede the fill').toBeLessThan(gradientAt)
     // Count data URIs, not 'url(' — each SVG tile contains a `filter='url(#n)'`
     // internally, so counting the token double-reports.
     expect(bg.split('data:image/svg+xml').length - 1, 'expected both grain and dither').toBe(2)
+    // VW-99 removed the tonal fill: on the wall it could not be told from a flat
+    // sheet of the same tone, and the full material still read as a flat digital
+    // rectangle. Asserted rather than merely deleted, so re-adding a gradient is
+    // a deliberate act with a wall run behind it, not a quiet revert.
+    expect(bg, 'the tonal fill was removed in VW-99').not.toContain('linear-gradient')
   })
 
   it('keeps a solid backgroundColor so native does not fall through', () => {

--- a/packages/ui/src/theme/materials.ts
+++ b/packages/ui/src/theme/materials.ts
@@ -20,7 +20,28 @@
  * why every material here keeps `backgroundColor` load-bearing on its own. A
  * material must never be the only thing carrying meaning.
  *
- * See coordination/design-explorations/surface-system-north-star.md §4.
+ * ── THE TONAL FILL IS GONE (VW-99, S-6 wall calibration) ───────────────────
+ *
+ * `paperSheet` used to carry a vertical ΔL* 3 gradient, sized "just under seen
+ * as a gradient". On the wall panel at ~3 m it could not be told from a flat
+ * sheet of the same tone, and the full material still read as — the operator's
+ * words — "a flat digital rectangle". It failed its own stated purpose, which
+ * was precisely to stop that.
+ *
+ * Raising it was not available. The design ceiling is ~ΔL* 4 (past that it reads
+ * decorative, which the exploration rejected), and the same run showed why the
+ * headroom would not have helped: the 0.025 ELEVATION step — a comparable ΔL*
+ * — was called instantly, because it sits at a hard edge between two flat
+ * fields. The fill spread the same amount smoothly over ~300 px, where vision is
+ * genuinely poor. It is a spatial-frequency problem, not an amplitude one, so
+ * the band between "invisible" and "decorative" may simply not exist here.
+ *
+ * Kept: grain, rim-light, contact shadow. `ditherTile` is retained pending one
+ * re-run — it existed only to stop the FILL banding, so it is probably dead
+ * weight now, but "probably" is not a measurement.
+ *
+ * See coordination/design-explorations/surface-system-north-star.md §4 and
+ * coordination/validation-runbooks/VW-99-depth-wall-calibration.md.
  */
 import type { ViewStyle } from 'react-native'
 import { getSemanticColors } from './tokens/semantic'
@@ -48,50 +69,9 @@ function perceivedLuminance(hex: string): number {
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255
 }
 
-const srgb2lin = (c8: number) => {
-  const s = c8 / 255
-  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
-}
-const lin2srgb = (v: number) => (v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055)
-const clamp01 = (x: number) => Math.min(1, Math.max(0, x))
-const fLab = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116)
-const fInv = (t: number) => (t ** 3 > 0.008856 ? t ** 3 : (t - 16 / 116) / 7.787)
-
-/** CIELAB (D65) for a hex. Used so the tonal fill can be specified in ΔL*. */
-function hexToLab(hex: string): [number, number, number] {
-  const rgb = parseHex(hex)
-  if (!rgb) return [50, 0, 0]
-  const [r, g, b] = rgb.map(srgb2lin)
-  const X = (r * 0.4124564 + g * 0.3575761 + b * 0.1804375) / 0.95047
-  const Y = r * 0.2126729 + g * 0.7151522 + b * 0.072175
-  const Z = (r * 0.0193339 + g * 0.119192 + b * 0.9503041) / 1.08883
-  const [fx, fy, fz] = [fLab(X), fLab(Y), fLab(Z)]
-  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)]
-}
-
-function labToHex(L: number, a: number, b: number): string {
-  const fy = (L + 16) / 116
-  const [fx, fz] = [fy + a / 500, fy - b / 200]
-  const [X, Y, Z] = [0.95047 * fInv(fx), fInv(fy), 1.08883 * fInv(fz)]
-  const rgb = [
-    X * 3.2404542 - Y * 1.5371385 - Z * 0.4985314,
-    -X * 0.969266 + Y * 1.8760108 + Z * 0.041556,
-    X * 0.0556434 - Y * 0.2040259 + Z * 1.0572252,
-  ]
-  return (
-    '#' +
-    rgb
-      .map((v) => Math.round(clamp01(lin2srgb(clamp01(v))) * 255).toString(16).padStart(2, '0'))
-      .join('')
-      .toUpperCase()
-  )
-}
-
-/** Shift a colour by ΔL* in CIELAB, holding its hue and chroma. */
-function shiftL(hex: string, dL: number): string {
-  const [L, a, b] = hexToLab(hex)
-  return labToHex(Math.max(0, Math.min(100, L + dL)), a, b)
-}
+// The CIELAB conversion chain (srgb2lin/lin2srgb/fLab/fInv, hexToLab/labToHex,
+// shiftL) lived here so the tonal fill could be specified in ΔL*. It had no
+// other caller, so it went with the fill — see the module header.
 
 // ── grain ───────────────────────────────────────────────────────────────────
 
@@ -146,23 +126,9 @@ export function ditherTile(): string {
   )
 }
 
-// ── tonal fill ──────────────────────────────────────────────────────────────
-
-/**
- * The tonal half of the paper recipe: a vertical top-lighter → bottom-darker
- * gradient across the fill, total span ΔL* ≤ 3.
- *
- * Three is deliberate and is close to a just-noticeable difference. The point is
- * not to be seen as a gradient — it is to stop a large plane reading as a flat
- * digital rectangle, by giving it the faint sense of light falling from above
- * that every physical sheet has. Push it past ~4 and it stops being material and
- * starts being a decorative gradient, which is the thing the exploration rejected.
- */
-export function tonalFill(tone: string): string {
-  const top = shiftL(tone, +1.5)
-  const bottom = shiftL(tone, -1.5)
-  return `linear-gradient(180deg, ${top} 0%, ${bottom} 100%)`
-}
+// `tonalFill` lived here until VW-99 measured it on the wall and found it
+// indiscernible. Deleted rather than left exported-but-unused; the reasoning is
+// in the module header, which is the part worth keeping.
 
 // ── the materials ───────────────────────────────────────────────────────────
 
@@ -182,8 +148,8 @@ export function tonalFill(tone: string): string {
 export function paperSheet(tone: string = c['surface-raised']): ViewStyle {
   return {
     backgroundColor: tone,
-    // Layered front-to-back: dither over grain over the tonal fill.
-    backgroundImage: `${ditherTile()}, ${grainForTone(tone)}, ${tonalFill(tone)}`,
+    // Layered front-to-back: dither over grain. No tonal fill — see VW-99 below.
+    backgroundImage: `${ditherTile()}, ${grainForTone(tone)}`,
     boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), 0 8px 22px rgba(0,0,0,0.50)',
   } as unknown as ViewStyle
 }

--- a/packages/ui/src/theme/materials.ts
+++ b/packages/ui/src/theme/materials.ts
@@ -114,9 +114,11 @@ export function grainForTone(baseColor: string): string {
  * because a low-contrast vertical gradient across a wide plane bands into visible
  * steps on an 8-bit panel, and a whisper of noise breaks the step edges up.
  *
- * Only worth applying where a gradient actually spans real width — {@link
- * paperSheet} already includes it via {@link tonalFill}. On a surface with no
- * gradient there is nothing to band, and this is dead weight.
+ * Only worth applying where a gradient actually spans real width. On a surface
+ * with no gradient there is nothing to band and this is dead weight — which is
+ * now the open question for {@link paperSheet} itself, since the gradient this
+ * existed to protect (`tonalFill`) is gone. VW-99 panel C4 decides it, on the
+ * wall, against a seeded positive control.
  */
 export function ditherTile(): string {
   return (

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -338,9 +338,28 @@ export const semanticColorsDark = {
   // one family works at every elevation instead of per-surface border tokens.
   // Shadows are demoted to floating-overlay use only (not shipped as a fill
   // separator here — see elevation.ts, follow-up S-4).
-  'hairline-subtle': 'rgba(255, 255, 255, 0.06)',
-  'hairline-default': 'rgba(255, 255, 255, 0.09)',
-  'hairline-strong': 'rgba(255, 255, 255, 0.14)',
+  //
+  // RETUNED on the wall (VW-99, S-6). The original .06/.09/.14 were set at a
+  // desk. On the panel at ~3 m `subtle` rendered but was indiscernible, and
+  // `default` — the load-bearing one, with no solid-border fallback since
+  // TD-07.14 — went weak on the lightest plane. `strong` read cleanly with room
+  // to spare, which is what made raising the whole family viable.
+  //
+  // Each tier steps up onto the next MEASURED-GOOD rung rather than an
+  // interpolated one: the new `subtle` is the old `default`, and the new
+  // `default` is the old `strong` — a value just confirmed legible on all four
+  // planes. Spacing goes 1 : 1.56 : 2.33, against the original 1 : 1.5 : 2.33.
+  //
+  // Keep these to TWO decimals. react-native-web quantises alpha to 8 bits, so
+  // a 3-decimal value silently rounds on the way to the DOM (.135 renders as
+  // .13) — the token would say one thing and paint another.
+  //
+  // DARK ONLY. The light family above composites toward BLACK on light planes,
+  // which this run says nothing about — do not mirror these numbers into it
+  // without its own verification.
+  'hairline-subtle': 'rgba(255, 255, 255, 0.09)',
+  'hairline-default': 'rgba(255, 255, 255, 0.14)',
+  'hairline-strong': 'rgba(255, 255, 255, 0.21)',
 
   // Interactive states
   'interactive-hover': 'rgba(255, 255, 255, 0.04)',


### PR DESCRIPTION
> ⚠️ **MERGE #150 FIRST.** That PR's calibration story imports `tonalFill`, which this PR deletes — whichever lands second breaks the other. Once #150 is in, I'll rebase this and update C3/C4 to match the new material, which the re-run needs anyway.

## The sheet was run on the wall

Two of four panels failed. This is the fix.

| Panel | Result |
|---|---|
| **C1** Hairlines | **FAIL** — retuned here |
| **C2** Tone steps | **PASS**, perfect score with the decoy caught |
| **C3** Tonal fill | **FAIL** — fill removed here |
| **C4** Banding | **VOID** — see below |

## C1 — hairlines retuned

At ~3 m, `subtle` rendered but was **indiscernible**, and `default` went weak on the lightest plane. Since TD-07.14 deleted the solid border tokens, `default` washing out **has no fallback**. `strong` read cleanly *with room to spare* — which is what made raising the family viable instead of forcing a compression.

Each tier now steps onto the previous tier's **measured-good** value rather than an interpolated one:

```
subtle   .06 → .09    (= the old default)
default  .09 → .14    (= the old strong — just confirmed legible on all 4 planes)
strong   .14 → .21
```

Spacing `1 : 1.56 : 2.33`, against the original `1 : 1.5 : 2.33`.

The first draft used `.135` to hold the ratios exactly. **react-native-web quantises alpha to 8 bits** and rendered it `.13` — a token that says one thing and paints another. Verified directly, so the family is two-decimal now and the comment says why.

## C2 — untouched, and that's the good news

All 5 edges counted, the 0.025 step called *easily*, seeded identical pair found. `elevation.ts` is not modified: **the tone half of the depth model survives the panel as designed**, which was the scarier of the two risks given shadow is gated off below level 4.

## C3 — the fill is gone, and amplitude couldn't have saved it

The ΔL\* 3 gradient could not be told from a flat sheet, and the full material still read as *"a flat digital rectangle"* — the exact thing the fill exists to prevent. It failed its own stated purpose, not just a visibility check.

Raising it wasn't available: the ceiling is ~ΔL\* 4 before it reads decorative. And the same run shows why the headroom wouldn't have helped — the **0.025 elevation step, a comparable ΔL\*, was called instantly**, because it sits at a hard edge between flat fields, while the fill spreads the same amount smoothly over ~300 px. That's a spatial-frequency problem, not an amplitude one.

So `tonalFill` is deleted, along with the CIELAB conversion chain (`hexToLab`/`labToHex`/`shiftL` + helpers) that existed only to serve it. The reasoning moves into the `materials.ts` module header, and a test asserts `paperSheet` carries no gradient — re-adding one should be deliberate, with a wall run behind it, not a quiet revert.

## C4 — void, not a pass

Neither field banded. But **the dither exists only to stop the FILL banding**, so with the fill invisible there was nothing on screen that *could* band — the panel was never able to fail. `ditherTile` is retained pending a re-run rather than removed on a result that proves nothing.

(My own runbook said "neither bands ⇒ remove the dither." That conclusion was wrong and is corrected.)

## R3's self-normalization assertion: absolute → ratio

The old `spread < 4 L*` tripped here (strong 3.46 → 5.29). That's **arithmetic, not regression**: absolute spread scales with alpha, so the assertion failed *any* strengthening regardless of whether the property held.

Measured relative spread `(max−min)/min` — **new** 0.27 / 0.29 / 0.29 vs **old** 0.28 / 0.27 / 0.28. Self-normalization is untouched. A ratio is scale-invariant, which is what the property actually claims.

## Not done deliberately

- **Light mode is not mirrored.** It composites toward *black* on light planes; this run says nothing about it.
- **`--color-divider` still sits at `rgba(255,255,255,0.09)`** — the old `hairline-default` value. Functionally a hairline, not covered by this run. Flagging as a follow-up rather than moving it blind.

## Verification

- 147 files / **2877 tests** green (−7 = the deleted `tonalFill` assertions)
- lint **0 errors**, raw-color violations **0**
- `format:check` flags `materials.ts` / `materials.test.ts` / `semantic.ts` — **identical baseline on main** (186 files fail repo-wide); `semantic.ts` is hand-aligned and must not be reformatted
- RNW alpha quantisation verified by direct probe, not assumed

Refs VW-99, TD-07.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)