### PR TITLE
Exempt src/lab from the device-internals and raw-color rules (TP-17)

### DIFF
--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -96,6 +96,23 @@ module.exports = tseslint.config(
     },
   },
 
+  // src/lab/** is exempt from no-device-internals. Lab holds specimen fixtures
+  // mined from real session transcripts, whose session UUIDs the rule reads as
+  // transport identifiers — a false positive: they are inert data in a scratch
+  // surface, never rendered as device internals. Lab is already excluded from
+  // what ships (package.json `files` carries `!src/lab`), so this doesn't weaken
+  // the guarantee for anything a consumer receives.
+  //
+  // Scoped as its own block rather than an `ignores` on the block above: that
+  // block is where the `titan` plugin is declared, and narrowing it would leave
+  // the plugin undefined for lab files, breaking the no-raw-color block below.
+  {
+    files: ['src/lab/**/*.{ts,tsx}'],
+    rules: {
+      'titan/no-device-internals': 'off',
+    },
+  },
+
   // Colour has one source of truth: the ramps, and the semantic tokens that
   // reference them. A raw colour in a component can't theme, can't be audited
   // for contrast/CVD, and won't move when the ramps are re-spaced — the v0.10.0
@@ -118,6 +135,10 @@ module.exports = tseslint.config(
       // a token reference resolves to `var(...)`, which breaks toHaveStyle. A
       // literal is the correct assertion, not debt.
       'src/**/*.test.{ts,tsx}',
+      // Lab specimen fixtures are mined from session transcripts: the hex that
+      // trips this rule sits inside prose `notes` strings, not styling. Same
+      // false positive as no-device-internals above, and lab never ships.
+      'src/lab/**',
     ],
     rules: {
       'titan/no-raw-color': 'error',


### PR DESCRIPTION
## Problem

`main`'s lint has been failing since #110 landed on 2026-07-30 ([run 30564169252](https://github.com/HJewkes/titan-design/actions/runs/30564169252)). All **316 errors** live in exactly two auto-generated lab fixtures:

```
files with ERRORS: 2 | total errors: 316
  291  src/lab/active-work/data/file-metrics.ts
   25  src/lab/active-work/data/aw-data.ts
--- errors inside src/lab/: 316 of 316
```

Both are false positives:

- **`titan/no-device-internals`** reads the fixtures' **session UUIDs** as transport identifiers. They're mined from Claude Code session transcripts — inert data, never rendered.
- **`titan/no-raw-color`** flags hex that sits inside prose `notes` strings (mined commit/PR write-ups), not styling.

Worth being precise about one thing, since it caused confusion while diagnosing: the *other* files that appear in the CI log — `Table.tsx`, `Sidebar.tsx`, `Treemap.tsx`, `EmptyState.stories.tsx`, the `Workout/*` set — carry **warnings only**, zero errors. Linting `Sidebar.tsx` alone reports `✖ 1 problem (0 errors, 1 warning)`. They show up because eslint prints every file with *any* problem.

## Why this is urgent, not cosmetic

`publish.yml`'s `publish` job is `needs: validate`, and `validate` runs `pnpm lint`. **While main is red, no release can reach npm** — a tag push would fail validate and silently never publish. This blocks TP-16's release (#154).

## Fix

Exempt `src/lab/**` from both rules. Lab is a scratch specimen surface and is already excluded from the published tarball (`package.json` `files` carries `!src/lab`), so this doesn't weaken the guarantee for anything a consumer receives.

The `no-device-internals` exemption is its **own config block** rather than an `ignores` on the existing one — that block is where the `titan` plugin is *declared*, and narrowing it would leave the plugin undefined for lab files, breaking the `no-raw-color` block that reuses it. The `no-raw-color` block declares no plugin, so it takes a plain `ignores` entry alongside the existing `src/theme/**` precedent.

## Verification

Guardrails still hold outside lab. A probe file carrying a UUID and a raw hex:

| location | result |
|---|---|
| `src/utils/__guardcheck.ts` | `✖ 2 problems (2 errors, 0 warnings)` — both rules fire |
| `src/lab/__guardcheck.ts` | clean |

Full suite (mirrors `publish.yml` validate):

| step | before | after |
|---|---|---|
| `pnpm lint` | ✖ 397 problems (**316 errors**) | ✅ 82 problems (**0 errors**, 82 warnings) |
| `pnpm type-check` | — | ✅ |
| `pnpm build` | — | ✅ |
| `pnpm test -- -- --run` | — | ✅ 148 files, 2887 tests |

One residual **warning**: `src/lab/active-work/data/session-signals.ts:3` now reports an unused `/* eslint-disable */` directive. Left as-is deliberately — the file is auto-generated (`tools/mine-session-signals.mjs`), and warnings don't fail the build.

Diff is one file. Filed as TP-17; found while verifying CI for TP-16 (#154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)