### PR TITLE
Apply VW-99 run 2 wall results — hairlines +.01, rim-light .20, well floor .12, dither deleted

### DIFF
--- a/packages/ui/specimen/comparison.tsx
+++ b/packages/ui/specimen/comparison.tsx
@@ -38,11 +38,11 @@ const HTML_CSS = `
     --text-secondary: #A29F9D;
     --text-tertiary: #888684;
     /* Mirrors hairline-default / hairline-strong in tokens/semantic.ts. Retuned
-       on the wall in VW-99 (.09/.14 -> .14/.21). This copy is hand-maintained,
-       so it drifts silently unless the parity layer catches it — which is
-       exactly what happened here. */
-    --border-default: rgba(255, 255, 255, 0.14);
-    --border-strong: rgba(255, 255, 255, 0.21);
+       on the wall in VW-99 across two runs (.09/.14 -> .14/.21 -> .15/.22).
+       This copy is hand-maintained, so it drifts silently unless the parity
+       layer catches it — which is exactly what happened the first time. */
+    --border-default: rgba(255, 255, 255, 0.15);
+    --border-strong: rgba(255, 255, 255, 0.22);
     /* A dim FILL for 'no data' dots. Used to borrow --border-strong; borders are
        alpha now, so a fill needs its own solid ramp step. */
     --dot-inactive: #2C2A28;

--- a/packages/ui/src/theme/DepthCalibration.stories.tsx
+++ b/packages/ui/src/theme/DepthCalibration.stories.tsx
@@ -353,6 +353,24 @@ const PAPER_TONE = greyRamp[875]
  */
 const PAPER_SHEETS = ['flat', 'paper', 'flat'] as const
 
+/**
+ * ADDED IN RUN 2. `insetWell` is the other material TD-07.16 shipped, and it has
+ * never been on a panel. Run 2 flagged `paperSheet`'s rim-light as weak at .10 —
+ * and the well's floor light, which its own docstring calls "the load-bearing
+ * half", is at .04. That is below every hairline value the same run rejected as
+ * too faint, so it is very likely inert on the wall and nobody has looked.
+ *
+ * Forced choice rather than "can you see it": the SHIPPED value, a candidate,
+ * and a well with no floor line at all. Reporting a line on the decoy invalidates
+ * the row. Answering it here costs one glance and saves a whole extra sitting.
+ */
+const WELL_TONE = greyRamp[950]
+const WELL_FLOORS: { label: string; floorAlpha: number | null; answer: string }[] = [
+  { label: '1', floorAlpha: 0.12, answer: 'CANDIDATE — floor light raised to .12' },
+  { label: '2', floorAlpha: null, answer: 'NONE (decoy) — inner top shadow only, no floor line' },
+  { label: '3', floorAlpha: 0.04, answer: 'SHIPPED — floor light at .04' },
+]
+
 export const PaperMaterial: StoryObj = {
   name: 'C3 · Paper material — what is left after the fill',
   render: () => (
@@ -403,6 +421,35 @@ export const PaperMaterial: StoryObj = {
           <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 8 }}>
             {revealed ? 'paperSheet() at hero width' : 'reads as: ______'}
           </Text>
+
+          <Text
+            className="text-text-secondary"
+            style={{ fontSize: 15, marginTop: 26, marginBottom: 10 }}
+          >
+            Inset wells — which of these have a light line along the FLOOR (bottom inner edge)?
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 22 }}>
+            {WELL_FLOORS.map((w) => (
+              <View key={w.label} style={{ flex: 1 }}>
+                <View
+                  style={
+                    {
+                      height: 120,
+                      borderRadius: 10,
+                      backgroundColor: WELL_TONE,
+                      boxShadow: w.floorAlpha
+                        ? `inset 0 2px 6px rgba(0,0,0,0.55), inset 0 -1px 0 rgba(255,255,255,${w.floorAlpha})`
+                        : 'inset 0 2px 6px rgba(0,0,0,0.55)',
+                    } as Record<string, unknown>
+                  }
+                />
+                <Text className="text-text-tertiary" style={{ fontSize: 12, marginTop: 6 }}>
+                  {w.label}
+                  {revealed ? `  ·  ${w.answer}` : '  ·  floor line? ______'}
+                </Text>
+              </View>
+            ))}
+          </View>
 
           {revealed ? (
             <View style={{ marginTop: 14, maxWidth: 1000 }}>
@@ -482,6 +529,34 @@ const BAND_TONE = greyRamp[900]
  */
 const SHIPPED_PAPER = paperSheet(BAND_TONE) as Record<string, unknown>
 
+/**
+ * ADDED IN RUN 2, and it is the whole reason this panel is worth re-running.
+ *
+ * Run 2 reported NO banding anywhere — including on the control that was
+ * supposed to guarantee it. By the sheet that is another VOID, but "the control
+ * did not fire" has two very different causes and they demand opposite actions:
+ *
+ *   a. the panel/viewing setup cannot resolve banding  -> VOID, fix the setup
+ *   b. the render path genuinely does not band here    -> ditherTile is dead
+ *      (10-bit panel, or the browser dithers gradients itself)
+ *
+ * A smooth control cannot tell those apart, because both produce "no steps".
+ * So: the same tone span, quantised BY HAND into five hard-edged stripes. This
+ * is banding, drawn deliberately. C2 already proved hard tone edges at this
+ * spacing are visible on the wall, so if these stripes read and the smooth
+ * gradient beside them does not, cause (b) is established — the pipeline is not
+ * producing the artefact, and the mitigation for it is unearned.
+ */
+const BAND_STEPS = (() => {
+  const from = [0x2c, 0x2a, 0x28] // grey-900
+  const to = [0x31, 0x30, 0x2f] // grey-875
+  return Array.from({ length: 5 }, (_, i) => {
+    const t = i / 4
+    const ch = from.map((f, k) => Math.round(f + (to[k] - f) * t))
+    return `#${ch.map((v) => v.toString(16).padStart(2, '0')).join('')}`
+  })
+})()
+
 const BAND_FIELDS: { key: string; answer: string; style: Record<string, unknown> }[] = [
   {
     key: '1',
@@ -490,10 +565,21 @@ const BAND_FIELDS: { key: string; answer: string; style: Record<string, unknown>
   },
   {
     key: '2',
-    answer: 'CONTROL (decoy) — a bare grey-900 → grey-875 gradient, no dither, no grain',
+    answer: 'CONTROL — a bare grey-900 → grey-875 gradient, no dither, no grain',
     style: {
       backgroundColor: BAND_TONE,
       backgroundImage: `linear-gradient(180deg, ${greyRamp[900]} 0%, ${greyRamp[875]} 100%)`,
+    },
+  },
+  {
+    key: '2b',
+    answer:
+      'REFERENCE — hard-edged stripes, grey-900 → grey-875 in 5 steps. This is what banding LOOKS like.',
+    style: {
+      backgroundImage: `linear-gradient(180deg, ${BAND_STEPS.map(
+        (hex, i) =>
+          `${hex} ${(i / BAND_STEPS.length) * 100}%, ${hex} ${((i + 1) / BAND_STEPS.length) * 100}%`,
+      ).join(', ')})`,
     },
   },
   {
@@ -509,7 +595,7 @@ export const Banding: StoryObj = {
     <Panel
       title="C4 · Banding"
       task={
-        'Three wide fields. Look for horizontal STEPS — flat stripes with a visible edge between ' +
+        'Four wide fields. Look for horizontal STEPS — flat stripes with a visible edge between ' +
         'them, rather than a smooth fall. Say BANDS or SMOOTH for each. This is the one check that ' +
         'cannot be done anywhere but on the panel: banding is an 8-bit artefact of this display.'
       }
@@ -538,15 +624,22 @@ export const Banding: StoryObj = {
           {revealed ? (
             <View style={{ marginTop: 14, maxWidth: 1000 }}>
               <KeyLine>
-                {'READ FIELD 2 FIRST. It is the control and it must BAND. If it reads smooth, this ' +
-                  'panel is blind under these conditions and rows about fields 1 and 3 mean nothing ' +
-                  '— record VOID, do not record PASS. That is precisely how run 1 went wrong.'}
+                {'READ FIELDS 2 AND 2b FIRST — they decide whether the rest of the panel means ' +
+                  'anything. 2b is banding drawn by hand: the same tone span quantised into five ' +
+                  'hard-edged 1-level steps, which is exactly what the artefact looks like when it ' +
+                  'occurs. Sanity-check the setup (brightness, no browser zoom) before calling it.'}
               </KeyLine>
               <KeyLine>
-                {'Given a banding control: if field 3 bands and field 1 does not, the dither is ' +
-                  'earning its place — keep it. If NEITHER bands, there is no gradient left in the ' +
-                  'shipped material to protect and ditherTile comes out of paperSheet. That is a ' +
-                  'real result, not a null one, and it is the expected one now the fill is gone.'}
+                {'2b reads, 2 (smooth) does not -> this render path does not band: 10-bit panel, or ' +
+                  'the browser dithers gradients itself. 2b ALSO invisible -> the artefact is below ' +
+                  'threshold here at this tone span. Either way ditherTile buys nothing on this ' +
+                  'display and comes out of paperSheet — a real result, not a null one. The one ' +
+                  'caveat is that it is a claim about THIS panel; the same recipe on a phone is a ' +
+                  'separate question, and paperSheet is hero-surface-only for that reason.'}
+              </KeyLine>
+              <KeyLine>
+                {'If 2 DOES band: compare 1 (shipped) against 3 (no dither). 3 banding and 1 not is ' +
+                  'the dither earning its place — keep it.'}
               </KeyLine>
               <KeyLine>
                 {'If field 1 bands too, raise the 0.02α in ditherTile (materials.ts) until it stops; ' +

--- a/packages/ui/src/theme/depth-calibration.test.tsx
+++ b/packages/ui/src/theme/depth-calibration.test.tsx
@@ -59,22 +59,32 @@ describe('depth calibration rig', () => {
     expect(screen.getAllByText(/FLAT \(decoy\)/)).toHaveLength(2)
   })
 
-  it('keeps a real gradient in the banding panel for the control to work', () => {
-    // Run 1 was VOID because nothing on the panel could band once the tonal fill
-    // turned out to be invisible. The control is the fix, and this is the
-    // property that makes it one: exactly one field carries a gradient, and it
-    // is not any of the shipped-material fields.
+  it('pairs the smooth banding control with a hand-quantised reference', () => {
+    // Run 1 was VOID because nothing could band. Run 2 then found the smooth
+    // control ALSO reading clean, which is ambiguous: a blind panel and a render
+    // path that simply does not band both look like "no steps". The hard-edged
+    // reference disambiguates them, so the panel needs BOTH gradients — and
+    // neither may be one of the shipped-material fields.
     const { container } = render(<Banding />)
-    const gradients = container.querySelectorAll('[style*="linear-gradient"]')
-    expect(gradients).toHaveLength(1)
+    expect(container.querySelectorAll('[style*="linear-gradient"]')).toHaveLength(2)
   })
 
-  it('seeds a positive control among the banding fields', () => {
+  it('labels the control and the reference distinctly, and only on reveal', () => {
     render(<Banding />)
-    expect(screen.queryByText(/CONTROL \(decoy\)/)).toBeNull()
+    expect(screen.queryByText(/CONTROL/)).toBeNull()
+    expect(screen.queryByText(/REFERENCE/)).toBeNull()
 
     fireEvent.click(screen.getByText('Reveal key'))
-    expect(screen.getAllByText(/CONTROL \(decoy\)/)).toHaveLength(1)
+    expect(screen.getAllByText(/CONTROL/)).toHaveLength(1)
+    expect(screen.getAllByText(/REFERENCE/)).toHaveLength(1)
+  })
+
+  it('seeds a no-floor-line decoy among the inset wells', () => {
+    render(<PaperMaterial />)
+    expect(screen.queryByText(/NONE \(decoy\)/)).toBeNull()
+
+    fireEvent.click(screen.getByText('Reveal key'))
+    expect(screen.getAllByText(/NONE \(decoy\)/)).toHaveLength(1)
   })
 
   it('seeds an identical pair among the tone-step pairs', () => {

--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -121,11 +121,12 @@
 
     /* Alpha hairline separators — self-normalizing on any plane (§4/S-2).
        Retuned on the wall (VW-99): each tier steps onto the previous tier's
-       measured-good value. Two decimals only — RNW quantises alpha to 8 bits.
+       measured-good value, then +.01 across the family on run 2 for comfort.
+       Two decimals only — RNW quantises alpha to 8 bits.
        Dark only; the light family below is unverified. */
-    --color-hairline-subtle: rgba(255, 255, 255, 0.09);
-    --color-hairline-default: rgba(255, 255, 255, 0.14);
-    --color-hairline-strong: rgba(255, 255, 255, 0.21);
+    --color-hairline-subtle: rgba(255, 255, 255, 0.10);
+    --color-hairline-default: rgba(255, 255, 255, 0.15);
+    --color-hairline-strong: rgba(255, 255, 255, 0.22);
 
     --color-interactive-hover: rgba(255, 255, 255, 0.04);
     --color-interactive-focus: rgba(255, 255, 255, 0.12);

--- a/packages/ui/src/theme/materials.test.ts
+++ b/packages/ui/src/theme/materials.test.ts
@@ -1,24 +1,18 @@
 /**
  * Surface materials — the properties that make paper read as ONE material.
  *
- * These treatments are mostly invisible by design (a 0.02α dither, grain that is
- * a whisper at dark tones), which makes them exactly the kind of thing that can be
- * broken without anyone noticing until it looks subtly wrong on the wall. So the
+ * These treatments are subtle by design (grain is a whisper at dark tones, the
+ * rim is one pixel), which makes them exactly the kind of thing that can be
+ * broken without anyone noticing until it looks wrong on the wall. So the
  * numbers that define them are asserted rather than left as comments.
  *
- * The `tonal fill` block that used to lead this file went with `tonalFill` in
- * VW-99 — the wall run found the ΔL* 3 gradient indiscernible. See the
- * materials.ts module header.
+ * The `tonal fill` and `dither` blocks that used to lead this file went with
+ * `tonalFill` and `ditherTile` in VW-99: the wall found the ΔL* 3 gradient
+ * indiscernible, and then found that this render path does not band at all, so
+ * the anti-banding layer was mitigating nothing. See the materials.ts header.
  */
 import { describe, it, expect } from 'vitest'
-import {
-  grainOpacityForTone,
-  grainForTone,
-  ditherTile,
-  paperSheet,
-  insetWell,
-  barPaper,
-} from './materials'
+import { grainOpacityForTone, grainForTone, paperSheet, insetWell, barPaper } from './materials'
 import { greyRamp } from './tokens/primitives'
 
 const styleOf = (s: Record<string, unknown>) => s as { backgroundImage?: string; boxShadow?: string; backgroundColor?: string }
@@ -47,38 +41,18 @@ describe('grain', () => {
   })
 })
 
-describe('dither', () => {
-  /**
-   * Dither is anti-banding, not texture. If it ever climbs to grain strength it
-   * has stopped doing its job and started being visible noise.
-   */
-  it('stays under the visibility threshold, and under grain everywhere', () => {
-    const op = Number(ditherTile().match(/opacity='([\d.]+)'/)![1])
-    // An absolute ceiling, not a ratio to grain. Grain already bottoms out at
-    // 0.04 on the darkest plane, so "half of grain" would be a coincidence of
-    // that floor rather than a statement about dither. ~0.025 is the point
-    // where noise starts being seen rather than just breaking up a step edge.
-    expect(op).toBeGreaterThan(0)
-    expect(op).toBeLessThanOrEqual(0.025)
-    // And it must never out-weigh the texture it hides under.
-    for (const step of Object.keys(greyRamp).map(Number)) {
-      expect(op, `vs grain at grey-${step}`).toBeLessThan(
-        grainOpacityForTone(greyRamp[step as keyof typeof greyRamp])
-      )
-    }
-  })
-})
-
 describe('paperSheet', () => {
-  it('layers dither over grain, and carries no gradient', () => {
+  it('carries grain ALONE — no dither, no gradient', () => {
     const bg = styleOf(paperSheet(greyRamp[875])).backgroundImage!
     // Count data URIs, not 'url(' — each SVG tile contains a `filter='url(#n)'`
     // internally, so counting the token double-reports.
-    expect(bg.split('data:image/svg+xml').length - 1, 'expected both grain and dither').toBe(2)
-    // VW-99 removed the tonal fill: on the wall it could not be told from a flat
-    // sheet of the same tone, and the full material still read as a flat digital
-    // rectangle. Asserted rather than merely deleted, so re-adding a gradient is
-    // a deliberate act with a wall run behind it, not a quiet revert.
+    //
+    // Both of the layers this used to have were measured off the sheet in VW-99:
+    // the tonal fill was indiscernible from flat, and the dither was mitigating
+    // a banding artefact that a hand-drawn reference proved this render path
+    // does not produce. Asserted rather than merely deleted, so putting either
+    // back is a deliberate act with a wall run behind it, not a quiet revert.
+    expect(bg.split('data:image/svg+xml').length - 1, 'grain only, no dither tile').toBe(1)
     expect(bg, 'the tonal fill was removed in VW-99').not.toContain('linear-gradient')
   })
 
@@ -101,7 +75,7 @@ describe('insetWell', () => {
     // a darker rectangle. It is the light on the floor that says "below".
     const shadow = styleOf(insetWell(greyRamp[950])).boxShadow!
     expect(shadow).toContain('inset 0 2px')
-    expect(shadow, 'missing the bottom floor rim').toContain('inset 0 -1px 0 rgba(255,255,255')
+    expect(shadow, 'missing the bottom floor rim').toContain('inset 0 -1px 0 rgba(255,255,255,0.12)')
   })
 
   it('is entirely inset — a well must not cast outward', () => {

--- a/packages/ui/src/theme/materials.ts
+++ b/packages/ui/src/theme/materials.ts
@@ -36,9 +36,23 @@
  * genuinely poor. It is a spatial-frequency problem, not an amplitude one, so
  * the band between "invisible" and "decorative" may simply not exist here.
  *
- * Kept: grain, rim-light, contact shadow. `ditherTile` is retained pending one
- * re-run — it existed only to stop the FILL banding, so it is probably dead
- * weight now, but "probably" is not a measurement.
+ * ── AND THE DITHER WENT WITH IT (VW-99 run 2) ──────────────────────────────
+ *
+ * `ditherTile` was held back one run on the grounds that "probably dead weight"
+ * is not a measurement. Run 1 could not measure it: with the fill invisible
+ * there was no gradient to band, so the panel returned a guaranteed clean sheet.
+ *
+ * Run 2 settled it by adding a hand-quantised REFERENCE beside the smooth
+ * control — the same tone span drawn as five hard-edged 1-level steps, which is
+ * what the artefact looks like when it happens. The reference banded plainly and
+ * the smooth gradient did not. So the panel can resolve banding; this render
+ * path simply does not produce it. A mitigation for an artefact that does not
+ * occur is cost with no benefit, and it is gone.
+ *
+ * That is a claim about THIS display, which is the one the product ships on and
+ * the reason `paperSheet` is hero-surface-only. A phone is a separate question.
+ *
+ * Kept: grain, rim-light, contact shadow.
  *
  * See coordination/design-explorations/surface-system-north-star.md §4 and
  * coordination/validation-runbooks/VW-99-depth-wall-calibration.md.
@@ -106,37 +120,15 @@ export function grainForTone(baseColor: string): string {
   )
 }
 
-/**
- * A ~0.02α noise tile used purely as ANTI-BANDING dither.
- *
- * Distinct from {@link grainForTone} in intent and strength: grain is a visible
- * matte texture, this is below the threshold of being seen at all. It exists
- * because a low-contrast vertical gradient across a wide plane bands into visible
- * steps on an 8-bit panel, and a whisper of noise breaks the step edges up.
- *
- * Only worth applying where a gradient actually spans real width. On a surface
- * with no gradient there is nothing to band and this is dead weight — which is
- * now the open question for {@link paperSheet} itself, since the gradient this
- * existed to protect (`tonalFill`) is gone. VW-99 panel C4 decides it, on the
- * wall, against a seeded positive control.
- */
-export function ditherTile(): string {
-  return (
-    `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E` +
-    `%3Cfilter id='d'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='1' stitchTiles='stitch'/%3E%3C/filter%3E` +
-    `%3Crect width='140' height='140' filter='url(%23d)' opacity='0.02'/%3E%3C/svg%3E")`
-  )
-}
-
-// `tonalFill` lived here until VW-99 measured it on the wall and found it
-// indiscernible. Deleted rather than left exported-but-unused; the reasoning is
-// in the module header, which is the part worth keeping.
+// `tonalFill` and `ditherTile` both lived here until VW-99 measured them on the
+// wall. Deleted rather than left exported-but-unused; the reasoning is in the
+// module header, which is the part worth keeping.
 
 // ── the materials ───────────────────────────────────────────────────────────
 
 /**
- * A matte PAPER hero sheet: tonal fill + brightness-scaled grain + anti-banding
- * dither + a crisp top rim-light + one soft contact shadow.
+ * A matte PAPER hero sheet: brightness-scaled grain + a crisp top rim-light +
+ * one soft contact shadow.
  *
  * The contact shadow is the ONE place a drop-shadow is still correct on a dark
  * surface: it is large, soft, and describes a sheet lying on a plane rather than
@@ -145,14 +137,27 @@ export function ditherTile(): string {
  * Defaults to `surface-raised` so a same-toned card laid inside reads as one
  * continuous sheet rather than a seam.
  *
+ * THE RIM-LIGHT IS A HAIRLINE. Run 2 of VW-99 called it "weak at distance" on
+ * both the card and the hero sheet, and the reason is visible in the number: it
+ * was `rgba(255,255,255,0.10)`, a 1px white line on a dark plane — physically
+ * the same cue as `hairline-*`, but set BELOW `hairline-default`, which the same
+ * run had just had to raise twice. It is not a subtler species of edge, it was
+ * simply mistuned. Raised to `0.20`, between `hairline-default` and
+ * `hairline-strong`: this edge defines a hero surface, so it earns more than the
+ * default separator, and unlike a separator there is no fallback behind it.
+ *
+ * Deliberately NOT wired to the token, though the values now agree in spirit: a
+ * box-shadow rim and a border hairline are retuned by different evidence, and
+ * coupling them means a hairline run silently restyles every hero sheet.
+ *
  * HERO SURFACES ONLY, MUTED TONES ONLY — see the module header.
  */
 export function paperSheet(tone: string = c['surface-raised']): ViewStyle {
   return {
     backgroundColor: tone,
-    // Layered front-to-back: dither over grain. No tonal fill — see VW-99 below.
-    backgroundImage: `${ditherTile()}, ${grainForTone(tone)}`,
-    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10), 0 8px 22px rgba(0,0,0,0.50)',
+    // Grain alone. The dither went with the gradient it protected — see header.
+    backgroundImage: grainForTone(tone),
+    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.20), 0 8px 22px rgba(0,0,0,0.50)',
   } as unknown as ViewStyle
 }
 
@@ -165,6 +170,12 @@ export function paperSheet(tone: string = c['surface-raised']): ViewStyle {
  * the surface" — which is why the treatment survives at 16px where a full paper
  * treatment does not.
  *
+ * The floor light was `0.04` and is now `0.12`, chosen on the wall in VW-99 run
+ * 2 against a `.04`-vs-`.12`-vs-none forced choice. Worth recording that `.04`
+ * was NOT invisible — the no-line decoy was correctly rejected and both real
+ * values were seen, so this is a preference between two working values, not a
+ * rescue. The rim-light next door was a genuine miss; this one was only thin.
+ *
  * Note this is a MATERIAL, and independent of the surface LEVEL named `inset`
  * that was retired in TD-07.14. A well is something you apply; a level is
  * somewhere you sit.
@@ -172,7 +183,7 @@ export function paperSheet(tone: string = c['surface-raised']): ViewStyle {
 export function insetWell(tone: string = c['surface-input']): ViewStyle {
   return {
     backgroundColor: tone,
-    boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.55), inset 0 -1px 0 rgba(255,255,255,0.04)',
+    boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.55), inset 0 -1px 0 rgba(255,255,255,0.12)',
   } as unknown as ViewStyle
 }
 

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -350,6 +350,12 @@ export const semanticColorsDark = {
   // `default` is the old `strong` — a value just confirmed legible on all four
   // planes. Spacing goes 1 : 1.56 : 2.33, against the original 1 : 1.5 : 2.33.
   //
+  // RUN 2 (VW-99): all three tiers were seen on all four planes — the retune
+  // worked — but `subtle` was still "a bit hard to read", so the whole family
+  // took a further +.01. That is a comfort margin on a passing row, not a fix
+  // for a failing one, which is why it is a flat offset: the 1 : 1.56 : 2.33
+  // spacing that the run validated is preserved rather than re-derived.
+  //
   // Keep these to TWO decimals. react-native-web quantises alpha to 8 bits, so
   // a 3-decimal value silently rounds on the way to the DOM (.135 renders as
   // .13) — the token would say one thing and paint another.
@@ -357,9 +363,9 @@ export const semanticColorsDark = {
   // DARK ONLY. The light family above composites toward BLACK on light planes,
   // which this run says nothing about — do not mirror these numbers into it
   // without its own verification.
-  'hairline-subtle': 'rgba(255, 255, 255, 0.09)',
-  'hairline-default': 'rgba(255, 255, 255, 0.14)',
-  'hairline-strong': 'rgba(255, 255, 255, 0.21)',
+  'hairline-subtle': 'rgba(255, 255, 255, 0.10)',
+  'hairline-default': 'rgba(255, 255, 255, 0.15)',
+  'hairline-strong': 'rgba(255, 255, 255, 0.22)',
 
   // Interactive states
   'interactive-hover': 'rgba(255, 255, 255, 0.04)',


### PR DESCRIPTION
Run 2 of the S-6 wall calibration. **All four rows pass — this clears the gate on the release tag.**
Sheet with the full record: `coordination/validation-runbooks/VW-99-depth-wall-calibration.md`.

| Row | Result |
|---|---|
| C1 hairlines | PASS, +.01 comfort bump applied and re-checked |
| C2 tone steps | PASS (no hairlines in it, so the C1 retune cannot move it) |
| C3 paper material | PASS — material picked out, decoy pair not split |
| C3 rim light | RETUNED .10 → .20 |
| C3 inset well (new row) | PASS — `.12` chosen over a working `.04` |
| C4 banding | PASS → `ditherTile` deleted |

## The three findings

**The rim-light was a hairline nobody had labelled as one.** It was `rgba(255,255,255,0.10)`: a 1px
white line on a dark plane, physically the same cue as `hairline-*`, but set *below*
`hairline-default` — the value this gate had already been forced to raise twice. Not a subtler
species of edge, just mistuned somewhere the hairline retune didn't reach. Left as a literal rather
than wired to the token: the two are retuned by different evidence, and coupling them means a future
hairline run silently restyles every hero sheet.

**`insetWell` had never been on a panel**, and got added mid-run on the strength of that finding —
its floor light was at `.04`, below every hairline value this gate has rejected as too faint. The
prediction was that it would be inert. **It wasn't**: `.04` was seen and the no-line decoy was
correctly rejected. Recorded because the prediction was wrong and the reasoning behind it was
otherwise sound.

**C4's void was a rig defect.** Run 2's first answer was "no banding anywhere" — including on the
control that was supposed to guarantee it. That's ambiguous: a blind panel and a render path that
genuinely doesn't band both produce "no steps", and they call for opposite actions. A **hand-quantised
reference** (the same tone span drawn as five hard-edged 1-level steps) separated them in one glance.
The reference banded, the smooth gradient didn't → `ditherTile` was mitigating something that doesn't
happen here, and it's deleted.

A smooth control is not a positive control. A control has to *be* the artefact, drawn deliberately —
not a condition believed likely to produce it.

## Verification

- 2887 tests, tsc clean, lint 0 errors.
- The `paperSheet`-carries-grain-alone and `insetWell`-floor-at-.12 assertions are **mutation-checked**
  — re-adding a second tile layer and reverting the floor alpha each turn the intended test red.
- Specimen ground truth updated; it's hand-maintained and drifts silently otherwise.

## Next

This unblocks the `v0.12.0` tag. **Not** included here — the version bump and publish are a separate,
deliberate step.