### PR TITLE
docs: repoint coordination/ references to sources/

### DIFF
--- a/packages/ui/scripts/generate-grey-ramp.mjs
+++ b/packages/ui/scripts/generate-grey-ramp.mjs
@@ -10,7 +10,7 @@
  * lives here, next to the values, and `--check` runs in CI.
  *
  * Derived from the v3 generator in
- * coordination/design-explorations/foundations/warm-grey-ramp/grey-ramp-v3.mjs
+ * sources/design/foundations/warm-grey-ramp/grey-ramp-v3.mjs
  * (the exploration HTML report is dropped; the math is verbatim). The rejected
  * v1 and v2 cuts are preserved there too — check before "improving" this.
  */

--- a/packages/ui/src/components/custom/Workout/README.md
+++ b/packages/ui/src/components/custom/Workout/README.md
@@ -105,7 +105,7 @@ type props without pulling the dependency.
   `SetStrip`/`SetBar` colors are the real titan ramp pins (`primitiveRamps` red-600 /
   orange-400 / amber-300 / green-300); the rail surfaces bind to the charcoal ramp +
   a subtle neumorphic inset (`neumorphicShadows.charcoal.pressed.subtle`). The heading
-  design is locked in `coordination/.../S3-sessionrail/DECISIONS-ExerciseRow.md`; the
+  design is locked in `sources/design/shell/S3-sessionrail/DECISIONS-ExerciseRow.md`; the
   exploration specimens live under `Custom/Workout/Explorations/*` (do not repoint yet).
   In Storybook the family nests by composition under **`Shell/SessionRail/…`**
   (organism → `ExerciseCardHeading` → `ExerciseHeading` → its atoms/molecules →

--- a/packages/ui/src/components/shell/README.md
+++ b/packages/ui/src/components/shell/README.md
@@ -19,7 +19,7 @@ SideNav ...................... organism — the 60px left rail (Shell/SideNav)
 └─ (accent bar) .............. bg-brand-primary edge bar on the active item
 ```
 
-Decisions locked 2026-07-08 (specimen `coordination/design-explorations/shell/S2-sidenav/`): lucide glyphs
+Decisions locked 2026-07-08 (specimen `sources/design/shell/S2-sidenav/`): lucide glyphs
 (activity · history · layers · figure) · **Plan** label (narrower than "Program") · active = **left accent
 bar** (short, centered on the icon+label) · **60px** icon+micro-label · live cue = **muted-green label**
 (`status-live-muted`) on the Live item while a set runs off-Live · four items, no footer, no top-nav. Fixed

--- a/packages/ui/src/components/shell/SessionRailSpecimen.stories.tsx
+++ b/packages/ui/src/components/shell/SessionRailSpecimen.stories.tsx
@@ -2,7 +2,7 @@
  * S3 · Session Rail — SPECIMEN (rapid-prototype, not yet a hardened component).
  *
  * A faithful React port of the R2/C3 converged rail
- * (coordination/design-explorations/drilldown-pass/r2-synthesis/gallery.html), brought into
+ * (sources/design/drilldown-pass/r2-synthesis/gallery.html), brought into
  * titan Storybook so we can iterate with the token system + real titan components + side-by-side.
  * Raw hex lives here on purpose — it mirrors the gallery 1:1; tokenization happens at harden.
  *

--- a/packages/ui/src/components/ui/surface/surface.contract.test.ts
+++ b/packages/ui/src/components/ui/surface/surface.contract.test.ts
@@ -8,7 +8,7 @@ import { getSemanticColors } from '../../../theme/tokens/semantic'
  * palette locks its eligibility mask with a value-level test.
  *
  * Scope: DARK mode only. The north-star diagnosis
- * (coordination/design-explorations/surface-system-north-star.md) measured and
+ * (sources/design/surface-system-north-star.md) measured and
  * fixed the dark ramp specifically; light mode has its own latent collisions
  * (e.g. `surface-overlay` === `surface-base`, both `#FFFFFF`) that were never
  * part of this investigation — flagged as a follow-up, not silently patched

--- a/packages/ui/src/theme/ColorPrimitives.stories.tsx
+++ b/packages/ui/src/theme/ColorPrimitives.stories.tsx
@@ -131,7 +131,7 @@ export const Ramps: StoryObj = {
         the warm ramp below — they were cold (neutral ran R−B down to −26) while the surfaces had
         been warm since v0.10.0, and nothing ever reconciled the two. The chromatics moved to the
         OKLCH ramps above. Spec and generator:
-        coordination/design-explorations/foundations/warm-grey-ramp/.
+        sources/design/foundations/warm-grey-ramp/.
       </Text>
 
       <SectionTitle>Chromatic — OKLCH tonal ramps</SectionTitle>

--- a/packages/ui/src/theme/DepthCalibration.stories.tsx
+++ b/packages/ui/src/theme/DepthCalibration.stories.tsx
@@ -32,7 +32,7 @@ import { grainForTone, paperSheet } from './materials'
  * HOW TO RUN. On the wall panel, at demo brightness, at demo viewing distance
  * (~3 m), with the room lit the way it will be lit. Answer every panel BEFORE
  * touching Reveal. Record on the sheet:
- * `voltras-workspace/coordination/validation-runbooks/VW-99-depth-wall-calibration.md`
+ * `voltras-workspace/sources/runbooks/VW-99-depth-wall-calibration.md`
  */
 const meta: Meta = {
   title: 'Foundations/Depth Calibration',

--- a/packages/ui/src/theme/materials.ts
+++ b/packages/ui/src/theme/materials.ts
@@ -54,8 +54,8 @@
  *
  * Kept: grain, rim-light, contact shadow.
  *
- * See coordination/design-explorations/surface-system-north-star.md §4 and
- * coordination/validation-runbooks/VW-99-depth-wall-calibration.md.
+ * See sources/design/surface-system-north-star.md §4 and
+ * sources/runbooks/VW-99-depth-wall-calibration.md.
  */
 import type { ViewStyle } from 'react-native'
 import { getSemanticColors } from './tokens/semantic'

--- a/packages/ui/src/theme/tokens/primitives.ts
+++ b/packages/ui/src/theme/tokens/primitives.ts
@@ -48,7 +48,7 @@ export const primitiveColors = {
  * (surface − 1) kept collapsing into it. `975` is the floor.
  *
  * Spec, generator and the rejected v1/v2 cuts:
- * coordination/design-explorations/foundations/warm-grey-ramp/
+ * sources/design/foundations/warm-grey-ramp/
  */
 export const greyRamp = {
   50: '#F9F6F3', //  L*97.0  W6
@@ -90,7 +90,7 @@ export const SURFACE_PLANE_STEPS = {
  * hexes. `pin` marks the step each ramp flows through its anchor.
  * This is the single source of truth for chromatic hexes — the categorical palette
  * below references these steps rather than duplicating values.
- * See coordination/design-explorations/foundations.
+ * See sources/design/foundations.
  */
 export const primitiveRamps = {
   red: {


### PR DESCRIPTION
The `voltras-workspace/coordination/` directory was retired (`VW-106`). Its contents now live under the active-work initiative's `sources/` tree, reachable space-free as `~/projects/voltras-workspace/sources`.

This PR repoints the stale `coordination/...` citations in this repo. **Comment and doc-link text only — no behavior change.**

Path mapping used: `design-explorations/`→`design/`, `validation-runbooks/`→`runbooks/`, `contract-audits/` + `bug-investigations/`→`audits/`; other subdirs keep their names. Retired session chrome (dated `HANDOFF-*`, `MERGE-*`, code reviews) moved to `sources/archive/` and is recovery-only — no live doc should cite it.

Verified: every rewritten path was checked to resolve. The 16 that do not were confirmed already dangling before the move (generated HTML previews and `2026-05-XX` placeholders), so this introduces no new broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)