### PR TITLE
Fix status-error-vivid collapsing onto status-error

### DIFF
--- a/packages/ui/src/theme/global.css
+++ b/packages/ui/src/theme/global.css
@@ -41,7 +41,7 @@
     --color-status-error-light: #E05254;
     --color-status-error-dark: #A4221C;
     --color-status-error-subtle: rgba(209, 67, 67, 0.12);
-    --color-status-error-vivid: #D14343;
+    --color-status-error-vivid: #FF4757;
     --color-status-error-vivid-light: #E05254;
     --color-status-error-vivid-dark: #A4221C;
     --color-status-error-vivid-subtle: rgba(255, 71, 87, 0.12);
@@ -193,7 +193,7 @@
     --color-status-error-light: #E05254;
     --color-status-error-dark: #A4221C;
     --color-status-error-subtle: #FFF4F4;
-    --color-status-error-vivid: #D14343;
+    --color-status-error-vivid: #FF4757;
     --color-status-error-vivid-light: #E05254;
     --color-status-error-vivid-dark: #A4221C;
     --color-status-error-vivid-subtle: rgba(255, 71, 87, 0.12);

--- a/packages/ui/src/theme/status-distinctness.test.ts
+++ b/packages/ui/src/theme/status-distinctness.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Status tokens that mean different things must LOOK different.
+ *
+ * `status-error-vivid` existed to separate "drop everything" from "serious",
+ * and it pointed at `ramp.red[600]` — the exact value of `status-error`. The two
+ * had been rendering as one colour for as long as the token had existed, in both
+ * themes. Three other places in the system already disagreed with it and said
+ * vivid was `#FF4757`: `--color-status-error-vivid-rgb`, the `-subtle` rgba, and
+ * the `glow` shadow in `Indicator`. Only the value anyone actually rendered was
+ * wrong.
+ *
+ * Nothing caught it because every existing token test asks whether a value is
+ * PRESENT and parity-matched across config.ts and global.css — a collapsed token
+ * is present and matches perfectly. Distinctness is a different question, so it
+ * gets its own gate.
+ *
+ * Found 2026-08-31 by measuring a rendered Storybook story, not by reading the
+ * tokens: `SeverityLabel`'s Critical and High dots came back the same RGB.
+ */
+import { describe, it, expect } from 'vitest'
+import { semanticColorsDark, semanticColorsLight } from './tokens/semantic'
+
+type SemanticMap = Record<string, string>
+
+const THEMES: [string, SemanticMap][] = [
+  ['dark', semanticColorsDark as SemanticMap],
+  ['light', semanticColorsLight as SemanticMap],
+]
+
+/**
+ * Token pairs a viewer is expected to tell apart at a glance. Each pair carries
+ * the reason, so a future retune can weigh it rather than just delete the row.
+ */
+const MUST_DIFFER: [string, string, string][] = [
+  [
+    'status-error',
+    'status-error-vivid',
+    'severity Critical vs High, and DeviceRow/DeviceIndicator "lost" vs a plain error',
+  ],
+  ['status-error', 'status-warning', 'error vs warning is the most common status pairing'],
+  ['status-warning', 'status-info', 'warning vs informational'],
+  ['status-success', 'status-info', 'succeeded vs merely reporting'],
+]
+
+describe('semantically distinct status tokens render distinct values', () => {
+  for (const [theme, colors] of THEMES) {
+    for (const [a, b, why] of MUST_DIFFER) {
+      it(`${theme}: ${a} !== ${b} — ${why}`, () => {
+        // Both must exist, or the assertion passes vacuously on a typo.
+        expect(colors[a], `${a} missing from ${theme}`).toBeTruthy()
+        expect(colors[b], `${b} missing from ${theme}`).toBeTruthy()
+        expect(colors[a]!.toLowerCase()).not.toBe(colors[b]!.toLowerCase())
+      })
+    }
+  }
+})
+
+describe('status-error-vivid is the vivid red the rest of the system already assumes', () => {
+  for (const [theme, colors] of THEMES) {
+    it(`${theme}: matches the #FF4757 that -rgb, -subtle and Indicator's glow encode`, () => {
+      expect(colors['status-error-vivid']!.toLowerCase()).toBe('#ff4757')
+    })
+  }
+})

--- a/packages/ui/src/theme/tokens/semantic.ts
+++ b/packages/ui/src/theme/tokens/semantic.ts
@@ -82,7 +82,7 @@ export const semanticColorsLight = {
   'status-error-dark': ramp.red[700],
   'status-error-subtle': ramp.red[50],
 
-  'status-error-vivid': ramp.red[600],     // vivid alert red
+  'status-error-vivid': '#FF4757',         // vivid alert red — NOT red[600], that is status-error
   'status-error-vivid-light': ramp.red[500],
   'status-error-vivid-dark': ramp.red[700],
   'status-error-vivid-subtle': 'rgba(255, 71, 87, 0.12)',
@@ -222,7 +222,7 @@ export const semanticColorsDark = {
   'status-error-dark': ramp.red[700],
   'status-error-subtle': 'rgba(209, 67, 67, 0.12)',
 
-  'status-error-vivid': ramp.red[600],
+  'status-error-vivid': '#FF4757',
   'status-error-vivid-light': ramp.red[500],
   'status-error-vivid-dark': ramp.red[700],
   'status-error-vivid-subtle': 'rgba(255, 71, 87, 0.12)',


### PR DESCRIPTION
## What

`status-error-vivid` pointed at `ramp.red[600]`, the exact value of `status-error`, in both themes. Critical and High severity rendered as one colour, and so did `DeviceRow`/`DeviceIndicator`'s `lost` state and a plain error. The value moves to `#FF4757`, which `--color-status-error-vivid-rgb`, the `-subtle` rgba, and `Indicator`'s `glow` shadow already encoded. Only the rendered value was wrong.

## Why nothing caught it

Every existing token test asks whether a value is present and parity-matched between `config.ts` and `global.css`. A collapsed token is present and parity-matched. Distinctness is a different question, so it gets its own gate: `theme/status-distinctness.test.ts` asserts that semantically distinct status pairs render distinct values in both themes, and that `status-error-vivid` matches the vivid red the rest of the system assumes.

Found 2026-08-31 by measuring a rendered Storybook story (`SeverityLabel`'s Critical and High dots came back the same RGB), not by reading the tokens.

## Verification

- Full `packages/ui` suite with this change: 162 files / 3052 tests passing.
- `tsc --noEmit` clean; no eslint warnings on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkTrVTkRGGNsWnDgnpRxYp